### PR TITLE
fix: show black screen when back from main screen

### DIFF
--- a/lib/extension/navigator_extensions.dart
+++ b/lib/extension/navigator_extensions.dart
@@ -1,0 +1,24 @@
+// Copyright 2024 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+extension NavigatorExtension on NavigatorState {
+  @optionalTypeArgs
+  Future<void> popOrExit<T extends Object?>([T? result]) async {
+    if (!canPop()) return SystemNavigator.pop();
+    return pop(result);
+  }
+}

--- a/lib/view/page_habits_display.dart
+++ b/lib/view/page_habits_display.dart
@@ -31,6 +31,7 @@ import '../component/helper.dart';
 import '../component/widget.dart';
 import '../extension/async_extensions.dart';
 import '../extension/color_extensions.dart';
+import '../extension/navigator_extensions.dart';
 import '../l10n/localizations.dart';
 import '../logging/helper.dart';
 import '../model/habit_daily_record_form.dart';
@@ -1104,7 +1105,9 @@ class _HabitsDisplayView extends State<HabitsDisplayView>
         onPopInvoked: (didPop) async {
           if (didPop) return;
           final canPopNow = await onWillPop();
-          if (mounted && canPopNow) Navigator.pop(this.context);
+          if (mounted && canPopNow) {
+            await Navigator.of(this.context).popOrExit();
+          }
         },
         child: Scaffold(
           resizeToAvoidBottomInset: false,

--- a/lib/view/page_habits_status_changer.dart
+++ b/lib/view/page_habits_status_changer.dart
@@ -23,6 +23,7 @@ import '../common/utils.dart';
 import '../component/helper.dart';
 import '../component/widget.dart';
 import '../extension/context_extensions.dart';
+import '../extension/navigator_extensions.dart';
 import '../logging/helper.dart';
 import '../model/custom_date_format.dart';
 import '../model/habit_date.dart';
@@ -177,7 +178,9 @@ class _HabitsStatusChangerView extends State<HabitsStatusChangerView> {
         : true;
     if (!mounted) return;
 
-    if (result) dismissAllToolTips().then((_) => Navigator.pop(context));
+    if (result) {
+      dismissAllToolTips().then((_) => Navigator.of(context).popOrExit());
+    }
   }
 
   Widget _buildDebugInfo(BuildContext context) =>


### PR DESCRIPTION
Navigator.pop() behavior has changed. it will not exit app in new widget `PopScope`, This has been handled separately.

```
When false, blocks the current route from being popped.
This includes the root route, where upon popping, the Flutter app would exit.
```

So this maybe a BUG in Flutter. Will try updating the version later to see if the problem is fixed.