### PR TITLE
Fix "Http Error" when running test reporter action on forked repo

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -2,11 +2,6 @@ name: Test CI
 
 on:
   workflow_call:
-    inputs:
-      with-repoter:
-        required: false
-        type: boolean
-        default: true
 
 permissions:
   checks: write
@@ -19,11 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup_flutter
-      - run: flutter test --machine > test_report.log
-      - name: Report
-        uses: dorny/test-reporter@v1
-        if: ${{ inputs.with-repoter }}
+      - run: |
+          set -o pipefail
+          flutter test --machine | tee test_report.log
+          set +o pipefail
+      - uses: actions/upload-artifact@v4
+        if: success() || failure()
         with:
-          name: "flutter test"
-          path: "test_report.log"
-          reporter: "flutter-json"
+          name: flutter-unitTest-output
+          path: test_report.log

--- a/.github/workflows/_test_report.yml
+++ b/.github/workflows/_test_report.yml
@@ -1,0 +1,21 @@
+# see: https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories
+name: "Test CI Report"
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v1
+        with:
+          artifact: flutter-unitTest-output
+          name: "flutter test"
+          path: "test_report.log"
+          reporter: "flutter-json"

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -14,18 +14,23 @@ jobs:
     uses: ./.github/workflows/_analyze.yml
 
   testing:
-    permissions:
-      checks: write
-      pull-requests: write
     uses: ./.github/workflows/_test.yml
-    with:
-      with-repoter: false
+
+  testing-report:
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+    needs:
+      - testing
+    uses: ./.github/workflows/_test_report.yml
 
   pre-build:
     name: Pre Building
     needs:
       - analyzing
       - testing
+      - testing-report
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/mr-check-post.yml
+++ b/.github/workflows/mr-check-post.yml
@@ -1,0 +1,17 @@
+name: Post Merge request checking
+
+on:
+  workflow_run:
+    workflows:
+      - Merge request checking
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    uses: ./.github/workflows/_test_report.yml


### PR DESCRIPTION
```log
Error: HttpError: Resource not accessible by integration
```

see [here](https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories)

> Workflows triggered by pull requests from forked repositories are executed with read-only token and therefore can't create check runs. To workaround this security restriction, it's required to use two separate workflows:
> 
>     CI runs in the context of the PR head branch with the read-only token. It executes the tests and uploads test results as a build artifact
>     Test Report runs in the context of the repository main branch with read/write token. It will download test results and create reports
> 
> The second workflow will only run after it has been merged into your default branch (typically main or master), it won't run in a PR unless after the workflow file is part of that branch.

