### PR TITLE
Upgrade flutter version from 3.13.9 to 3.19.6

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,6 +1,6 @@
 {
-  "flutterSdkVersion": "3.13.9",
+  "flutterSdkVersion": "3.19.6",
   "flavors": {
-    "release": "3.13.9"
+    "release": "3.19.6"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ coverage/html/
 
 # fvm
 .fvm/flutter_sdk
+.fvm/release
+.fvm/version
+.fvm/versions/
 
 # coverage
 coverage/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,4 @@
 [submodule "flutter"]
 	path = .flutter
 	url = https://github.com/flutter/flutter.git
-	tag = 3.13.9
-
+	tag = 3.19.6

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,7 +30,8 @@
     "**/.flutter": true
   },
   "files.associations": {
-    "*.arb": "json"
+    "*.arb": "json",
+    "*.gradle": "groovy"
   },
   "[dart]": {
     "editor.formatOnSave": true,

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -33,7 +33,7 @@ linter:
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
     # FIXME: ignore with 3.13.x's linter bug.
     # see https://github.com/dart-lang/linter/issues/4753
-    use_build_context_synchronously: false
+    # use_build_context_synchronously: false
     # Prefer relative imports for files in lib/.
     # see: https://dart.dev/tools/linter-rules/prefer_relative_imports
     prefer_relative_imports: true

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,14 +1,18 @@
+/* groovylint-disable CompileStatic, DuplicateStringLiteral, NoDef, VariableTypeRequired */
+
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    id 'dev.flutter.flutter-gradle-plugin'
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new FileNotFoundException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -20,10 +24,6 @@ def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 def customCompileSdkVersion = localProperties.getProperty('flutter.compileSdkVersion')
 if (customCompileSdkVersion == null) {
@@ -62,15 +62,16 @@ android {
 
     defaultConfig {
         multiDexEnabled true
+        /* groovylint-disable-next-line LineLength */
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "io.github.friesi23.mhabit"
+        applicationId 'io.github.friesi23.mhabit'
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        resourceConfigurations += ["en", "ar", "de", "es", "fa", "fr", "it", "nb-rNO", "pt-rBR", "ru", "vi", "zh"]
+        resourceConfigurations += ['en', 'ar', 'de', 'es', 'fa', 'fr', 'it', 'nb-rNO', 'pt-rBR', 'ru', 'vi', 'zh']
     }
 
     signingConfigs {
@@ -87,6 +88,7 @@ android {
             signingConfig keystoreProperties['storeFile'] ? signingConfigs.release : signingConfigs.debug
         }
     }
+
     namespace 'io.github.friesi23.mhabit'
 }
 
@@ -95,7 +97,6 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.window:window:1.0.0'
     implementation 'androidx.window:window-java:1.0.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,4 @@
-buildscript {
-    ext.kotlin_version = '1.8.22'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
+/* groovylint-disable CompileStatic */
 
 allprojects {
     repositories {
@@ -24,6 +13,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-tasks.register("clean", Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,11 +1,27 @@
+/* groovylint-disable CompileStatic, ImplicitClosureParameter, NoDef, VariableTypeRequired */
+
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file('local.properties').withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty('flutter.sdk')
+        assert flutterSdkPath != null, 'flutter.sdk not set in local.properties'
+        return flutterSdkPath
+    }()
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id 'dev.flutter.flutter-plugin-loader' version '1.0.0'
+    id 'com.android.application' version '8.1.3' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
+}
+
 include ':app'
-
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
-
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
-
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,1 @@
+extensions:

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+# platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -114,19 +114,19 @@ SPEC CHECKSUMS:
   DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
   DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
   file_picker: 15fd9539e4eb735dc54bae8c0534a7a9511a03de
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   flutter_timezone: ffb07bdad3c6276af8dada0f11978d8a1f8a20bb
   open_file_plus: 05737718530c14cf02868e3b7754d7fe4df76d8b
   package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
-  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
-  url_launcher_ios: bbd758c6e7f9fd7b5b1d4cde34d2b95fcce5e812
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
-PODFILE CHECKSUM: ed11bcbce7d892a5cf6ce26330e9d4aa9739ddff
+PODFILE CHECKSUM: 38a5d5ec463a50cc13d7630ab79f450537b24db1
 
 COCOAPODS: 1.14.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/component/widgets/date_picker.dart
+++ b/lib/component/widgets/date_picker.dart
@@ -14,12 +14,12 @@
 //
 // Copy source code from flutter: flutter/lib/src/material/date_picker.dart
 // Flutter license place at LICENSE_THIRDPARTY.md
-import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 
+import '../../extension/textscale_extensions.dart';
 import '../../l10n/localizations.dart';
 import '../../logging/helper.dart';
 import 'chip_list.dart';
@@ -53,8 +53,8 @@ class HabitDatetimePickerDialog extends DatePickerDialog {
 
 class _HabitDatetimePickerDialog extends State<HabitDatetimePickerDialog>
     with RestorationMixin {
-  late final RestorableDateTime _selectedDate =
-      RestorableDateTime(widget.initialDate);
+  late final RestorableDateTimeN _selectedDate =
+      RestorableDateTimeN(widget.initialDate);
   late final _RestorableDatePickerEntryMode _entryMode =
       _RestorableDatePickerEntryMode(widget.initialEntryMode);
   final _RestorableAutovalidateMode _autovalidateMode =
@@ -97,9 +97,9 @@ class _HabitDatetimePickerDialog extends State<HabitDatetimePickerDialog>
     Navigator.pop(
         context,
         widget.currentDateTime.copyWith(
-          year: _selectedDate.value.year,
-          month: _selectedDate.value.month,
-          day: _selectedDate.value.day,
+          year: _selectedDate.value?.year,
+          month: _selectedDate.value?.month,
+          day: _selectedDate.value?.day,
         ));
   }
 
@@ -177,12 +177,14 @@ class _HabitDatetimePickerDialog extends State<HabitDatetimePickerDialog>
     final TextTheme textTheme = theme.textTheme;
     // Constrain the textScaleFactor to the largest supported value to prevent
     // layout issues.
-    final double textScaleFactor =
-        math.min(MediaQuery.textScaleFactorOf(context), 1.3);
+    final TextScaler textScale =
+        MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3);
 
     final l10n = L10n.of(context);
 
-    final String dateText = localizations.formatMediumDate(_selectedDate.value);
+    final String dateText = _selectedDate.value == null
+        ? ""
+        : localizations.formatMediumDate(_selectedDate.value!);
     final Color onPrimarySurface = colorScheme.brightness == Brightness.light
         ? colorScheme.onPrimary
         : colorScheme.onSurface;
@@ -390,7 +392,7 @@ class _HabitDatetimePickerDialog extends State<HabitDatetimePickerDialog>
                 nextDateChip: nextDateChip,
               ));
 
-    final Size dialogSize = _dialogSize(context) * textScaleFactor;
+    final Size dialogSize = textScale.scaleForSize(_dialogSize(context));
     return Dialog(
       insetPadding:
           const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
@@ -401,9 +403,7 @@ class _HabitDatetimePickerDialog extends State<HabitDatetimePickerDialog>
         duration: _dialogSizeAnimationDuration,
         curve: Curves.easeIn,
         child: MediaQuery(
-          data: MediaQuery.of(context).copyWith(
-            textScaleFactor: textScaleFactor,
-          ),
+          data: MediaQuery.of(context).copyWith(textScaler: textScale),
           child: Builder(builder: (context) {
             switch (orientation) {
               case Orientation.portrait:

--- a/lib/component/widgets/habit_score_chart.dart
+++ b/lib/component/widgets/habit_score_chart.dart
@@ -259,8 +259,8 @@ class HabitScoreChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double textScaleFactor =
-        math.min(MediaQuery.textScaleFactorOf(context), 1.3);
+    final TextScaler textScaler =
+        MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3);
 
     appLog.build.debug(context);
     final double maxX = (data.length - 1).toDouble();
@@ -274,7 +274,7 @@ class HabitScoreChart extends StatelessWidget {
           showTitles: true,
           getTitlesWidget: _buildRightTitle,
           reservedSize:
-              protoLeftWidgetSize.width * textScaleFactor + leftTipsSpace,
+              textScaler.scale(protoLeftWidgetSize.width) + leftTipsSpace,
           interval: 20,
         ),
       ),

--- a/lib/component/widgets/markdown_body.dart
+++ b/lib/component/widgets/markdown_body.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
@@ -24,7 +22,7 @@ import '../widget.dart';
 class ThematicMarkdownBody extends StatelessWidget {
   final String data;
   final HabitColorType? colorType;
-  final double? textScaleFactor;
+  final TextScaler? textScaler;
   final MarkdownImageBuilder? imageBuilder;
   final MarkdownTapLinkCallback? onTapLink;
 
@@ -32,18 +30,15 @@ class ThematicMarkdownBody extends StatelessWidget {
     super.key,
     required this.data,
     this.colorType,
-    this.textScaleFactor,
+    this.textScaler,
     this.imageBuilder,
     this.onTapLink,
   });
 
-  double _getDefaultTextScaleFactor(BuildContext context) =>
-      math.min(MediaQuery.textScaleFactorOf(context), 1.3);
-
   MarkdownStyleSheet _getStyleSheet(BuildContext context) {
     final themeData = Theme.of(context);
     return MarkdownStyleSheet.fromTheme(themeData).copyWith(
-      textScaleFactor: textScaleFactor ?? _getDefaultTextScaleFactor(context),
+      textScaler: textScaler ?? MediaQuery.textScalerOf(context),
       a: TextStyle(color: themeData.colorScheme.primary),
       blockquote: themeData.textTheme.bodyMedium!
           .copyWith(color: themeData.colorScheme.primary),

--- a/lib/extension/textscale_extensions.dart
+++ b/lib/extension/textscale_extensions.dart
@@ -1,0 +1,20 @@
+// Copyright 2024 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+
+extension TextScaleExtension on TextScaler {
+  Size scaleForSize<T extends Size>(T size) =>
+      Size(scale(size.width), scale(size.height));
+}

--- a/lib/model/habit_stat.dart
+++ b/lib/model/habit_stat.dart
@@ -31,7 +31,7 @@ class HabitSummarySelectedStatistic {
   int get selected => activated + archived;
 
   @override
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     if (other is! HabitSummarySelectedStatistic) return false;
     return activated == other.activated && archived == other.archived;
   }
@@ -160,7 +160,7 @@ class HabitSummaryStatisticsData {
   });
 
   @override
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) {
       return true;
     }

--- a/lib/view/_debug.dart
+++ b/lib/view/_debug.dart
@@ -37,7 +37,7 @@ class DebugBuilderMethods {
           color: index.isOdd ? Colors.white : Colors.black12,
           height: 100.0,
           child: Center(
-            child: Text('$index', textScaleFactor: 5),
+            child: Text('$index', textScaler: const TextScaler.linear(5)),
           ),
         );
       },

--- a/lib/view/common/custom_datetime_format_picker.dart
+++ b/lib/view/common/custom_datetime_format_picker.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 
 import '../../component/widget.dart';
@@ -102,14 +100,14 @@ class _CustomDateTimeFormatPickerDialogState
 
   @override
   Widget build(BuildContext context) {
-    final textScaleFactor =
-        math.min(MediaQuery.textScaleFactorOf(context), 1.3);
     const div = Divider();
 
     Widget buildTitle(BuildContext context, {L10n? l10n}) {
       final formatter = _crtConfig.getFormatter(l10n?.localeName);
       return SizedBox(
-        height: 40.0 * textScaleFactor,
+        height: MediaQuery.textScalerOf(context)
+            .clamp(maxScaleFactor: 1.3)
+            .scale(40.0),
         child: AnimatedSwitcher(
           duration: const Duration(milliseconds: 100),
           child: FittedBox(

--- a/lib/view/common/habit_record_number_picker.dart
+++ b/lib/view/common/habit_record_number_picker.dart
@@ -335,8 +335,8 @@ class _HabitRecordTextField extends StatelessWidget {
     final textTheme = themeData.textTheme;
     final l10n = L10n.of(context);
 
-    final double textScaleFactor =
-        math.min(MediaQuery.textScaleFactorOf(context), 1.3);
+    final TextScaler textScaler =
+        MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3);
 
     final increaseButton = _NumberStepButton(
       onUpdate: onIncreaseButtonPressed,
@@ -349,7 +349,7 @@ class _HabitRecordTextField extends StatelessWidget {
         height: textFieldRightButtonFieldHeight / 2,
         child: Icon(
           MdiIcons.menuUp,
-          size: textFieldRightButtonIconSize * textScaleFactor,
+          size: textScaler.scale(textFieldRightButtonIconSize),
           color: increaseButtonEnabled
               ? colorScheme.outline
               : colorScheme.outlineVariant,
@@ -368,7 +368,7 @@ class _HabitRecordTextField extends StatelessWidget {
         height: textFieldRightButtonFieldHeight / 2,
         child: Icon(
           MdiIcons.menuDown,
-          size: textFieldRightButtonIconSize * textScaleFactor,
+          size: textScaler.scale(textFieldRightButtonIconSize),
           color: decreaseButtonEnabled
               ? colorScheme.outline
               : colorScheme.outlineVariant,
@@ -405,8 +405,8 @@ class _HabitRecordTextField extends StatelessWidget {
         Expanded(child: textField),
         const SizedBox(width: 10),
         SizedBox(
-          height: textFieldRightButtonFieldHeight * textScaleFactor,
-          width: textFieldRightButtonFieldWidth * textScaleFactor,
+          height: textScaler.scale(textFieldRightButtonFieldHeight),
+          width: textScaler.scale(textFieldRightButtonFieldWidth),
           child: Column(
             children: [
               Expanded(child: increaseButton),

--- a/lib/view/common/habit_summary_list_tile.dart
+++ b/lib/view/common/habit_summary_list_tile.dart
@@ -84,9 +84,8 @@ class _HabitSummaryListTile extends State<HabitSummaryListTile> {
   @override
   void initState() {
     super.initState();
-    _horizonalScrollController = widget.horizonalScrollControllerGroup != null
-        ? widget.horizonalScrollControllerGroup!.addAndGet()
-        : null;
+    _horizonalScrollController =
+        widget.horizonalScrollControllerGroup?.addAndGet();
   }
 
   @override
@@ -109,8 +108,9 @@ class _HabitSummaryListTile extends State<HabitSummaryListTile> {
 
   HabitSummaryData get data => widget.data;
 
-  double getTextScaleFactor(BuildContext context) => math.min(
-      MediaQuery.textScaleFactorOf(context), kMaxHabitSummaryListTileTextScale);
+  TextScaler getTextScaler(BuildContext context) =>
+      MediaQuery.textScalerOf(context)
+          .clamp(maxScaleFactor: kMaxHabitSummaryListTileTextScale);
 
   Widget _buildProgressCircle(BuildContext context,
       {Color? color, Color? backgroundColor}) {
@@ -120,7 +120,7 @@ class _HabitSummaryListTile extends State<HabitSummaryListTile> {
         value: data.progress.toDouble() / 100,
         color: color,
         backgroundColor: backgroundColor,
-        strokeWidth: 6 * getTextScaleFactor(context),
+        strokeWidth: getTextScaler(context).scale(6.0),
         isComplated: data.isComplated,
         isArchived: data.isArchived,
       ),
@@ -141,7 +141,7 @@ class _HabitSummaryListTile extends State<HabitSummaryListTile> {
             overflow: TextOverflow.ellipsis,
             maxLines: 2,
             softWrap: false,
-            textScaleFactor: getTextScaleFactor(context),
+            textScaler: getTextScaler(context),
           ),
         ),
       ),
@@ -202,13 +202,9 @@ class _HabitSummaryListTile extends State<HabitSummaryListTile> {
         _getDefaultListTileColor(themeData);
     final TextTheme textTheme = themeData.textTheme;
 
-    final double textScaleFactor = getTextScaleFactor(context);
-
     final DateTime crtDate = widget.startDate ?? DateTime.now();
-    int? limitItemCount;
-
-    limitItemCount = widget.endDate == null
-        ? limitItemCount
+    final int? limitItemCount = widget.endDate == null
+        ? null
         : math.max(crtDate.difference(widget.endDate!).inDays, 0) + 1;
 
     Widget? leftPartBuilder() {
@@ -263,7 +259,7 @@ class _HabitSummaryListTile extends State<HabitSummaryListTile> {
               themeColor?.selectedColor ??
               defaultThemeColor.selectedColor
           : null,
-      height: height * textScaleFactor,
+      height: getTextScaler(context).scale(height),
       itemHeight: height,
       minItemCoun: kHabitSummaryListTilMinShowDate,
       scrollPhysicsBuilder: widget.scrollPhysicsBuilder,

--- a/lib/view/for_app_about/app_about_license_thirdparty_tile.dart
+++ b/lib/view/for_app_about/app_about_license_thirdparty_tile.dart
@@ -38,8 +38,9 @@ class _AppAboutThirdPartyLicenseTileState
       context: context,
       builder: (context) => L10nBuilder(
         builder: (context, l10n) => AlertDialog(
-          content: RawScrollbar(
+          content: Scrollbar(
             child: SingleChildScrollView(
+              primary: true,
               child: MarkdownBody(
                 data: licenseText,
                 shrinkWrap: false,

--- a/lib/view/for_app_about/app_about_license_tile.dart
+++ b/lib/view/for_app_about/app_about_license_tile.dart
@@ -35,8 +35,9 @@ class _AppAboutLicenseTileState extends State<AppAboutLicenseTile> {
       context: context,
       builder: (context) => L10nBuilder(
         builder: (context, l10n) => AlertDialog(
-          content: RawScrollbar(
+          content: Scrollbar(
             child: SingleChildScrollView(
+              primary: true,
               scrollDirection: Axis.vertical,
               child: MarkdownBody(
                 data: "```text\n$licenseText\n```",

--- a/lib/view/for_app_about/app_about_version_tile.dart
+++ b/lib/view/for_app_about/app_about_version_tile.dart
@@ -47,8 +47,9 @@ class _AppAboutVersionTileState extends State<AppAboutVersionTile> {
       context: context,
       builder: (context) => L10nBuilder(
         builder: (context, l10n) => AlertDialog(
-          content: RawScrollbar(
+          content: Scrollbar(
             child: SingleChildScrollView(
+              primary: true,
               scrollDirection: Axis.vertical,
               child: MarkdownBody(
                 data: text,

--- a/lib/view/for_habit_detail/habit_detail_freq_chart.dart
+++ b/lib/view/for_habit_detail/habit_detail_freq_chart.dart
@@ -422,14 +422,15 @@ class HabitDetailFreqChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double textScaleFactor =
-        math.min(MediaQuery.textScaleFactorOf(context), 1.3);
+    final TextScaler textScaler =
+        MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3);
 
-    final eachSize = this.eachSize * textScaleFactor;
+    final eachSize = textScaler.scale(this.eachSize);
     final limit = math.max(1, allowWidth ~/ math.max(eachSize, cellWidth));
     final firstDate = getFirstDate(limit);
     final lastDate = getLastDate(limit);
-    final titleHeight = this.titleHeight * math.max(1.0, textScaleFactor);
+    final titleHeight =
+        textScaler.clamp(minScaleFactor: 1.0).scale(this.titleHeight);
 
     final isToday = offset == 0;
     final isLast = lastDate.isBefore(habitStartDate);

--- a/lib/view/for_habit_detail/habit_detail_score_chart.dart
+++ b/lib/view/for_habit_detail/habit_detail_score_chart.dart
@@ -144,12 +144,13 @@ class HabitDetailScoreChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = L10n.of(context);
-    final double textScaleFactor =
-        math.min(MediaQuery.textScaleFactorOf(context), 1.3);
+    final TextScaler textScaler =
+        MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3);
 
-    final eachSize = this.eachSize * textScaleFactor;
+    final eachSize = textScaler.scale(this.eachSize);
     final limit = math.max(1, allowWidth ~/ eachSize);
-    final titleHeight = this.titleHeight * math.max(1.0, textScaleFactor);
+    final titleHeight =
+        textScaler.clamp(minScaleFactor: 1.0).scale(this.titleHeight);
 
     final firstDate = getFirstDate(limit);
     var lastDate = getLastDate(limit);

--- a/lib/view/for_habit_detail/habit_edit_repl_rcd_cal.dart
+++ b/lib/view/for_habit_detail/habit_edit_repl_rcd_cal.dart
@@ -108,10 +108,11 @@ class _HabitEditReplacementRecordCalendarDialog
 
   void _openHabitRecordResonModifierDialog(
       BuildContext context, HabitRecordDate date) async {
+    HabitDetailViewModel viewmodel;
     String initReason = '';
 
-    if (!mounted) return;
-    final viewmodel = context.read<HabitDetailViewModel>();
+    if (!context.mounted) return;
+    viewmodel = context.read<HabitDetailViewModel>();
 
     if (!viewmodel.mounted || viewmodel.habitDetailData == null) return;
     final record = viewmodel.getHabitRecordData(date);
@@ -122,7 +123,7 @@ class _HabitEditReplacementRecordCalendarDialog
       initReason = rcd?.reason ?? '';
     }
 
-    if (!mounted) return;
+    if (!context.mounted) return;
     final result = await showHabitRecordReasonModifierDialog(
       context: context,
       initReason: initReason,
@@ -131,7 +132,9 @@ class _HabitEditReplacementRecordCalendarDialog
       colorType: viewmodel.habitColorType,
     );
 
-    if (result == null || result == initReason || !mounted) return;
+    if (result == null || result == initReason || !context.mounted) return;
+    viewmodel = context.read<HabitDetailViewModel>();
+    if (!viewmodel.mounted) return;
     viewmodel.changeRecordReason(date, result);
   }
 

--- a/lib/view/for_habit_edit/habit_frequency_picker.dart
+++ b/lib/view/for_habit_edit/habit_frequency_picker.dart
@@ -242,12 +242,12 @@ class _HabitFrequencyTextField extends StatelessWidget {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final textTheme = themeData.textTheme;
-    final textScaleFactor =
-        math.min(MediaQuery.textScaleFactorOf(context), 1.3);
+    final textScaler =
+        MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3);
 
     return SizedBox(
-      height: _kDefaultHabitFreqTextFieldHeight * textScaleFactor,
-      width: _kDefualtHabitFreqTextFieldWidth * textScaleFactor,
+      height: textScaler.scale(_kDefaultHabitFreqTextFieldHeight),
+      width: textScaler.scale(_kDefualtHabitFreqTextFieldWidth),
       child: TextField(
         textAlign: TextAlign.center,
         controller: controller,

--- a/lib/view/for_habit_edit/habit_target_days_picker.dart
+++ b/lib/view/for_habit_edit/habit_target_days_picker.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -238,8 +236,8 @@ class _HabitCustomTargetDaysTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textScaleFactor =
-        math.min(MediaQuery.textScaleFactorOf(context), 1.3);
+    final textScaler =
+        MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3);
 
     final themeData = Theme.of(context);
     final textTheme = themeData.textTheme;
@@ -258,8 +256,8 @@ class _HabitCustomTargetDaysTile extends StatelessWidget {
         children: [
           Flexible(
             child: SizedBox(
-              height: 30 * textScaleFactor,
-              width: 48 * textScaleFactor,
+              height: textScaler.scale(30.0),
+              width: textScaler.scale(48.0),
               child: TextField(
                 textAlign: TextAlign.center,
                 controller: inputController,

--- a/lib/view/for_habits_display/sliver_calendar_bar.dart
+++ b/lib/view/for_habits_display/sliver_calendar_bar.dart
@@ -66,9 +66,8 @@ class _SliverCalendarBar extends State<SliverCalendarBar> {
   @override
   void initState() {
     super.initState();
-    _horizonalScrollController = widget.horizonalScrollControllerGroup != null
-        ? widget.horizonalScrollControllerGroup!.addAndGet()
-        : null;
+    _horizonalScrollController =
+        widget.horizonalScrollControllerGroup?.addAndGet();
   }
 
   @override

--- a/lib/view/page_app_debugger.dart
+++ b/lib/view/page_app_debugger.dart
@@ -83,7 +83,7 @@ class AppDebuggerViewState extends State<AppDebuggerView> with XShare {
   void _onDownloadLogButtonPressed(BuildContext context) async {
     final filePath = await debugLogFilePath;
     final fileExist = await File(filePath).exists();
-    if (!mounted) return;
+    if (!context.mounted) return;
     if (!fileExist) return _showDebugLogFileDismissSnackbar();
     final subject = L10n.of(context)?.debug_downladDebugLogs_subject;
     switch (defaultTargetPlatform) {
@@ -100,11 +100,11 @@ class AppDebuggerViewState extends State<AppDebuggerView> with XShare {
     final filePath = await debugLogFilePath;
     final fileObj = File(filePath);
     final fileExist = await fileObj.exists();
-    if (!mounted) return;
+    if (!context.mounted) return;
     if (!fileExist) return _showDebugLogFileDismissSnackbar();
     await fileObj.delete();
     AppLoggerMananger.reloadDebuggingLogger(filePath: filePath);
-    if (!mounted) return;
+    if (!context.mounted) return;
     final snackbar = BuildWidgetHelper().buildSnackBarWithDismiss(context,
         content: L10nBuilder(
           builder: (context, l10n) => l10n != null
@@ -126,14 +126,14 @@ class AppDebuggerViewState extends State<AppDebuggerView> with XShare {
     final filePath = await debugInfoFilePath;
     final debugInfo = await AppInfo().generateAppDebugInfo();
     await File(filePath).writeAsString(debugInfo, mode: FileMode.writeOnly);
-    if (!mounted) return;
+    if (!context.mounted) return;
     final subject = L10n.of(context)?.debug_downladDebugInfo_subject;
     pickAndSaveToFile(filePath, subject: subject);
   }
 
   void _onFABPressed(BuildContext context) async {
     final zipFilePath = await generateZippedDebugInfo();
-    if (!mounted) return;
+    if (!context.mounted) return;
     final subject =
         L10n.of(context)?.debug_downladDebugZip_subject(debuggerZipFile);
     switch (defaultTargetPlatform) {

--- a/lib/view/page_app_setting.dart
+++ b/lib/view/page_app_setting.dart
@@ -123,43 +123,43 @@ class _AppSettingView extends State<AppSettingView>
   }
 
   void _openCustomDateTimeFormatPickerDialog(BuildContext context) async {
-    if (!mounted) return;
+    if (!context.mounted) return;
     final config = context.read<AppCustomDateYmdHmsConfigViewModel>();
     final result = await showCustomDateTimeFormatPickerDialog(
         context: context, config: config.config);
 
-    if (!mounted || result == null) return;
+    if (!context.mounted || result == null) return;
     context.read<AppCustomDateYmdHmsConfigViewModel>().setNewConfig(result);
   }
 
   void _openAppFirtDaySelectDialog(BuildContext context) async {
-    if (!mounted) return;
+    if (!context.mounted) return;
     final firstday = context.read<AppFirstDayViewModel>();
     final result = await showAppSettingFirstDaySelectDialog(
         context: context, firstDay: firstday.firstDay);
 
-    if (!mounted || result == null) return;
+    if (!context.mounted || result == null) return;
     final firtdayvm = context.read<AppFirstDayViewModel>();
     firtdayvm.setNewFirstDay(result);
   }
 
   void _onAppLanguageTilePressed(BuildContext context) async {
-    if (!mounted) return;
+    if (!context.mounted) return;
     final currentLocale = context.read<AppLanguageViewModel>().languange;
     final result = await showAppLanguageChangerDialog(
         context: context, selectedLocale: currentLocale);
 
-    if (!mounted || result == null) return;
+    if (!context.mounted || result == null) return;
     context.read<AppLanguageViewModel>().switchLanguage(result.choosenLanguage);
   }
 
   void _openClearAppCacheDialog(BuildContext context) async {
-    if (!mounted) return;
+    if (!context.mounted) return;
     final result = await showAppSettingClearCacheDialog(context: context);
-    if (!mounted || result != true) return;
+    if (!context.mounted || result != true) return;
 
     final resultList = await context.read<AppCachesViewModel>().clearAllCache();
-    if (!mounted) return;
+    if (!context.mounted) return;
 
     var hasSuss = false, hasFail = false;
     for (var result in resultList) {
@@ -217,19 +217,19 @@ class _AppSettingView extends State<AppSettingView>
   }
 
   void _onExportAllTilePressed(BuildContext context) async {
-    if (!mounted) return;
+    if (!context.mounted) return;
     final confirmResult = await showExporterConfirmDialog(
       context: context,
       exportAll: true,
     );
 
-    if (!mounted || confirmResult == null) return;
+    if (!context.mounted || confirmResult == null) return;
     final filePath = await context
         .read<HabitFileExporterViewModel>()
         .exportAllHabitsData(
           withRecords: confirmResult == ExporterConfirmResultType.withRecords,
         );
-    if (!mounted || filePath == null) return;
+    if (!context.mounted || filePath == null) return;
     //TODO: add snackbar result
     shareXFiles([XFile(filePath)], context: context);
   }
@@ -307,11 +307,13 @@ class _AppSettingView extends State<AppSettingView>
       },
     );
 
-    if (result == null || !result) return;
+    if (!mounted || result == null || !result) return;
     await Future.wait([
       context.read<ProfileViewModel>().clear(),
       NotificationService().cancelAppReminder()
     ]);
+
+    if (!mounted) return;
     await context.read<ProfileViewModel>().reload();
 
     if (!mounted) return;
@@ -337,17 +339,17 @@ class _AppSettingView extends State<AppSettingView>
   }
 
   void _onExportDBTilePressed(BuildContext context) async {
-    if (!mounted) return;
+    if (!context.mounted) return;
     final dbPath = path.join(await getDatabasesPath(), appDBName);
-    if (!mounted) return;
+    if (!context.mounted) return;
     shareXFiles([XFile(dbPath)], context: context);
   }
 
   void _onClearDBTilePressed(BuildContext context) async {
-    if (!mounted) return;
+    if (!context.mounted) return;
     final result = await showAppSettingConfirmClearDBDiloag(context: context);
 
-    if (!mounted) return;
+    if (!context.mounted) return;
     switch (result) {
       case AppSettingConfirmClearDBOp.confirm:
         break;
@@ -356,14 +358,14 @@ class _AppSettingView extends State<AppSettingView>
             .read<HabitFileExporterViewModel>()
             .exportAllHabitsData();
         final dbPath = path.join(await getDatabasesPath(), appDBName);
-        if (!mounted) return;
+        if (!context.mounted) return;
         final result = await shareXFiles(
             [if (filePath != null) XFile(filePath), XFile(dbPath)],
             context: context);
         if (result.status == ShareResultStatus.success) {
           break;
         } else {
-          if (!mounted) return;
+          if (!context.mounted) return;
           final snackBar = BuildWidgetHelper().buildSnackBarWithDismiss(
             context,
             content: const Text("clear failed, must saved backup first"),
@@ -379,11 +381,9 @@ class _AppSettingView extends State<AppSettingView>
 
     await context.read<DBHelperViewModel>().reload();
     await NotificationService().cancelAllHabitReminders();
-    if (!mounted) return;
-    final snackBar = BuildWidgetHelper().buildSnackBarWithDismiss(
-      context,
-      content: const Text("clear database success"),
-    );
+    if (!context.mounted) return;
+    final snackBar = BuildWidgetHelper().buildSnackBarWithDismiss(context,
+        content: const Text("clear database success"));
     ScaffoldMessenger.maybeOf(context)?.showSnackBar(snackBar);
 
     context

--- a/lib/view/page_habit_detail.dart
+++ b/lib/view/page_habit_detail.dart
@@ -1050,10 +1050,9 @@ class _HabitDescTileList extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = L10n.of(context);
     final viewmodel = context.read<HabitDetailViewModel>();
-    final textScaleFactor =
-        math.min(MediaQuery.textScaleFactorOf(context), 1.3);
-    final descMinHeight =
-        kHabitDetailFreqChartTitleHeight * math.max(1.0, textScaleFactor);
+    final TextScaler textScaler = MediaQuery.textScalerOf(context)
+        .clamp(minScaleFactor: 1.0, maxScaleFactor: 1.3);
+    final descMinHeight = textScaler.scale(kHabitDetailFreqChartTitleHeight);
 
     return _HabitDetailTileListFramework(
       title: HabitDetailChartTitle(
@@ -1067,7 +1066,7 @@ class _HabitDescTileList extends StatelessWidget {
             child: ThematicMarkdownBody(
               data: viewmodel.habitDesc,
               colorType: viewmodel.habitColorType,
-              textScaleFactor: textScaleFactor,
+              textScaler: textScaler,
             ),
           ),
         ),

--- a/lib/view/page_habit_detail.dart
+++ b/lib/view/page_habit_detail.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:math' as math;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -645,15 +643,14 @@ class _HabitDetailView extends State<HabitDetailView>
       return Consumer<HabitDetailScoreChartViewModel>(
         builder: (context, chartvm, child) => LayoutBuilder(
           builder: (context, constraints) {
-            final double textScaleFactor =
-                math.min(MediaQuery.textScaleFactorOf(context), 1.3);
             final now = HabitDate.now();
             return HabitDetailScoreChart(
               padding: kHabitDetailWidgetPadding,
               eachSize: 48.0,
               allowWidth: constraints.maxWidth,
-              titleHeight: kHabitDetailFreqChartTitleHeight *
-                  math.max(1.0, textScaleFactor),
+              titleHeight: MediaQuery.textScalerOf(context)
+                  .clamp(minScaleFactor: 1.0, maxScaleFactor: 1.3)
+                  .scale(kHabitDetailFreqChartTitleHeight),
               getFirstDate: (limit) =>
                   chartvm.getCurrentChartFirstDate(now, limit),
               getLastDate: (limit) =>
@@ -730,9 +727,6 @@ class _HabitDetailView extends State<HabitDetailView>
           AppCustomDateYmdHmsConfigViewModel>(
         builder: (context, chartvm, configvm, child) => LayoutBuilder(
           builder: (context, constraints) {
-            final double textScaleFactor =
-                math.min(MediaQuery.textScaleFactorOf(context), 1.3);
-
             final viewmodel = context.read<HabitDetailViewModel>();
             final now = HabitDate.now();
 
@@ -748,8 +742,9 @@ class _HabitDetailView extends State<HabitDetailView>
               allowWidth: isLargeScreen
                   ? (constraints.maxWidth - _largeScreenTwoChartBetween) / 2
                   : constraints.maxWidth,
-              titleHeight: kHabitDetailFreqChartTitleHeight *
-                  math.max(1.0, textScaleFactor),
+              titleHeight: MediaQuery.textScalerOf(context)
+                  .clamp(minScaleFactor: 1.0, maxScaleFactor: 1.3)
+                  .scale(kHabitDetailFreqChartTitleHeight),
               largeScreenTwoChartBetween: _largeScreenTwoChartBetween,
               getFirstDate: (limit) =>
                   chartvm.getCurrentChartFirstDate(now, limit),
@@ -1022,10 +1017,9 @@ class _HabitDetailTileListFramework extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textScaleFactor =
-        math.min(MediaQuery.textScaleFactorOf(context), 1.3);
-    final titleHeight =
-        kHabitDetailFreqChartTitleHeight * math.max(1.0, textScaleFactor);
+    final titleHeight = MediaQuery.textScalerOf(context)
+        .clamp(minScaleFactor: 1.0, maxScaleFactor: 1.3)
+        .scale(kHabitDetailFreqChartTitleHeight);
 
     return Padding(
       padding: kHabitDetailWidgetPadding,

--- a/lib/view/page_habit_detail.dart
+++ b/lib/view/page_habit_detail.dart
@@ -306,46 +306,51 @@ class _HabitDetailView extends State<HabitDetailView>
     viewmodel = context.read<HabitDetailViewModel>();
     if (!viewmodel.mounted || viewmodel.habitUUID == null) return;
     summary = context.maybeRead<HabitSummaryViewModel>();
-    if (summary == null || !summary.mounted) {
-      final change = await viewmodel.onConfirmToDeleteHabit();
-      return Navigator.pop(
-        context,
-        DetailPageReturn(
-          op: DetailPageReturnOpr.deleted,
-          habitName: viewmodel.habitName,
-          recordList: change != null ? [change] : null,
-        ),
-      );
-    }
 
-    // use summary method in default
-    return Navigator.pop(
-      context,
-      DetailPageReturn(
-        op: DetailPageReturnOpr.deleted,
-        habitName: viewmodel.habitName,
-        recordList: await summary.forHabitDetail
-            .onConfirmToDeleteHabit(viewmodel.habitUUID!),
-      ),
-    );
+    if (summary != null && summary.mounted) {
+      final changes = await summary.forHabitDetail
+          .onConfirmToDeleteHabit(viewmodel.habitUUID!);
+      if (mounted) {
+        Navigator.pop(
+          context,
+          DetailPageReturn(
+            op: DetailPageReturnOpr.deleted,
+            habitName: viewmodel.habitName,
+            recordList: changes,
+          ),
+        );
+      }
+    } else {
+      final change = await viewmodel.onConfirmToDeleteHabit();
+      if (mounted) {
+        Navigator.pop(
+          context,
+          DetailPageReturn(
+            op: DetailPageReturnOpr.deleted,
+            habitName: viewmodel.habitName,
+            recordList: change != null ? [change] : null,
+          ),
+        );
+      }
+    }
   }
 
   void _exportHabitAndShared(BuildContext context) async {
     HabitFileExporterViewModel fileExporter;
 
-    if (!mounted) return;
+    if (!context.mounted) return;
     final confirmResult = await showExporterConfirmDialog(
       context: context,
       exportAll: false,
     );
 
-    if (!mounted || confirmResult == null) return;
+    if (!context.mounted || confirmResult == null) return;
     fileExporter = context.read<HabitFileExporterViewModel>();
     final filePath = await fileExporter.exportHabitData(
       widget.habitUUID,
       withRecords: confirmResult == ExporterConfirmResultType.withRecords,
     );
-    if (!mounted || filePath == null) return;
+    if (!context.mounted || filePath == null) return;
     //TODO: add snackbar result
     shareXFiles([XFile(filePath)], text: "Export Habit", context: context);
   }

--- a/lib/view/page_habit_edit.dart
+++ b/lib/view/page_habit_edit.dart
@@ -118,7 +118,7 @@ class _HabitEditView extends State<HabitEditView> {
       BuildContext context, HabitColorType colorType) async {
     final result = await showHabitColorPickerDialog(
         context: context, colorType: colorType);
-    if (result == null || !mounted) return;
+    if (result == null || !context.mounted) return;
     context.read<HabitFormViewModel>().colorType = result;
   }
 
@@ -136,7 +136,7 @@ class _HabitEditView extends State<HabitEditView> {
     final result = await showHabitFrequencyPickerDialog(
         context: context, frequency: frequency);
     appLog.navi.info("$runtimeType._openFrequencyPickerDialog", ex: [result]);
-    if (result == null || !mounted) return;
+    if (result == null || !context.mounted) return;
     context.read<HabitFormViewModel>().frequency = result;
   }
 
@@ -145,7 +145,7 @@ class _HabitEditView extends State<HabitEditView> {
     final result = await showHabitDatePickerDialog(
         context: context, date: startDate, colorType: colorType);
     appLog.navi.info("$runtimeType._openDatePickerDialog", ex: [result]);
-    if (result == null || !mounted) return;
+    if (result == null || !context.mounted) return;
     context.read<HabitFormViewModel>().startDate =
         HabitStartDate.dateTime(result);
   }
@@ -157,7 +157,7 @@ class _HabitEditView extends State<HabitEditView> {
       initialCustomTargetDays:
           context.read<AppCachesViewModel>().habitEditTargetDaysInputFill,
     );
-    if (result == null || !mounted) return;
+    if (result == null || !context.mounted) return;
     context.read<HabitFormViewModel>().targetDays = result.targetDays;
     if (result.isCustomDaysType) {
       context
@@ -175,7 +175,7 @@ class _HabitEditView extends State<HabitEditView> {
       reminder: reminder ?? HabitReminder.dailyMidnight,
       colorType: colorType,
     );
-    if (!mounted || result == null) return;
+    if (!context.mounted || result == null) return;
     context.read<HabitFormViewModel>().reminder = context
         .read<HabitFormViewModel>()
         .reminder
@@ -185,10 +185,10 @@ class _HabitEditView extends State<HabitEditView> {
   void _openTimerPickerDialog(
       BuildContext context, HabitReminder? reminder) async {
     await NotificationService().requestPermissions();
-    if (!mounted) return;
+    if (!context.mounted) return;
     final result =
         await showTimePicker(context: context, initialTime: TimeOfDay.now());
-    if (!mounted || result == null) return;
+    if (!context.mounted || result == null) return;
     final newReminder = (context.read<HabitFormViewModel>().reminder ??
             HabitReminder.dailyMidnight)
         .copyWith(time: result);

--- a/lib/view/page_habits_display.dart
+++ b/lib/view/page_habits_display.dart
@@ -1099,8 +1099,13 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
     //#endregion
 
     return ColorfulNavibar(
-      child: WillPopScope(
-        onWillPop: onWillPop,
+      child: PopScope(
+        canPop: false,
+        onPopInvoked: (didPop) async {
+          if (didPop) return;
+          final canPopNow = await onWillPop();
+          if (mounted && canPopNow) Navigator.pop(this.context);
+        },
         child: Scaffold(
           resizeToAvoidBottomInset: false,
           body: Selector<AppCompactUISwitcherViewModel, Tuple2<bool, double>>(

--- a/lib/view/page_habits_display.dart
+++ b/lib/view/page_habits_display.dart
@@ -164,10 +164,10 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
     );
     if (result == null || result == false) return;
 
-    if (!mounted) return;
+    if (!context.mounted) return;
     viewmodel = context.read<HabitSummaryViewModel>();
     final recordList = await viewmodel.archivedSelectedHabits();
-    if (!mounted || recordList == null) return;
+    if (!context.mounted || recordList == null) return;
 
     final archivedCount = recordList.length;
     viewmodel = context.read<HabitSummaryViewModel>();
@@ -212,10 +212,10 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
     );
     if (result == null || result == false) return;
 
-    if (!mounted) return;
+    if (!context.mounted) return;
     viewmodel = context.read<HabitSummaryViewModel>();
     final recordList = await viewmodel.unarchivedSelectedHabits();
-    if (!mounted || recordList == null) return;
+    if (!context.mounted || recordList == null) return;
 
     final archivedCount = recordList.length;
     viewmodel = context.read<HabitSummaryViewModel>();
@@ -260,10 +260,10 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
     );
     if (result == null || result == false) return;
 
-    if (!mounted) return;
+    if (!context.mounted) return;
     viewmodel = context.read<HabitSummaryViewModel>();
     final recordList = await viewmodel.deleteSelectedHabits();
-    if (!mounted || recordList == null) return;
+    if (!context.mounted || recordList == null) return;
 
     final deletedCount = recordList.length;
     viewmodel = context.read<HabitSummaryViewModel>();
@@ -296,11 +296,11 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
         return;
       case HabitDisplayMainMenuDialogOpr.showSortMenu:
         await Future.delayed(const Duration(milliseconds: 300));
-        if (!mounted) return;
+        if (!context.mounted) return;
         _openHabitSummarySortSelectorDialog(context);
         break;
       case HabitDisplayMainMenuDialogOpr.openSettings:
-        if (!mounted) return;
+        if (!context.mounted) return;
         _openAppSettingsPage(context);
         break;
     }
@@ -321,7 +321,7 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
       sortDirection: context.read<HabitsSortViewModel>().sortDirection,
     );
 
-    if (!mounted || result == null) return;
+    if (!context.mounted || result == null) return;
     context
         .read<HabitsSortViewModel>()
         .setNewSortMode(sortType: result.item1, sortDirection: result.item2);
@@ -348,7 +348,7 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
       initReason = rcd?.reason ?? '';
     }
 
-    if (!mounted) return;
+    if (!context.mounted) return;
     final result = await showHabitRecordReasonModifierDialog(
       context: context,
       initReason: initReason,
@@ -357,7 +357,7 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
       colorType: data.colorType,
     );
 
-    if (result == null || result == initReason || !mounted) return;
+    if (result == null || result == initReason || !context.mounted) return;
     context
         .read<HabitSummaryViewModel>()
         .changeRecordReason(parentUUID, date, result);
@@ -400,7 +400,7 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
       colorType: data.colorType,
     );
 
-    if (result == null || result == orgNum || !mounted) return;
+    if (result == null || result == orgNum || !context.mounted) return;
     viewmodel = context.read<HabitSummaryViewModel>();
     if (!viewmodel.mounted) return;
     viewmodel.changeRecordValue(parentUUID, date, result);
@@ -420,7 +420,7 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
       exportAll: false,
     );
 
-    if (!mounted || confirmResult == null) return;
+    if (!context.mounted || confirmResult == null) return;
     final filePath = await context
         .read<HabitFileExporterViewModel>()
         .exportMultiHabitsData(
@@ -428,7 +428,7 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
           withRecords: confirmResult == ExporterConfirmResultType.withRecords,
         );
 
-    if (!mounted || filePath == null) return;
+    if (!context.mounted || filePath == null) return;
     context.read<HabitSummaryViewModel>().exitEditMode();
     //TODO: add snackbar result
     shareXFiles([XFile(filePath)],
@@ -977,7 +977,7 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
                 .loadData(inFutureBuilder: true);
             await Future.delayed(_kHabitListFutureLoadDuration);
             await loadedFuture;
-            if (mounted &&
+            if (context.mounted &&
                 context
                     .read<HabitSummaryViewModel>()
                     .consumeClearSnackBarFlag()) {
@@ -1025,7 +1025,7 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
             child: HabitDisplayDevelopSliverList(
               onAddCountHabitsPressed: (count) async {
                 await debugAddMultiTempHabit(context, count: count);
-                if (!mounted) return;
+                if (!context.mounted) return;
                 context.read<HabitSummaryViewModel>().rockreloadDBToggleSwich();
               },
             ),

--- a/lib/view/page_habits_status_changer.dart
+++ b/lib/view/page_habits_status_changer.dart
@@ -298,10 +298,11 @@ class _HabitsStatusChangerView extends State<HabitsStatusChangerView> {
 
     final vm = context.read<HabitStatusChangerViewModel>();
     final div = buildDivider(context);
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) {
+        if (didPop) return;
         _onClosePageButtonPressed(defaultConfirmResult: true);
-        return false;
       },
       child: PageFramework(
         appbar: _AppBar(

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -68,9 +68,9 @@ SPEC CHECKSUMS:
   flutter_timezone: 6b906d1740654acb16e50b639835628fea851037
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
-  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
   url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
 

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "61.0.0"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "6.4.1"
   animated_check:
     dependency: "direct main"
     description:
@@ -29,18 +29,18 @@ packages:
     dependency: "direct main"
     description:
       name: animations
-      sha256: ef57563eed3620bd5d75ad96189846aca1e033c0c45fc9a7d26e80ab02b88a70
+      sha256: d3d6dcfb218225bbe68e87ccf6378bbb2e32a94900722c5f81611dad089911cb
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.11"
   archive:
     dependency: "direct main"
     description:
       name: archive
-      sha256: ecf4273855368121b1caed0d10d4513c7241dfc813f7d3c8933b36622ae9b265
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.1"
+    version: "3.6.1"
   args:
     dependency: transitive
     description:
@@ -173,10 +173,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   color:
     dependency: transitive
     description:
@@ -213,18 +213,18 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "595a29b55ce82d53398e1bcc2cba525d7bd7c59faeb2d2540e9d42c390cfeeeb"
+      sha256: "3945034e86ea203af7a056d98e98e42a5518fff200d6e8e6647e1886b07e936e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.4"
+    version: "1.8.0"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "2f9d2cbccb76127ba28528cb3ae2c2326a122446a83de5a056aaa3880d3882c5"
+      sha256: "55d7b444feb71301ef6b8838dbc1ae02e63dd48c8773f3810ff53bb1e2945b32"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+7"
+    version: "0.3.4+1"
   crypto:
     dependency: "direct main"
     description:
@@ -261,10 +261,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.6"
   dartx:
     dependency: transitive
     description:
@@ -333,10 +333,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   file:
     dependency: transitive
     description:
@@ -463,18 +463,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: "21b085a1c185e46701373866144ced56cfb7a0c33f63c916bb8fe2d0c1491278"
+      sha256: "04c4722cc36ec5af38acc38ece70d22d3c2123c61305d555750a091517bbe504"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.19"
+    version: "0.6.23"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "592dc01a18961a51c24ae5d963b724b2b7fa4a95c100fe8eb6ca8a5a4732cadf"
+      sha256: "8cf40eebf5dec866a6d1956ad7b4f7016e6c0cc69847ab946833b7d43743809f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.18"
+    version: "2.0.19"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -553,10 +553,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -586,10 +586,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e"
+      sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.7"
+    version: "4.2.0"
   image_size_getter:
     dependency: transitive
     description:
@@ -638,6 +638,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.8.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   linked_scroll_controller:
     dependency: "direct main"
     description:
@@ -674,26 +698,26 @@ packages:
     dependency: transitive
     description:
       name: markdown
-      sha256: "1b134d9f8ff2da15cb298efe6cd8b7d2a78958c1b00384ebcbdf13fe340a6c90"
+      sha256: ef2a1298144e3f985cc736b22e0ccdaf188b5b3970648f2d9dc13efd1d9df051
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.1"
+    version: "7.2.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: "direct main"
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   material_design_icons_flutter:
     dependency: "direct main"
     description:
@@ -706,18 +730,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   named_html_color:
     dependency: "direct main"
     description:
@@ -786,10 +810,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_parsing:
     dependency: transitive
     description:
@@ -810,18 +834,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "51f0d2c554cfbc9d6a312ab35152fc77e2f0b758ce9f1a444a3a1e5b8f3c6b7f"
+      sha256: a248d8146ee5983446bf03ed5ea8f6533129a12b11f12057ad1b4a67a2b3b41d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -850,10 +874,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: cb3798bef7fc021ac45b308f4b51208a152792445cce0448c9a4ba5879dd8750
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "6.0.2"
   platform:
     dependency: transitive
     description:
@@ -898,10 +922,10 @@ packages:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.0"
   quiver:
     dependency: "direct main"
     description:
@@ -946,18 +970,18 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
+      sha256: "1ee8bf911094a1b592de7ab29add6f826a7331fb854273d55918693d5364a1f2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "7708d83064f38060c7b39db12aefe449cb8cdc031d6062280087bc4cdb988f5c"
+      sha256: "0a8a893bf4fd1152f93fec03a415d11c27c74454d96e2318a7ac38dd18683ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.5"
+    version: "2.4.0"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -978,10 +1002,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
+      sha256: "9aee1089b36bd2aafe06582b7d7817fd317ef05fc30e6ba14bff247d0933042a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -1103,50 +1127,50 @@ packages:
     dependency: "direct main"
     description:
       name: sqflite
-      sha256: a9016f495c927cb90557c909ff26a6d92d9bd54fc42ba92e19d4e79d61e798c6
+      sha256: a43e5a27235518c03ca238e7b4732cf35eabe863a369ceba6cbefa537a66f16d
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.3+1"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "28d8c66baee4968519fb8bd6cdbedad982d6e53359091f0b74544a9f32ec72d5"
+      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.4"
   sqflite_common_ffi:
     dependency: "direct main"
     description:
       name: sqflite_common_ffi
-      sha256: "35d2fce1e971707c227cc4775cc017d5eafe06c2654c3435ebd5c3ad6c170f5f"
+      sha256: "4d6137c29e930d6e4a8ff373989dd9de7bac12e3bc87bce950f6e844e8ad3bb5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0+4"
+    version: "2.3.3"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: db65233e6b99e99b2548932f55a987961bc06d82a31a0665451fa0b4fff4c3fb
+      sha256: b384f598b813b347c5a7e5ffad82cbaff1bec3d1561af267041e66f6f0899295
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.4.3"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -1183,26 +1207,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
+      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.3"
+    version: "1.24.9"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
+      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3"
+    version: "0.5.9"
   test_cov_console:
     dependency: "direct dev"
     description:
@@ -1255,26 +1279,26 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: c512655380d241a337521703af62d2c122bf7b77a46ff7dd750092aa9433499c
+      sha256: "21b704ce5fa560ea9f3b525b43601c678728ba46725bab9b01187b4831377ed3"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.4"
+    version: "6.3.0"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: d4ed0711849dd8e33eb2dd69c25db0d0d3fdc37e0a62e629fe32f57a22db2745
+      sha256: "17cd5e205ea615e2c6ea7a77323a11712dffa0720a8a90540db57a01347f9ad9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.3.2"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "75bb6fe3f60070407704282a2d295630cab232991eb52542b18347a8a941df03"
+      sha256: "7068716403343f6ba4969b4173cbf3b84fc768042124bc2c011e5d782b24fe89"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.4"
+    version: "6.3.0"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -1303,10 +1327,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "7fd2f55fe86cea2897b963e864dc01a7eb0719ecc65fcef4c1cc3d686d718bb2"
+      sha256: "8d9e750d8c9338601e709cd0885f95825086bd8b642547f26bda435aade95d8a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.1"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1319,10 +1343,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.4.0"
   vector_graphics:
     dependency: transitive
     description:
@@ -1359,10 +1383,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "11.10.0"
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:
@@ -1375,18 +1399,18 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.5"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -1407,18 +1431,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: b0f37db61ba2f2e9b7a78a1caece0052564d1bc70668156cf3a29d676fe4e574
+      sha256: "0eaf06e3446824099858367950a813472af675116bf63f008a4c2a75ae13e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "5.5.0"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "41fd8a189940d8696b1b810efb9abcf60827b6cbfab90b0c43e8439e3a39d85a"
+      sha256: "10589e0d7f4e053f2c61023a31c9ce01146656a70b7b7f0828c0b46d7da2a9bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   worker_manager:
     dependency: transitive
     description:
@@ -1439,10 +1463,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "5bc72e1e45e941d825fd7468b9b4cc3b9327942649aeb6fc5cdbf135f0a86e84"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:
@@ -1452,5 +1476,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
 
   # Extra Features
   dynamic_color: ^1.5.4
-  material_color_utilities: ^0.5.0
+  material_color_utilities: ^0.8.0
   linked_scroll_controller: ^0.2.0
   sliver_tools: ^0.2.9
   share_plus: ^7.2.1

--- a/windows/flutter/CMakeLists.txt
+++ b/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS


### PR DESCRIPTION
Upgrade flutter version to 3.19.6 (last stable version with dart 3.3 (3.3.4). Main reason for upgrading this version is:

- More stronger syntax checking (to prevent some bugs at async coding).
- To prevent falling too far behind Flutter's major version, which could be more difficult for future upgrades.
- Flutter project itself has fixed lot of bugs.

This update include following changes:

1. Fix unexpected warnings if enable `use_build_context_synchronously`, see [here](https://github.com/dart-lang/linter/issues/4753) to get more information.

2. Breaking changes
    - [Deprecate textScaleFactor in favor of TextScaler](https://docs.flutter.dev/release/breaking-changes/deprecate-textscalefactor)
    - [Android Predictive Back](https://docs.flutter.dev/release/breaking-changes/android-predictive-back)
    - [Deprecated imperative apply of Flutter's Gradle plugins](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply)

> for full breaking changes with two versions, see [Flutter 3.19](https://docs.flutter.dev/release/breaking-changes#released-in-flutter-3-19) and [Flutter 3.16](https://docs.flutter.dev/release/breaking-changes#released-in-flutter-3-16).

3. Fix Scrollbar's Exception on desktop platforms (windows/macos/linux) in app's `changelog` and `license` dialog.