### PR TITLE
chore: bump version to v1.23.0+138-pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 [中文](./docs/CHANGELOG/zh.md)
 
+## 1.23.0+138-pre
+
+- Flutter 3.35.7 / Dart 3.4 toolchain with API migrations
+- Android: AGP 8.12.3 with Kotlin/Gradle tuning
+- iOS/macOS: project sync to new toolchain
+- Dependency updates (share_plus, app_settings, fl_chart, package_info_plus, flutter_timezone, copy_with_extension, source_gen, flutter_lints, intl)
+- Code formatting and maintenance cleanup
+
 ## 1.22.10+137
 
 - fixed: ensure UI refresh works correctly (#475)

--- a/android/app/src/f_store/fastlane/metadata/android/en-US/changelogs/138.txt
+++ b/android/app/src/f_store/fastlane/metadata/android/en-US/changelogs/138.txt
@@ -1,0 +1,5 @@
+- Flutter 3.35.7 / Dart 3.4 toolchain with API migrations
+- Android: AGP 8.12.3 with Kotlin/Gradle tuning
+- iOS/macOS: project sync to new toolchain
+- Dependency updates (share_plus, app_settings, fl_chart, package_info_plus, flutter_timezone, copy_with_extension, source_gen, flutter_lints, intl)
+- Code formatting and maintenance cleanup

--- a/android/app/src/f_store/fastlane/metadata/android/zh-CN/changelogs/138.txt
+++ b/android/app/src/f_store/fastlane/metadata/android/zh-CN/changelogs/138.txt
@@ -1,0 +1,5 @@
+- 升级 Flutter 3.35.7 / Dart 3.4，并迁移相关 API（Radio、DatePicker、activeColor）
+- Android：升级 AGP 到 8.12.3，同时调整 Kotlin/Gradle
+- iOS/macOS：工程同步到新工具链
+- 依赖更新（share_plus、app_settings、fl_chart、package_info_plus、flutter_timezone、copy_with_extension、source_gen、flutter_lints、intl）
+- 代码格式化和清理

--- a/configs/flatpak_builder/io.github.friesi23.mhabit.metainfo.xml
+++ b/configs/flatpak_builder/io.github.friesi23.mhabit.metainfo.xml
@@ -95,6 +95,9 @@
     <category>Utility</category>
   </categories>
   <releases>
+    <release version="1.23.0+138-pre" date="2026-01-06">
+      <url type="details">https://github.com/FriesI23/mhabit/releases/tag/v1.23.0+138-pre</url>
+    </release>
     <release version="1.22.10+137" date="2026-01-04">
       <url type="details">https://github.com/FriesI23/mhabit/releases/tag/v1.22.10+137</url>
     </release>

--- a/docs/CHANGELOG/zh.md
+++ b/docs/CHANGELOG/zh.md
@@ -1,5 +1,13 @@
 # 更新日志
 
+## 1.23.0+138-pre
+
+- 升级 Flutter 3.35.7 / Dart 3.4，并迁移相关 API（Radio、DatePicker、activeColor）
+- Android：升级 AGP 到 8.12.3，同时调整 Kotlin/Gradle
+- iOS/macOS：工程同步到新工具链
+- 依赖更新（share_plus、app_settings、fl_chart、package_info_plus、flutter_timezone、copy_with_extension、source_gen、flutter_lints、intl）
+- 代码格式化和清理
+
 ## 1.22.10+137
 
 - 修复：确保界面刷新正常 (#475)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,5 +1,9 @@
-# Released: 1.22.9+136
+# Released: 1.23.0+138-pre
 
 **🧹 Others**
 
-- fixed: ensure UI refresh works correctly (#475)
+- Upgrade to Flutter 3.35.7 / Dart 3.4 toolchain with API migrations
+- Update Android AGP 8.12.3 with Kotlin/Gradle updates and JVM memory tweaks
+- Update iOS / macOS projects to align with the new toolchain
+- Dependency bumps (pubspec.lock): intl 0.19.0 → 0.20.2; fl_chart 1.0.0 → 1.1.1; share_plus 11.1.0 → 12.0.1; app_settings 6.1.1 → 7.0.0; package_info_plus 8.3.1 → 9.0.0; flutter_timezone 4.1.1 → 5.0.1; copy_with_extension 6.0.1 → 9.1.1; source_gen 2.0.0 → 3.1.0; flutter_lints 5.0.0 → 6.0.0
+- Code formatting and maintenance cleanup

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.22.10+137
+version: 1.23.0+138-pre
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
**🧹 Others**

- Upgrade to Flutter 3.35.7 / Dart 3.4 toolchain with API migrations
- Update Android AGP 8.12.3 with Kotlin/Gradle updates and JVM memory tweaks
- Update iOS / macOS projects to align with the new toolchain
- Dependency bumps (pubspec.lock): intl 0.19.0 → 0.20.2; fl_chart 1.0.0 → 1.1.1; share_plus 11.1.0 → 12.0.1; app_settings 6.1.1 → 7.0.0; package_info_plus 8.3.1 → 9.0.0; flutter_timezone 4.1.1 → 5.0.1; copy_with_extension 6.0.1 → 9.1.1; source_gen 2.0.0 → 3.1.0; flutter_lints 5.0.0 → 6.0.0
- Code formatting and maintenance cleanup
