### PR TITLE
fix: reminder broken on android in release mode

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,3 +4,6 @@ android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+# fixup: flutter_local_notifications plugin not compatible with R8 full mode.
+# see issue #118,#135 on github.
+android.enableR8.fullMode = false


### PR DESCRIPTION
- change r8 to compatibility mode.

resolved #135, resolved #118