### PR TITLE
fix: remove DependencyInfoBlock from android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -118,6 +118,8 @@ android {
         buildConfig = true
     }
 
+    // Unverifiable encrypted Blob
+    // https://github.com/FriesI23/mhabit/issues/205
     dependenciesInfo {
         includeInApk = false
         includeInBundle = false

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -118,6 +118,11 @@ android {
         buildConfig = true
     }
 
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
+
     namespace 'io.github.friesi23.mhabit'
 }
 


### PR DESCRIPTION
Strip `dependenciesInfo` block, see [here](https://android.izzysoft.de/articles/named/iod-scan-apkchecks) and #205 get more information.

resolve #205