### PR TITLE
Fix: dealing with unavailable getetag

### DIFF
--- a/lib/extension/webdav_extensions.dart
+++ b/lib/extension/webdav_extensions.dart
@@ -18,9 +18,9 @@ import 'package:simple_webdav_client/utils.dart';
 import '../common/exceptions.dart';
 
 extension WebDavResourceExtention on WebDavStdResource {
-  WebDavStdResourceProp<String> get getetag =>
-      find(WebDavElementNames.getetag, namespace: kDavNamespaceUrlStr).first
-          as WebDavStdResourceProp<String>;
+  WebDavStdResourceProp<String>? get getetag =>
+      find(WebDavElementNames.getetag, namespace: kDavNamespaceUrlStr)
+          .firstOrNull as WebDavStdResourceProp<String>?;
 
   WebDavStdResourceProp<ResourceTypes> get resourcetype =>
       find(WebDavElementNames.resourcetype, namespace: kDavNamespaceUrlStr)

--- a/lib/model/_app_sync_tasks/webdav_app_sync_models.dart
+++ b/lib/model/_app_sync_tasks/webdav_app_sync_models.dart
@@ -136,16 +136,21 @@ class WebDavResourceContainer {
   factory WebDavResourceContainer.fromResource(WebDavStdResource resource,
       {Uri? overridePath}) {
     assert(resource.error == null);
-    final getetag = resource.getetag;
-    if (getetag.error != null) throw getetag.error!;
-    if (getetag.status != HttpStatus.ok) {
-      throw WebDavStdResError(
-          "Resouce ${resource.path}'s dav:getetag status error, "
-          "prop=${getetag.toDebugString()}");
+
+    void checkProp(WebDavResourceProp prop) {
+      if (prop.error != null) throw prop.error!;
+      if (prop.status != HttpStatus.ok) {
+        throw WebDavStdResError("Resouce ${resource.path}'s "
+            "${prop.namespace}:${prop.name} status error, "
+            "prop=${prop.toDebugString()}");
+      }
     }
+
+    final getetag = resource.getetag;
+    if (getetag != null) checkProp(getetag);
     return WebDavResourceContainer(
       path: overridePath ?? resource.path,
-      etag: resource.getetag.value,
+      etag: resource.getetag?.value,
     );
   }
 


### PR DESCRIPTION
Handle missing `getetag` for collection on some WebDAV servers like Koofr.

link: #276, #292