### PR TITLE
build: update Flatpak tooling to Freedesktop 25.08

### DIFF
--- a/.github/workflows/_build-linux-flatpak.yml
+++ b/.github/workflows/_build-linux-flatpak.yml
@@ -87,7 +87,7 @@ jobs:
     needs:
       - build
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-23.08
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
       options: --privileged
     runs-on: ${{ needs.build.outputs.runner }}
     outputs:

--- a/configs/flatpak_builder/io.github.friesi23.mhabit.yml
+++ b/configs/flatpak_builder/io.github.friesi23.mhabit.yml
@@ -5,39 +5,40 @@ app-id: io.github.friesi23.mhabit
 runtime: org.freedesktop.Sdk
 # Make sure to keep this version in sync with corresponding release CI
 # e.g. .github/workflows/app-release.yaml#jobs.build-linux-flatpak
-runtime-version: "23.08"
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 command: mhabit
 separate-locales: false
 finish-args:
   - --share=network
   - --share=ipc
+  - --device=dri
   - --socket=fallback-x11
   - --socket=wayland
   - --socket=system-bus
-  - --device=dri
   - --talk-name=org.freedesktop.portal.Desktop
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
 modules:
+  # <2026-05-19> The Freedesktop runtime version 25.08 provides the libsecret module.
   # Required by: flutter_secure_storage
   # https://github.com/flathub/shared-modules/blob/master/libsecret/libsecret.json
-  - name: libsecret
-    buildsystem: meson
-    config-opts:
-      - -Dmanpage=false
-      - -Dvapi=false
-      - -Dgtk_doc=false
-      - -Dintrospection=false
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share/man
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.6.tar.xz
-        sha256: 747b8c175be108c880d3adfb9c3537ea66e520e4ad2dccf5dce58003aeeca090
+  # - name: libsecret
+  #   buildsystem: meson
+  #   config-opts:
+  #     - -Dmanpage=false
+  #     - -Dvapi=false
+  #     - -Dgtk_doc=false
+  #     - -Dintrospection=false
+  #   cleanup:
+  #     - /bin
+  #     - /include
+  #     - /lib/pkgconfig
+  #     - /share/man
+  #   sources:
+  #     - type: archive
+  #       url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.6.tar.xz
+  #       sha256: 747b8c175be108c880d3adfb9c3537ea66e520e4ad2dccf5dce58003aeeca090
 
   - name: jsoncpp
     buildsystem: meson

--- a/scripts/build_flatpak.sh
+++ b/scripts/build_flatpak.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2025 Fries_I23
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/build_flatpak.sh
+++ b/scripts/build_flatpak.sh
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+
 if [[ "$(uname)" != "Linux" ]]; then
     echo "Error: This script is only intended for linux systems." >&2
     exit 1
@@ -25,9 +27,17 @@ check_command() {
     fi
 }
 
+check_flatpak_app() {
+    local app_id="$1"
+    if ! flatpak info "$app_id" &>/dev/null; then
+        echo "Error: Flatpak app '$app_id' is not installed." >&2
+        exit 1
+    fi
+}
+
 check_command flutter
 check_command flatpak
-check_command flatpak-builder
+check_flatpak_app org.flatpak.Builder
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
@@ -35,10 +45,15 @@ flutter clean
 flutter pub get
 flutter build linux --release
 
+set -x
+
 mkdir -p "$HERE/../build/linux/flatpak_builder"
 cd "$HERE/../build/linux/flatpak_builder"
-flatpak-builder --force-clean build-dir \
+flatpak run org.flatpak.Builder \
+    --force-clean build-dir \
     --repo=repo-dir \
     --default-branch=main \
     "$HERE/../configs/flatpak_builder/io.github.friesi23.mhabit.yml"
 flatpak build-bundle repo-dir mhabit.flatpak io.github.friesi23.mhabit main
+
+set +x

--- a/scripts/build_flatpak_pre.sh
+++ b/scripts/build_flatpak_pre.sh
@@ -22,10 +22,11 @@ case "${ARCH}" in
   *)         echo "Unsupported arch: ${ARCH}"; exit 1 ;;
 esac
 
-apt-get install -y flatpak flatpak-builder
+apt-get install -y flatpak
 
 flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
-flatpak install -y "org.freedesktop.Sdk/${FLAT_ARCH}/23.08"
-flatpak install -y "org.freedesktop.Platform/${FLAT_ARCH}/23.08"
+flatpak install -y "org.freedesktop.Sdk/${FLAT_ARCH}/25.08"
+flatpak install -y "org.freedesktop.Platform/${FLAT_ARCH}/25.08"
 flatpak install -y flathub org.freedesktop.appstream-glib
+flatpak install -y flathub org.flatpak.Builder


### PR DESCRIPTION
Switch local Flatpak builds to org.flatpak.Builder, update the workflow and manifest to the Freedesktop 25.08 runtime, and drop the host flatpak-builder package from the setup script.

link: https://github.com/flathub/io.github.friesi23.mhabit/issues/26