### PR TITLE
chore: bump version to v1.24.0+153-pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 [中文](./docs/CHANGELOG/zh.md)
 
+## 1.24.0+153-pre
+
+- Upgrade Flutter to 3.41.9 and migrate required framework breaking changes
+- Update package dependencies, generated files, and Fastlane lockfiles
+- Update GitHub Actions/CI runtimes and add a Linux build check
+- Update iOS lifecycle integration and desktop native asset handling for newer toolchains
+- Fix App Sync server iter type handling
+- Fix theme colors
+- Update the source builder wiki
+
 ## 1.23.12+152-pre
 
 - Add Basque translation resources and locale metadata, thanks to Txopi's contribution on GitHub (#523, #529)

--- a/android/app/src/f_store/fastlane/metadata/android/en-US/changelogs/153.txt
+++ b/android/app/src/f_store/fastlane/metadata/android/en-US/changelogs/153.txt
@@ -1,0 +1,7 @@
+- Upgrade Flutter to 3.41.9 and migrate required framework breaking changes
+- Update package dependencies, generated files, and Fastlane lockfiles
+- Update GitHub Actions/CI runtimes and add a Linux build check
+- Update iOS lifecycle integration and desktop native asset handling for newer toolchains
+- Fix App Sync server iter type handling
+- Fix theme colors
+- Update the source builder wiki

--- a/android/app/src/f_store/fastlane/metadata/android/zh-CN/changelogs/153.txt
+++ b/android/app/src/f_store/fastlane/metadata/android/zh-CN/changelogs/153.txt
@@ -1,0 +1,7 @@
+- 升级 Flutter 到 3.41.9，并迁移所需的框架破坏性变更
+- 更新依赖包、生成文件和 Fastlane lockfile
+- 更新 GitHub Actions/CI 运行时，并新增 Linux 构建检查
+- 为新工具链更新 iOS 生命周期集成和桌面端 native assets 处理
+- 修复 App Sync server 的 iter type 处理
+- 修复主题颜色
+- 更新 source builder wiki 文档

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -13,6 +13,8 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+require_relative "../../fastlane/deploy_lane_helper"
+
 default_platform(:android)
 
 default_platform(:android)
@@ -43,6 +45,7 @@ platform :android do
     flavor = options[:flavor] || "f_store"
     meta_path = options[:meta_path] || "app/src/#{flavor}/fastlane/metadata/android"
     track = options[:track]
+    dry_run = DeployLaneHelper.dry_run_enabled?(options)
 
     upload_params = {
       metadata_path: meta_path,
@@ -57,6 +60,17 @@ platform :android do
       upload_params[:aab] = "../build/app/outputs/bundle/#{flavor}Release/app-#{flavor}-release.aab"
       upload_params[:track] = track if track
     end
+
+    if dry_run
+      DeployLaneHelper.report_dry_run_skip(
+        action: "supply",
+        artifact: upload_params[:aab],
+        track: track,
+        metadata_path: meta_path
+      )
+      next
+    end
+
     supply(upload_params)
   end
 
@@ -67,6 +81,7 @@ platform :android do
     do_build = options.fetch(:build, true)
     do_clean = options.fetch(:clean, true)
     track = options[:track]
+    dry_run = DeployLaneHelper.dry_run_enabled?(options)
 
     upload_params = {
       sync_image_upload: true,
@@ -77,6 +92,17 @@ platform :android do
 
     clean() if do_clean
     build(flavor: flavor) if do_build
+
+    if dry_run
+      DeployLaneHelper.report_dry_run_skip(
+        action: "upload_to_play_store",
+        artifact: upload_params[:aab],
+        track: track,
+        metadata_path: meta_path
+      )
+      next
+    end
+
     upload_to_play_store(upload_params)
   end
 end

--- a/configs/flatpak_builder/io.github.friesi23.mhabit.metainfo.xml
+++ b/configs/flatpak_builder/io.github.friesi23.mhabit.metainfo.xml
@@ -99,6 +99,9 @@
     <category>Utility</category>
   </categories>
   <releases>
+    <release version="1.24.0+153-pre" date="2026-05-17">
+      <url type="details">https://github.com/FriesI23/mhabit/releases/tag/v1.24.0+153-pre</url>
+    </release>
     <release version="1.23.12+152-pre" date="2026-05-14">
       <url type="details">https://github.com/FriesI23/mhabit/releases/tag/v1.23.12+152-pre</url>
     </release>

--- a/docs/CHANGELOG/zh.md
+++ b/docs/CHANGELOG/zh.md
@@ -1,5 +1,15 @@
 # 更新日志
 
+## 1.24.0+153-pre
+
+- 升级 Flutter 到 3.41.9，并迁移所需的框架破坏性变更
+- 更新依赖包、生成文件和 Fastlane lockfile
+- 更新 GitHub Actions/CI 运行时，并新增 Linux 构建检查
+- 为新工具链更新 iOS 生命周期集成和桌面端 native assets 处理
+- 修复 App Sync server 的 iter type 处理
+- 修复主题颜色
+- 更新 source builder wiki 文档
+
 ## 1.23.12+152-pre
 
 - 添加巴斯克语翻译资源及语言元数据，感谢 Txopi 在 GitHub 上的贡献（#523 #529）

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,19 +1,13 @@
-# Pre-Released: v1.23.12+152
-
-**🌐 Localization**
-- Add Basque translation resources and locale metadata, thanks to Txopi's contribution on GitHub (#523, #529)
-- Update Arabic translation, thanks to abdelbasset jabrane's contribution on Weblate (#529)
-- Update French translation, thanks to biram's contribution on Weblate (#529)
-- Update Hebrew translation, thanks to Omer I.S.'s contribution on Weblate (#529)
-- Update Turkish translation, thanks to Soykan Aydın's contribution on Weblate (#529)
-- Update Traditional Chinese translation, thanks to William's contribution on Weblate (#529)
-- Update Android, iOS, macOS, and Windows localization metadata (#529)
+# Pre-Released: v1.24.0+153
 
 **🧹 Others**
-- Update contributors (#529)
-- Add the Android ADI registration asset for the f_store flavor
-- Update Flathub metainfo brand colors and summary (#534)
+- Upgrade Flutter to 3.41.9 and migrate required framework breaking changes
+- Update package dependencies and regenerated code, including notification, sharing, device info, and copy-with outputs
+- Update GitHub Actions and CI runtime versions, and add a Linux build check
+- Update iOS lifecycle integration with SceneDelegate and refresh platform toolchain/Fastlane dependencies
+- Improve desktop native asset handling for Windows and Linux builds
+- Fix App Sync server iter type handling
+- Fix theme colors
 
 **📝 Documentation**
-- Update README grammar (#525)
-- Update wording in the installation guide (#519)
+- Update the source builder wiki

--- a/fastlane/deploy_lane_helper.rb
+++ b/fastlane/deploy_lane_helper.rb
@@ -1,0 +1,20 @@
+module DeployLaneHelper
+  module_function
+
+  def dry_run_enabled?(options)
+    value = options[:dry_run]
+    return true if value == true
+    return true if value.to_s.downcase == "true"
+
+    ENV["DRY_RUN"].to_s == "1"
+  end
+
+  def report_dry_run_skip(action:, artifact: nil, track: nil, locales: nil,
+                          metadata_path: nil)
+    FastlaneCore::UI.important("[dry_run] Skipping #{action}")
+    FastlaneCore::UI.message("artifact: #{artifact}") if artifact
+    FastlaneCore::UI.message("track: #{track}") if track
+    FastlaneCore::UI.message("locales: #{locales.join(', ')}") if locales && !locales.empty?
+    FastlaneCore::UI.message("metadata_path: #{metadata_path}") if metadata_path
+  end
+end

--- a/fastlane/testflight_changelog_helper.rb
+++ b/fastlane/testflight_changelog_helper.rb
@@ -1,0 +1,50 @@
+module TestflightChangelogHelper
+  ANDROID_TESTFLIGHT_LOCALE_MAP = {
+    "en-US" => "en-US",
+    "zh-Hans" => "zh-CN"
+  }.freeze
+
+  module_function
+
+  def read_flutter_build_number(pubspec_path)
+    version_line = File.readlines(pubspec_path).find do |line|
+      line.start_with?("version:")
+    end
+    FastlaneCore::UI.user_error!("Missing version in #{pubspec_path}") if version_line.nil?
+
+    match = version_line.match(/\+(\d+)/)
+    FastlaneCore::UI.user_error!("Missing build number in #{pubspec_path}") if match.nil?
+
+    match[1]
+  end
+
+  def load(metadata_dir:, pubspec_path:, build_number: nil)
+    build_number ||= read_flutter_build_number(pubspec_path)
+    localized_build_info = {}
+
+    ANDROID_TESTFLIGHT_LOCALE_MAP.each do |testflight_locale, android_locale|
+      changelog_path = File.join(
+        metadata_dir,
+        android_locale,
+        "changelogs",
+        "#{build_number}.txt"
+      )
+      next unless File.file?(changelog_path)
+
+      whats_new = File.read(changelog_path).strip
+      next if whats_new.empty?
+
+      localized_build_info[testflight_locale] = { whats_new: whats_new }
+    end
+
+    if localized_build_info.empty?
+      FastlaneCore::UI.user_error!(
+        "No Android changelog files found for build #{build_number} under #{metadata_dir}"
+      )
+    end
+
+    changelog = localized_build_info["en-US"]&.dig(:whats_new)
+    changelog ||= localized_build_info.values.first[:whats_new]
+    [changelog, localized_build_info]
+  end
+end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -13,7 +13,23 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+require_relative "../../fastlane/deploy_lane_helper"
+require_relative "../../fastlane/testflight_changelog_helper"
+
 default_platform(:ios)
+
+def testflight_android_changelog_metadata_dir(flavor)
+  flavor_dir = File.expand_path(
+    "../../android/app/src/#{flavor}/fastlane/metadata/android",
+    __dir__
+  )
+  return flavor_dir if Dir.exist?(flavor_dir)
+
+  shared_dir = File.expand_path("../../fastlane/metadata/android", __dir__)
+  return shared_dir if Dir.exist?(shared_dir)
+
+  UI.user_error!("No Android changelog metadata found for flavor #{flavor}")
+end
 
 platform :ios do
   desc "Clean environment"
@@ -49,6 +65,7 @@ platform :ios do
     do_build = options.fetch(:build, true)
     do_clean = options.fetch(:clean, true)
     track = options[:track] || "alpha"
+    dry_run = DeployLaneHelper.dry_run_enabled?(options)
     ipa_path = "../build/ios/Build/Fastlane/Release-#{flavor}"
 
     clean() if do_clean
@@ -59,22 +76,51 @@ platform :ios do
       output_directory: ipa_path
     )
 
-    if track == "beta"
-      upload_to_testflight(
-        ipa: "#{ipa_path}/Runner.ipa",
-        uses_non_exempt_encryption: true,
-        distribute_external: true,
-        groups: ["Beta"]
-      )
-    elsif track == "public"
+    if track == "public"
+      if dry_run
+        DeployLaneHelper.report_dry_run_skip(
+          action: "upload_to_app_store",
+          artifact: "#{ipa_path}/Runner.ipa",
+          track: track
+        )
+        next
+      end
+
       upload_to_app_store(
         ipa: "#{ipa_path}/Runner.ipa"
       )
     else
-      upload_to_testflight(
-        ipa: "#{ipa_path}/Runner.ipa",
-        uses_non_exempt_encryption: true
+      changelog, localized_build_info = TestflightChangelogHelper.load(
+        metadata_dir: testflight_android_changelog_metadata_dir(flavor),
+        pubspec_path: File.expand_path("../../pubspec.yaml", __dir__),
+        build_number: options[:changelog_build_number]&.to_s
       )
+      upload_options = {
+        ipa: "#{ipa_path}/Runner.ipa",
+        uses_non_exempt_encryption: true,
+        changelog: changelog,
+        localized_build_info: localized_build_info
+      }
+
+      if dry_run
+        DeployLaneHelper.report_dry_run_skip(
+          action: "upload_to_testflight",
+          artifact: upload_options[:ipa],
+          track: track,
+          locales: localized_build_info.keys
+        )
+        next
+      end
+
+      if track == "beta"
+        upload_to_testflight(
+          **upload_options,
+          distribute_external: true,
+          groups: ["Beta"]
+        )
+      else
+        upload_to_testflight(**upload_options)
+      end
     end
   end
 end

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -13,7 +13,23 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+require_relative "../../fastlane/deploy_lane_helper"
+require_relative "../../fastlane/testflight_changelog_helper"
+
 default_platform(:ios)
+
+def testflight_android_changelog_metadata_dir(flavor)
+  flavor_dir = File.expand_path(
+    "../../android/app/src/#{flavor}/fastlane/metadata/android",
+    __dir__
+  )
+  return flavor_dir if Dir.exist?(flavor_dir)
+
+  shared_dir = File.expand_path("../../fastlane/metadata/android", __dir__)
+  return shared_dir if Dir.exist?(shared_dir)
+
+  UI.user_error!("No Android changelog metadata found for flavor #{flavor}")
+end
 
 platform :ios do
   desc "Clean environment"
@@ -50,6 +66,7 @@ platform :ios do
     do_build = options.fetch(:build, true)
     do_clean = options.fetch(:clean, true)
     track = options[:track] || "alpha"
+    dry_run = DeployLaneHelper.dry_run_enabled?(options)
     pkg_path = "../build/macos/Build/Fastlane/Release-#{flavor}"
 
     clean() if do_clean
@@ -60,22 +77,51 @@ platform :ios do
       output_directory: pkg_path
     )
 
-    if track == "beta"
-      upload_to_testflight(
-        pkg: "#{pkg_path}/mhabit.pkg",
-        uses_non_exempt_encryption: true,
-        distribute_external: true,
-        groups: ["Beta"]
-      )
-    elsif track == "public"
+    if track == "public"
+      if dry_run
+        DeployLaneHelper.report_dry_run_skip(
+          action: "upload_to_app_store",
+          artifact: "#{pkg_path}/mhabit.pkg",
+          track: track
+        )
+        next
+      end
+
       upload_to_app_store(
         pkg: "#{pkg_path}/mhabit.pkg"
       )
     else
-      upload_to_testflight(
-        pkg: "#{pkg_path}/mhabit.pkg",
-        uses_non_exempt_encryption: true
+      changelog, localized_build_info = TestflightChangelogHelper.load(
+        metadata_dir: testflight_android_changelog_metadata_dir(flavor),
+        pubspec_path: File.expand_path("../../pubspec.yaml", __dir__),
+        build_number: options[:changelog_build_number]&.to_s
       )
+      upload_options = {
+        pkg: "#{pkg_path}/mhabit.pkg",
+        uses_non_exempt_encryption: true,
+        changelog: changelog,
+        localized_build_info: localized_build_info
+      }
+
+      if dry_run
+        DeployLaneHelper.report_dry_run_skip(
+          action: "upload_to_testflight",
+          artifact: upload_options[:pkg],
+          track: track,
+          locales: localized_build_info.keys
+        )
+        next
+      end
+
+      if track == "beta"
+        upload_to_testflight(
+          **upload_options,
+          distribute_external: true,
+          groups: ["Beta"]
+        )
+      else
+        upload_to_testflight(**upload_options)
+      end
     end
   end
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.23.12+152-pre
+version: 1.24.0+153-pre
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
**🧹 Others**
- Upgrade Flutter to 3.41.9 and migrate required framework breaking changes
- Update package dependencies and regenerated code, including notification, sharing, device info, and copy-with outputs
- Update GitHub Actions and CI runtime versions, and add a Linux build check
- Update iOS lifecycle integration with SceneDelegate and refresh platform toolchain/Fastlane dependencies
- Improve desktop native asset handling for Windows and Linux builds
- Fix App Sync server iter type handling
- Fix theme colors

**📝 Documentation**
- Update the source builder wiki
