### PR TITLE
fix: keep OverflowBar style consistent with pre-migration on picker dialog

### DIFF
--- a/lib/view/common/habit_record_number_picker.dart
+++ b/lib/view/common/habit_record_number_picker.dart
@@ -274,6 +274,8 @@ class _HabitRecordCustomNumberPickerDialog
             Padding(
               padding: const EdgeInsets.only(top: 24, bottom: 12),
               child: OverflowBar(
+                spacing: 8.0,
+                alignment: MainAxisAlignment.end,
                 children: [
                   TextButton(
                     onPressed: () {

--- a/lib/view/common/habit_record_reason_modifier.dart
+++ b/lib/view/common/habit_record_reason_modifier.dart
@@ -103,6 +103,8 @@ class _HabitRecordReasonModifierDialog
             Padding(
               padding: const EdgeInsets.only(top: 24, bottom: 12),
               child: OverflowBar(
+                spacing: 8.0,
+                alignment: MainAxisAlignment.end,
                 children: [
                   TextButton(
                     onPressed: () {


### PR DESCRIPTION
See ["Deprecate `ButtonBar` in favor of `OverflowBar`"](https://docs.flutter.dev/release/breaking-changes/deprecate-buttonbar).

Align to the end and set the spacing to 8.0 to match`ButtonBar` style.