### PR TITLE
fix: exclude habits that haven’t started yet from today’s list

### DIFF
--- a/lib/providers/habits_today.dart
+++ b/lib/providers/habits_today.dart
@@ -236,6 +236,7 @@ class HabitsTodayViewModel extends ChangeNotifier
         .sort(_sortType, _sortDirection)
         .where((e) {
           if (!e.isActived) return false;
+          if (e.startDate > now) return false;
           if (e.getRecordByDate(now) != null) return false;
           return true;
         })


### PR DESCRIPTION
before: 
<img width="317" height="68" alt="Screenshot 2025-12-06 at 17 25 41" src="https://github.com/user-attachments/assets/19dab88c-3320-419d-9506-93d216b0b368" />

after: 
\<not shown\>