### PR TITLE
chore(flatpak): add brand colors and shorten summary in metainfo

### DIFF
--- a/configs/flatpak_builder/io.github.friesi23.mhabit.metainfo.xml
+++ b/configs/flatpak_builder/io.github.friesi23.mhabit.metainfo.xml
@@ -2,12 +2,16 @@
 <component type="desktop">
   <id>io.github.friesi23.mhabit</id>
   <name>Table Habit</name>
-  <summary>Micro habit tracker for personal growth</summary>
+  <summary>Build micro habits</summary>
   <metadata_license>MIT</metadata_license>
   <project_license>Apache-2.0</project_license>
   <developer id="io.github.friesi23">
     <name>Fries_I23</name>
   </developer>
+  <branding>
+    <color type="primary" scheme_preference="light">#458EF7</color>
+    <color type="primary" scheme_preference="dark">#1E4C8F</color>
+  </branding>
   <launchable type="desktop-id">io.github.friesi23.mhabit.desktop</launchable>
   <provides>
     <binary>mhabit</binary>

--- a/flatpak/io.github.friesi23.mhabit.metainfo.xml
+++ b/flatpak/io.github.friesi23.mhabit.metainfo.xml
@@ -2,12 +2,16 @@
 <component type="desktop">
   <id>io.github.friesi23.mhabit</id>
   <name>Table Habit</name>
-  <summary>Micro habit tracker for personal growth</summary>
+  <summary>Build micro habits</summary>
   <metadata_license>MIT</metadata_license>
   <project_license>Apache-2.0</project_license>
   <developer id="io.github.friesi23">
     <name>Fries_I23</name>
   </developer>
+  <branding>
+    <color type="primary" scheme_preference="light">#458EF7</color>
+    <color type="primary" scheme_preference="dark">#1E4C8F</color>
+  </branding>
   <launchable type="desktop-id">io.github.friesi23.mhabit.desktop</launchable>
   <provides>
     <binary>mhabit</binary>


### PR DESCRIPTION
- [x] Branding - Has primary brand colors
- [x] ~~App Icon - No baked-in shadows~~
- [x] Summary - Shorter than 35 characters
- [x] ~~Screenshots - Default setting~~
- [x] ~~Screenshots - Include window shadow and rounded corners