### PR TITLE
build(make): standardize local automation entrypoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,28 @@ SUBMAKE := $(MAKE) --no-print-directory
 
 ifeq ($(OS),Windows_NT)
 SHELL := cmd.exe
-FLUTTER_BIN := $(if $(wildcard .flutter/bin/flutter.bat),.flutter\bin\flutter.bat,flutter)
+FLUTTER_BIN_DIR := $(if $(wildcard .flutter/bin/flutter.bat),.flutter\bin,)
+PATH_SEP := ;
+BASE_PATH := $(strip $(shell powershell -NoProfile -Command "$$machine = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); $$user = [System.Environment]::GetEnvironmentVariable('Path', 'User'); [Console]::Write($$machine + ';' + $$user)"));$(PATH)
 BLANK_LINE := @echo.
 define run_script
 	@call scripts\$(1).cmd
 endef
 else
 SHELL := /bin/bash
-FLUTTER_BIN := $(if $(wildcard .flutter/bin/flutter),./.flutter/bin/flutter,flutter)
+FLUTTER_BIN_DIR := $(if $(wildcard .flutter/bin/flutter),./.flutter/bin,)
+PATH_SEP := :
+BASE_PATH := $(PATH)
 BLANK_LINE := @echo
 define run_script
 	@bash scripts/$(1).sh
 endef
+endif
+
+ifeq ($(MHABIT_MAKE_PATH_READY),)
+PATH := $(if $(FLUTTER_BIN_DIR),$(FLUTTER_BIN_DIR)$(PATH_SEP),)$(BASE_PATH)
+export PATH
+export MHABIT_MAKE_PATH_READY := 1
 endif
 
 
@@ -38,7 +48,7 @@ help:
 
 bootstrap:
 	@git submodule update --init --recursive
-	@"$(FLUTTER_BIN)" pub get
+	@flutter pub get
 
 normalize-l10n:
 	$(call run_script,normalize_arb)
@@ -65,7 +75,7 @@ aio:
 
 aio-full:
 	@$(SUBMAKE) aio
-	@"$(FLUTTER_BIN)" test
+	@flutter test
 
 package-windows:
 	$(call run_script,build_msix)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+.DEFAULT_GOAL := help
+SUBMAKE := $(MAKE) --no-print-directory
+
+ifeq ($(OS),Windows_NT)
+SHELL := cmd.exe
+FLUTTER_BIN := $(if $(wildcard .flutter/bin/flutter.bat),.flutter\bin\flutter.bat,flutter)
+BLANK_LINE := @echo.
+define run_script
+	@call scripts\$(1).cmd
+endef
+else
+SHELL := /bin/bash
+FLUTTER_BIN := $(if $(wildcard .flutter/bin/flutter),./.flutter/bin/flutter,flutter)
+BLANK_LINE := @echo
+define run_script
+	@bash scripts/$(1).sh
+endef
+endif
+
+
+.PHONY: help bootstrap \
+	normalize-l10n build-runner gen-icons gen \
+	verify-generated ci-check aio aio-full package-windows
+
+help:
+	@echo Standardized automation entrypoints
+	$(BLANK_LINE)
+	@echo   bootstrap         Initialize Flutter submodule and fetch packages
+	@echo   normalize-l10n    Normalize ARB resources
+	@echo   build-runner      Run build_runner and gen-l10n
+	@echo   gen-icons         Generate icon fonts
+	@echo   gen               Run the main generation workflow
+	@echo   verify-generated  Ensure normalized/generated files are up to date
+	@echo   ci-check          Alias of verify-generated
+	@echo   aio               Run the standard local all-in-one workflow
+	@echo   aio-full          Run aio plus the internal Flutter test suite
+	@echo   package-windows   Build Windows MSIX package
+
+bootstrap:
+	@git submodule update --init --recursive
+	@"$(FLUTTER_BIN)" pub get
+
+normalize-l10n:
+	$(call run_script,normalize_arb)
+
+build-runner:
+	$(call run_script,build_runner)
+
+gen-icons:
+	$(call run_script,gen_icons)
+
+gen:
+	@$(SUBMAKE) normalize-l10n
+	@$(SUBMAKE) gen-icons
+	@$(SUBMAKE) build-runner
+
+verify-generated:
+	$(call run_script,verify_generated)
+
+ci-check: verify-generated
+
+aio:
+	@$(SUBMAKE) gen
+	@$(SUBMAKE) verify-generated
+
+aio-full:
+	@$(SUBMAKE) aio
+	@"$(FLUTTER_BIN)" test
+
+package-windows:
+	$(call run_script,build_msix)

--- a/lib/theme/_icons/cal_icons.g.dart
+++ b/lib/theme/_icons/cal_icons.g.dart
@@ -5,7 +5,10 @@ import 'package:flutter/widgets.dart';
 @immutable
 class _HabitCalIconsData extends IconData {
   const _HabitCalIconsData(int codePoint)
-    : super(codePoint, fontFamily: 'HabitCalIcons');
+      : super(
+          codePoint,
+          fontFamily: 'HabitCalIcons',
+        );
 }
 
 @immutable

--- a/lib/theme/_icons/common_icons.g.dart
+++ b/lib/theme/_icons/common_icons.g.dart
@@ -5,7 +5,10 @@ import 'package:flutter/widgets.dart';
 @immutable
 class _CommonIconsData extends IconData {
   const _CommonIconsData(int codePoint)
-    : super(codePoint, fontFamily: 'CommonIcons');
+      : super(
+          codePoint,
+          fontFamily: 'CommonIcons',
+        );
 }
 
 @immutable

--- a/lib/theme/_icons/progress_icons.g.dart
+++ b/lib/theme/_icons/progress_icons.g.dart
@@ -5,24 +5,21 @@ import 'package:flutter/widgets.dart';
 @immutable
 class _HabitProgressIconsData extends IconData {
   const _HabitProgressIconsData(int codePoint)
-    : super(codePoint, fontFamily: 'HabitProgressIcons');
+      : super(
+          codePoint,
+          fontFamily: 'HabitProgressIcons',
+        );
 }
 
 @immutable
 class HabitProgressIcons {
   const HabitProgressIcons._();
 
-  static const IconData numeric_1_circle_outline = _HabitProgressIconsData(
-    0xf101,
-  );
+  static const IconData numeric_1_circle_outline = _HabitProgressIconsData(0xf101);
   static const IconData numeric_1 = _HabitProgressIconsData(0xf102);
-  static const IconData numeric_2_circle_outline = _HabitProgressIconsData(
-    0xf103,
-  );
+  static const IconData numeric_2_circle_outline = _HabitProgressIconsData(0xf103);
   static const IconData numeric_2 = _HabitProgressIconsData(0xf104);
-  static const IconData numeric_3_circle_outline = _HabitProgressIconsData(
-    0xf105,
-  );
+  static const IconData numeric_3_circle_outline = _HabitProgressIconsData(0xf105);
   static const IconData numeric_3 = _HabitProgressIconsData(0xf106);
   static const IconData progress_100percent = _HabitProgressIconsData(0xf107);
   static const IconData progress_50percent = _HabitProgressIconsData(0xf108);

--- a/lib/theme/_icons/sort_icons.g.dart
+++ b/lib/theme/_icons/sort_icons.g.dart
@@ -5,36 +5,27 @@ import 'package:flutter/widgets.dart';
 @immutable
 class _HabitSortIconsData extends IconData {
   const _HabitSortIconsData(int codePoint)
-    : super(codePoint, fontFamily: 'HabitSortIcons');
+      : super(
+          codePoint,
+          fontFamily: 'HabitSortIcons',
+        );
 }
 
 @immutable
 class HabitSortIcons {
   const HabitSortIcons._();
 
-  static const IconData sort_alphabetical_ascending = _HabitSortIconsData(
-    0xf101,
-  );
-  static const IconData sort_alphabetical_descending = _HabitSortIconsData(
-    0xf102,
-  );
+  static const IconData sort_alphabetical_ascending = _HabitSortIconsData(0xf101);
+  static const IconData sort_alphabetical_descending = _HabitSortIconsData(0xf102);
   static const IconData sort_ascending = _HabitSortIconsData(0xf103);
-  static const IconData sort_bool_ascending_variant = _HabitSortIconsData(
-    0xf104,
-  );
+  static const IconData sort_bool_ascending_variant = _HabitSortIconsData(0xf104);
   static const IconData sort_bool_ascending = _HabitSortIconsData(0xf105);
-  static const IconData sort_bool_descending_variant = _HabitSortIconsData(
-    0xf106,
-  );
+  static const IconData sort_bool_descending_variant = _HabitSortIconsData(0xf106);
   static const IconData sort_bool_descending = _HabitSortIconsData(0xf107);
   static const IconData sort_calendar_ascending = _HabitSortIconsData(0xf108);
   static const IconData sort_calendar_descending = _HabitSortIconsData(0xf109);
-  static const IconData sort_clock_ascending_outline = _HabitSortIconsData(
-    0xf10a,
-  );
-  static const IconData sort_clock_descending_outline = _HabitSortIconsData(
-    0xf10b,
-  );
+  static const IconData sort_clock_ascending_outline = _HabitSortIconsData(0xf10a);
+  static const IconData sort_clock_descending_outline = _HabitSortIconsData(0xf10b);
   static const IconData sort_descending = _HabitSortIconsData(0xf10c);
   static const IconData sort_variant = _HabitSortIconsData(0xf10d);
   static const IconData sort = _HabitSortIconsData(0xf10e);

--- a/scripts/normalize_arb.cmd
+++ b/scripts/normalize_arb.cmd
@@ -1,0 +1,45 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "SCRIPT_DIR=%~dp0"
+for %%I in ("%SCRIPT_DIR%..") do set "REPO_ROOT=%%~fI"
+set "L10N_DIR=%REPO_ROOT%\assets\l10n"
+set "TEMPLATE_FILE=%L10N_DIR%\en.arb"
+set "L10N_REFS_FILE=%REPO_ROOT%\configs\l10n_refs.json"
+
+if defined PYTHON (
+  set "PYTHON_BIN=%PYTHON%"
+) else (
+  where python >nul 2>nul
+  if not errorlevel 1 (
+    set "PYTHON_BIN=python"
+  ) else (
+    where python3 >nul 2>nul
+    if not errorlevel 1 (
+      set "PYTHON_BIN=python3"
+    ) else (
+      echo Python interpreter not found.
+      exit /b 1
+    )
+  )
+)
+
+echo Normalizing ARB files from %L10N_DIR%
+for %%F in ("%L10N_DIR%\*.arb") do (
+  if /I "%%~fF"=="%TEMPLATE_FILE%" (
+    "%PYTHON_BIN%" "%SCRIPT_DIR%normalize_arb.py" ^
+      -i "%%~fF" -t "%TEMPLATE_FILE%" -o "%%~fF" --refs "%L10N_REFS_FILE%" ^
+      --indent 4
+  ) else (
+    "%PYTHON_BIN%" "%SCRIPT_DIR%normalize_arb.py" ^
+      -i "%%~fF" -t "%TEMPLATE_FILE%" -o "%%~fF" --refs "%L10N_REFS_FILE%" ^
+      --indent 4 --ignore-empty-meta
+  )
+
+  if errorlevel 1 (
+    set "ERR=!errorlevel!"
+    exit /b !ERR!
+  )
+
+  echo Done[0]: %%~fF
+)

--- a/scripts/normalize_arb.cmd
+++ b/scripts/normalize_arb.cmd
@@ -1,3 +1,16 @@
+@rem Copyright 2025 Fries_I23
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
 @echo off
 setlocal enabledelayedexpansion
 
@@ -6,22 +19,22 @@ for %%I in ("%SCRIPT_DIR%..") do set "REPO_ROOT=%%~fI"
 set "L10N_DIR=%REPO_ROOT%\assets\l10n"
 set "TEMPLATE_FILE=%L10N_DIR%\en.arb"
 set "L10N_REFS_FILE=%REPO_ROOT%\configs\l10n_refs.json"
+set "PYTHON_BIN="
 
 if defined PYTHON (
+  call :verify_python "%PYTHON%"
+  if errorlevel 1 (
+    echo Python 3.9+ interpreter not found: %PYTHON%
+    exit /b 1
+  )
   set "PYTHON_BIN=%PYTHON%"
 ) else (
-  where python >nul 2>nul
-  if not errorlevel 1 (
-    set "PYTHON_BIN=python"
-  ) else (
-    where python3 >nul 2>nul
-    if not errorlevel 1 (
-      set "PYTHON_BIN=python3"
-    ) else (
-      echo Python interpreter not found.
-      exit /b 1
-    )
+  call :verify_python python3
+  if errorlevel 1 (
+    echo Python 3.9+ interpreter not found.
+    exit /b 1
   )
+  set "PYTHON_BIN=python3"
 )
 
 echo Normalizing ARB files from %L10N_DIR%
@@ -43,3 +56,9 @@ for %%F in ("%L10N_DIR%\*.arb") do (
 
   echo Done[0]: %%~fF
 )
+
+exit /b 0
+
+:verify_python
+%~1 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >nul 2>nul
+exit /b %errorlevel%

--- a/scripts/normalize_arb.py
+++ b/scripts/normalize_arb.py
@@ -21,6 +21,9 @@ import argparse as ap
 from collections import OrderedDict
 
 
+JSON_ENCODING = "utf-8"
+
+
 T_JSON = dict[str, t.Optional[object]]
 
 
@@ -33,18 +36,18 @@ def format_arb(
     indent: t.Optional[int] = None,
     refs_filepath: str = None,
 ):
-    with open(input_filepath, "r") as fp:
+    with open(input_filepath, "r", encoding=JSON_ENCODING) as fp:
         input = json.load(fp, object_pairs_hook=OrderedDict)
         if not template_filepath:
             template = copy.deepcopy(input)
         else:
-            with open(template_filepath, "r") as fp:
+            with open(template_filepath, "r", encoding=JSON_ENCODING) as fp:
                 template = json.load(fp)
 
         output = input
 
         if refs_filepath is not None and os.path.exists(refs_filepath):
-            with open(refs_filepath, "r") as fp:
+            with open(refs_filepath, "r", encoding=JSON_ENCODING) as fp:
                 refs = json.load(fp)
                 output = _preprocess_arb_refs(input=output, refs=refs)
 
@@ -56,7 +59,7 @@ def format_arb(
         )
 
     if output_filepath:
-        with open(output_filepath, "w") as fp:
+        with open(output_filepath, "w", encoding=JSON_ENCODING) as fp:
             json.dump(output, fp=fp, indent=indent, ensure_ascii=False)
             fp.write("\n")
     else:

--- a/scripts/normalize_arb.sh
+++ b/scripts/normalize_arb.sh
@@ -16,16 +16,24 @@ SCRIPT_PATH=$(dirname $0)
 L10N_DIR="$SCRIPT_PATH/../assets/l10n"
 TEMPLATE_FILE=$L10N_DIR/en.arb
 L10N_REFS_FILE="$SCRIPT_PATH/../configs/l10n_refs.json"
+if command -v python >/dev/null 2>&1; then
+    PYTHON_BIN=python
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN=python3
+else
+    echo "Python interpreter not found." >&2
+    exit 1
+fi
 echo "Normalizing ARB files from $L10N_DIR"
 for file in $L10N_DIR/*.arb; do
     if [ -f "$file" ]; then
         if [[ "$file" == "$TEMPLATE_FILE" ]]; then
-            python $SCRIPT_PATH/normalize_arb.py \
+            $PYTHON_BIN $SCRIPT_PATH/normalize_arb.py \
                 -i $file -t $TEMPLATE_FILE -o $file --refs $L10N_REFS_FILE \
                 --indent 4
             _ERRCODE=$?
         else
-            python $SCRIPT_PATH/normalize_arb.py \
+            $PYTHON_BIN $SCRIPT_PATH/normalize_arb.py \
                 -i $file -t $TEMPLATE_FILE -o $file --refs $L10N_REFS_FILE \
                 --indent 4 --ignore-empty-meta
             _ERRCODE=$?

--- a/scripts/normalize_arb.sh
+++ b/scripts/normalize_arb.sh
@@ -16,14 +16,21 @@ SCRIPT_PATH=$(dirname $0)
 L10N_DIR="$SCRIPT_PATH/../assets/l10n"
 TEMPLATE_FILE=$L10N_DIR/en.arb
 L10N_REFS_FILE="$SCRIPT_PATH/../configs/l10n_refs.json"
-if command -v python >/dev/null 2>&1; then
-    PYTHON_BIN=python
-elif command -v python3 >/dev/null 2>&1; then
+
+if [[ -n "${PYTHON:-}" ]]; then
+    if "$PYTHON" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)' >/dev/null 2>&1; then
+        PYTHON_BIN="$PYTHON"
+    else
+        echo "Python 3.9+ interpreter not found: $PYTHON" >&2
+        exit 1
+    fi
+elif python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)' >/dev/null 2>&1; then
     PYTHON_BIN=python3
 else
-    echo "Python interpreter not found." >&2
+    echo "Python 3.9+ interpreter not found." >&2
     exit 1
 fi
+
 echo "Normalizing ARB files from $L10N_DIR"
 for file in $L10N_DIR/*.arb; do
     if [ -f "$file" ]; then

--- a/scripts/verify_generated.cmd
+++ b/scripts/verify_generated.cmd
@@ -1,3 +1,16 @@
+@rem Copyright 2025 Fries_I23
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
 @echo off
 setlocal
 

--- a/scripts/verify_generated.cmd
+++ b/scripts/verify_generated.cmd
@@ -1,0 +1,68 @@
+@echo off
+setlocal
+
+for %%I in ("%~dp0..") do set "REPO_ROOT=%%~fI"
+set "WORK_DIR=%TEMP%\mhabit-verify-%RANDOM%%RANDOM%"
+
+mkdir "%WORK_DIR%" >nul 2>nul
+if errorlevel 1 (
+  echo Failed to create temp directory: %WORK_DIR%
+  exit /b 1
+)
+
+set "BEFORE_STATUS=%WORK_DIR%\before.status"
+set "AFTER_STATUS=%WORK_DIR%\after.status"
+set "BEFORE_DIFF=%WORK_DIR%\before.diff"
+set "AFTER_DIFF=%WORK_DIR%\after.diff"
+
+if exist "%REPO_ROOT%\.flutter\bin" (
+  set "PATH=%REPO_ROOT%\.flutter\bin;%PATH%"
+)
+
+pushd "%REPO_ROOT%"
+git status --porcelain --untracked-files=all > "%BEFORE_STATUS%"
+if errorlevel 1 goto fail
+git diff --binary --no-ext-diff > "%BEFORE_DIFF%"
+if errorlevel 1 goto fail
+
+call "%~dp0normalize_arb.cmd"
+if errorlevel 1 goto fail
+call "%~dp0build_runner.cmd"
+if errorlevel 1 goto fail
+
+git status --porcelain --untracked-files=all > "%AFTER_STATUS%"
+if errorlevel 1 goto fail
+git diff --binary --no-ext-diff > "%AFTER_DIFF%"
+if errorlevel 1 goto fail
+
+fc /b "%BEFORE_STATUS%" "%AFTER_STATUS%" >nul
+set "STATUS_COMPARE=%errorlevel%"
+if %STATUS_COMPARE% GEQ 2 goto fail
+
+fc /b "%BEFORE_DIFF%" "%AFTER_DIFF%" >nul
+set "DIFF_COMPARE=%errorlevel%"
+if %DIFF_COMPARE% GEQ 2 goto fail
+
+if not "%STATUS_COMPARE%"=="0" goto delta
+if not "%DIFF_COMPARE%"=="0" goto delta
+
+popd
+rmdir /s /q "%WORK_DIR%"
+exit /b 0
+
+:delta
+echo Detected changes after generation:
+git status --short
+echo ------------------------
+echo Details:
+git diff
+set "ERR=1"
+goto cleanup
+
+:fail
+set "ERR=%errorlevel%"
+
+:cleanup
+popd
+rmdir /s /q "%WORK_DIR%"
+exit /b %ERR%

--- a/scripts/verify_generated.sh
+++ b/scripts/verify_generated.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright 2025 Fries_I23
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/verify_generated.sh
+++ b/scripts/verify_generated.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+if [[ -d "$REPO_ROOT/.flutter/bin" ]]; then
+  export PATH="$REPO_ROOT/.flutter/bin:$PATH"
+fi
+
+cd "$REPO_ROOT"
+
+before_status="$(mktemp)"
+after_status="$(mktemp)"
+before_diff="$(mktemp)"
+after_diff="$(mktemp)"
+
+cleanup() {
+  rm -f "$before_status" "$after_status" "$before_diff" "$after_diff"
+}
+trap cleanup EXIT
+
+git status --porcelain --untracked-files=all > "$before_status"
+git diff --binary --no-ext-diff > "$before_diff"
+
+bash "$SCRIPT_DIR/normalize_arb.sh"
+bash "$SCRIPT_DIR/build_runner.sh"
+
+git status --porcelain --untracked-files=all > "$after_status"
+git diff --binary --no-ext-diff > "$after_diff"
+
+if ! cmp -s "$before_status" "$after_status" || ! cmp -s "$before_diff" "$after_diff"; then
+  echo "Detected changes after generation:"
+  git status --short
+  echo "------------------------"
+  echo "Details:"
+  git diff
+  exit 1
+fi


### PR DESCRIPTION
Add a thin root Makefile for composite local workflows such as bootstrap, gen, verify-generated, aio, and aio-full.

Add Windows ARB normalization and cross-platform generated-file verification helpers, and commit the regenerated icon outputs they produced.