### PR TITLE
Add semi-automated release-flow scripts and orchestrator prompt

### DIFF
--- a/docs/prompts/mhabit-release-flow.md
+++ b/docs/prompts/mhabit-release-flow.md
@@ -1,0 +1,40 @@
+You are the release-flow orchestrator for the mhabit repo. Orchestration only — call scripts/sub-prompts in order, stop at confirmation gates. Procedural facts live in the wiki, not here.
+
+## Pin
+
+- version: HEAD
+
+`HEAD` = floating (like a Docker `latest` tag / git `HEAD`): resolve via `git log -1 --format=%H -- docs/wiki/Dev꞉-Push-To-New-Version.md` and re-read that file each time before trusting Source of Truth below. A fixed commit hash = pinned: stop re-resolving, only re-validate when the user bumps this value.
+
+## Source of Truth
+
+`docs/wiki/Dev꞉-Push-To-New-Version.md`, at the commit recorded in `version` above. Covers wiki steps 1–6 only. Steps 7–9 and Post-1 (tag, wait for CI, publish, Flathub manifest PR) stay manual — never execute them, point the user back to the wiki.
+
+## Files
+
+- `pubspec.yaml` — version authority
+- `Makefile` `aio-full` — gen + fix + verify-generated + test
+- `scripts/release_bump.sh` / `.cmd` — Stage 1: terminal version confirm (`bin/bump_version.py`), then `flutter clean && make aio-full`
+- `scripts/release_postgen.sh` / `.cmd` — Stage 3: `bin/release_postgen.py` sequences fastlane/Apple/Flatpak generation
+- `prompts/mhabit-release-notes.md` (parent workspace) — Stage 2: owns all release-note content judgment
+
+## On Invocation
+
+If stable-vs-pre/beta or the mode (ask/plan/execute) aren't already stated, ask via an interactive multiple-choice prompt (e.g. Claude Code's `AskUserQuestion`) instead of waiting for free-text arguments.
+
+## Rules
+
+- Stable-vs-pre/beta is always the user's call — never infer or override it.
+- Suggest the next version from commits/PRs since the last same-type tag (feature/fix/breaking → patch/minor/major; build number always +1 from `pubspec.yaml`). Show the reasoning.
+- Stage 1: never touch `pubspec.yaml`, `flutter`, or `make` directly — delegate to `release_bump.sh`/`.cmd`. Stop on failure, surface it verbatim.
+- Stage 2: delegate all content judgment to the `mhabit-release-notes` prompt's Execute Mode; don't redefine its rules here. CHANGELOG/`zh.md` stay stable-only per that prompt's own scope.
+- Stage 3: run `release_postgen.sh`/`.cmd --release|--pre` matching Stage 1's confirmed mode.
+- Confirm before every stage transition — never auto-chain.
+
+## Modes
+
+- **Ask** — read-only. Inspect `pubspec.yaml`, recent tags, `git status` of generated paths, and release-doc state. Report: current stage, what's outstanding, next action.
+- **Plan** — no edits/execution. Confirm mode, compute the suggested version with reasoning, list all 3 stages with commands and confirmation gates.
+- **Execute** — run Stages 1→3 per Rules, stopping at each gate. After each stage, report: outcome, what needs confirming, the next stage once confirmed.
+
+{{{input}}}

--- a/docs/prompts/mhabit-release-flow.md
+++ b/docs/prompts/mhabit-release-flow.md
@@ -8,7 +8,7 @@ You are the release-flow orchestrator for the mhabit repo. Orchestration only �
 
 ## Source of Truth
 
-`docs/wiki/Dev꞉-Push-To-New-Version.md`, at the commit recorded in `version` above. Covers wiki steps 1–6 only. Steps 7–9 and Post-1 (tag, wait for CI, publish, Flathub manifest PR) stay manual — never execute them, point the user back to the wiki.
+`docs/wiki/Dev꞉-Push-To-New-Version.md`, at the commit recorded in `version` above. Covers wiki steps 1–6, plus a gated Stage 4 for step 7 (see Rules). Steps 8–9 and Post-1 (wait for CI, publish, Flathub manifest PR) stay manual always — never execute them, point the user back to the wiki.
 
 ## Files
 
@@ -17,6 +17,12 @@ You are the release-flow orchestrator for the mhabit repo. Orchestration only �
 - `scripts/release_bump.sh` / `.cmd` — Stage 1: terminal version confirm (`bin/bump_version.py`), then `flutter clean && make aio-full`
 - `scripts/release_postgen.sh` / `.cmd` — Stage 3: `bin/release_postgen.py` sequences fastlane/Apple/Flatpak generation
 - `prompts/mhabit-release-notes.md` (parent workspace) — Stage 2: owns all release-note content judgment
+- Stage 3 verification paths (check `git status`/`git diff`, don't just trust exit code):
+  - `fastlane/metadata/android/*/changelogs` — F-Droid, stable-only
+  - `android/app/src/f_store/fastlane/metadata/android/*/changelogs` — Google Play, stable + beta
+  - `ios/fastlane`, `macos/fastlane` — Apple, stable-only
+  - `configs/flatpak_builder/*.metainfo.xml` — Flatpak, stable + beta
+  - `flatpak/*.metainfo.xml` — Flathub, stable-only; a beta run showing **no diff** here is expected (`-pre` entries are stripped before writing), not a failure
 
 ## On Invocation
 
@@ -27,14 +33,15 @@ If stable-vs-pre/beta or the mode (ask/plan/execute) aren't already stated, ask 
 - Stable-vs-pre/beta is always the user's call — never infer or override it.
 - Suggest the next version from commits/PRs since the last same-type tag (feature/fix/breaking → patch/minor/major; build number always +1 from `pubspec.yaml`). Show the reasoning.
 - Stage 1: never touch `pubspec.yaml`, `flutter`, or `make` directly — delegate to `release_bump.sh`/`.cmd`. Stop on failure, surface it verbatim.
-- Stage 2: delegate all content judgment to the `mhabit-release-notes` prompt's Execute Mode; don't redefine its rules here. CHANGELOG/`zh.md` stay stable-only per that prompt's own scope.
-- Stage 3: run `release_postgen.sh`/`.cmd --release|--pre` matching Stage 1's confirmed mode.
+- Stage 2: delegate all content judgment to the `mhabit-release-notes` prompt's Execute Mode; don't redefine its rules here. Both stable and beta get `CHANGELOG.md`/`zh.md` entries; that prompt also owns deleting `-pre` entries a stable release supersedes.
+- Stage 3: run `release_postgen.sh`/`.cmd --release|--pre` matching Stage 1's confirmed mode, then check the verification paths above with `git status`/`git diff`.
+- Stage 4 (wiki step 7 — commit + tag + push) is gated: after Stage 3, always stop and explicitly ask before doing any of it, even if everything else succeeded. Only skip asking if the user has already granted standing "auto upload" authorization for this session; a one-time "yes" answers only that one gate, not future ones. Wiki steps 8–9 and Post-1 stay manual always regardless of authorization — never execute those.
 - Confirm before every stage transition — never auto-chain.
 
 ## Modes
 
 - **Ask** — read-only. Inspect `pubspec.yaml`, recent tags, `git status` of generated paths, and release-doc state. Report: current stage, what's outstanding, next action.
-- **Plan** — no edits/execution. Confirm mode, compute the suggested version with reasoning, list all 3 stages with commands and confirmation gates.
-- **Execute** — run Stages 1→3 per Rules, stopping at each gate. After each stage, report: outcome, what needs confirming, the next stage once confirmed.
+- **Plan** — no edits/execution. Confirm mode, compute the suggested version with reasoning, list Stages 1–3 with commands and confirmation gates, and note Stage 4 is gated behind explicit per-run confirmation.
+- **Execute** — run Stages 1→3 per Rules, stopping at each gate. After Stage 3, stop and explicitly ask about Stage 4 (commit + tag + push) before doing it, unless standing auto-upload authorization is active. After each stage, report: outcome, what needs confirming, the next stage once confirmed.
 
 {{{input}}}

--- a/docs/prompts/mhabit-release-flow.md
+++ b/docs/prompts/mhabit-release-flow.md
@@ -1,5 +1,7 @@
 You are the release-flow orchestrator for the mhabit repo. Orchestration only — call scripts/sub-prompts in order, stop at confirmation gates. Procedural facts live in the wiki, not here.
 
+**Mandatory: use the scripts, not hand-run commands.** Every stage below has a designated script (`release_bump.sh`/`.cmd`, `release_postgen.sh`/`.cmd`). Always invoke that script. Do not substitute your own `flutter`/`make`/`git`/python commands for what a script already does, even if you're confident you know the right command — the script is the source of truth for sequencing, confirmation, and idempotency. Manual command execution is a **fallback only**, allowed solely when the script itself cannot run (not found, permission error, missing `poetry`/env) — and only after telling the user the script failed and that you are falling back to manual steps.
+
 ## Pin
 
 - version: HEAD
@@ -32,9 +34,9 @@ If stable-vs-pre/beta or the mode (ask/plan/execute) aren't already stated, ask 
 
 - Stable-vs-pre/beta is always the user's call — never infer or override it.
 - Suggest the next version from commits/PRs since the last same-type tag (feature/fix/breaking → patch/minor/major; build number always +1 from `pubspec.yaml`). Show the reasoning.
-- Stage 1: never touch `pubspec.yaml`, `flutter`, or `make` directly — delegate to `release_bump.sh`/`.cmd`. Stop on failure, surface it verbatim.
+- Stage 1: never touch `pubspec.yaml`, `flutter`, or `make` directly — always go through `release_bump.sh`/`.cmd`, never hand-run the equivalent commands yourself. Stop on failure, surface it verbatim; only fall back to manual steps if the script itself won't run, and say so first.
 - Stage 2: delegate all content judgment to the `mhabit-release-notes` prompt's Execute Mode; don't redefine its rules here. Both stable and beta get `CHANGELOG.md`/`zh.md` entries; that prompt also owns deleting `-pre` entries a stable release supersedes.
-- Stage 3: run `release_postgen.sh`/`.cmd --release|--pre` matching Stage 1's confirmed mode, then check the verification paths above with `git status`/`git diff`.
+- Stage 3: always go through `release_postgen.sh`/`.cmd --release|--pre` matching Stage 1's confirmed mode — never call `gen_changelogs.sh`/`gen_changelogs_darwin.sh`/`gen_flatpak_info.sh` directly yourself as a substitute. Then check the verification paths above with `git status`/`git diff`. Only fall back to running those generator scripts manually if `release_postgen.sh`/`.cmd` itself won't run, and say so first.
 - Stage 4 (wiki step 7 — commit + tag + push) is gated: after Stage 3, always stop and explicitly ask before doing any of it, even if everything else succeeded. Only skip asking if the user has already granted standing "auto upload" authorization for this session; a one-time "yes" answers only that one gate, not future ones. Wiki steps 8–9 and Post-1 stay manual always regardless of authorization — never execute those.
 - Confirm before every stage transition — never auto-chain.
 

--- a/docs/wiki/Dev꞉-Push-To-New-Version.md
+++ b/docs/wiki/Dev꞉-Push-To-New-Version.md
@@ -13,9 +13,7 @@
 
    ```shell
    flutter clean
-   flutter pub get
-   scripts/normalize_arb.sh
-   scripts/build_runner.sh
+   make aio-full
    ```
 
 ## 2. Update Release Description

--- a/docs/wiki/Dev꞉-Push-To-New-Version.md
+++ b/docs/wiki/Dev꞉-Push-To-New-Version.md
@@ -1,5 +1,10 @@
 <!-- markdownlint-disable no-inline-html first-line-heading -->
 
+> Steps 1–6 below can be semi-automated with an AI tool's agent/command mode
+> using the `docs/prompts/mhabit-release-flow.md` prompt. Step 7 can also be
+> done through that prompt, but it always stops to ask for explicit
+> confirmation first. Steps 8–9 and Post-1 stay manual always.
+
 ## 1. Bump App Version
 
 > - [x] stable

--- a/docs/wiki/Dev꞉-Push-To-New-Version.md
+++ b/docs/wiki/Dev꞉-Push-To-New-Version.md
@@ -31,19 +31,26 @@ You can start from `docs/release.template.md` and then update it for the target 
 ## 3. Update Changelog
 
 > - [x] stable
-> - [ ] beta
+> - [x] beta
 
 Add the release changelog in `CHANGELOG.md`, keeping its content consistent with `docs/release.md`.
 
 > Optionally, provide a translated changelog in `docs/CHANGELOG/<locale>.md`.
 
-## 4. F-Droid
+## 4. Android Platforms
 
 > - [x] stable
-> - [ ] beta
+> - [x] beta
 
-Metainfo required by F-Droid must be included in repo along with current tag,
-with Fastlane-compatible sturcture and format.
+Metadata required by F-Droid and Google Play must be included in repo along with
+current tag, with Fastlane-compatible structure and format.
+
+- **F-Droid**: `fastlane/metadata/android/<locale>/changelogs`
+  > - [x] stable
+  > - [ ] beta
+- **Google Play** (`f_store` flavor): `android/app/src/f_store/fastlane/metadata/android/<locale>/changelogs`
+  > - [x] stable
+  > - [x] beta
 
 Update info can be auto-generated from `CHANGELOG.md` by executing:
 

--- a/scripts/python-scripts/bin/bump_version.py
+++ b/scripts/python-scripts/bin/bump_version.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Fries_I23
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Confirm a suggested pubspec.yaml version and write it.
+
+Entry points: scripts/release_bump.sh, scripts/release_bump.cmd. They run
+this script first, then (only on success) run `flutter clean` and
+`make aio-full` themselves, since both rely on PATH/PATHEXT resolution that
+is more reliably handled by the native shell than by Python's subprocess.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+(-pre)?$")
+
+
+def resolve_repo_root() -> Path:
+    script_path = Path(__file__).resolve()
+    for parent in script_path.parents:
+        if (parent / "pubspec.yaml").is_file() and (parent / ".git").exists():
+            return parent
+    raise RuntimeError(
+        f"Failed to resolve repository root from script path: {script_path}"
+    )
+
+
+REPO_ROOT = resolve_repo_root()
+PUBSPEC = REPO_ROOT / "pubspec.yaml"
+
+
+def log_info(message: str) -> None:
+    print(f"[INFO] {message}")
+
+
+def log_error(message: str) -> None:
+    print(f"[ERROR] {message}", file=sys.stderr)
+
+
+def read_current_version() -> str:
+    for line in PUBSPEC.read_text(encoding="utf-8").splitlines():
+        if line.startswith("version:"):
+            return line.split(":", 1)[1].strip()
+    raise RuntimeError(f"No version field found in {PUBSPEC}")
+
+
+def write_version(version: str) -> None:
+    lines = PUBSPEC.read_text(encoding="utf-8").splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if line.startswith("version:"):
+            newline = "\n" if line.endswith("\n") else ""
+            lines[i] = f"version: {version}{newline}"
+            break
+    else:
+        raise RuntimeError(f"No version field found in {PUBSPEC}")
+    PUBSPEC.write_text("".join(lines), encoding="utf-8")
+
+
+def confirm_version(suggested: str) -> str | None:
+    current = read_current_version()
+    print(f"Current pubspec.yaml version: {current}")
+    print(f"Suggested next version:       {suggested}")
+    answer = input(
+        "Apply suggested version? [y]es / [n]o-abort / "
+        "or type a replacement version: "
+    ).strip()
+
+    if answer in ("", "y", "Y"):
+        return suggested
+    if answer in ("n", "N"):
+        return None
+    if not VERSION_RE.match(answer):
+        log_error(f"Replacement version '{answer}' does not match x.y.z+a[-pre]")
+        sys.exit(2)
+    return answer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="bump_version.py",
+        description="Confirm and apply a pubspec.yaml version bump.",
+    )
+    parser.add_argument("--version", required=True, dest="suggested")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not VERSION_RE.match(args.suggested):
+        log_error(f"Suggested version '{args.suggested}' does not match x.y.z+a[-pre]")
+        sys.exit(2)
+
+    final = confirm_version(args.suggested)
+    if final is None:
+        log_info("Aborted, pubspec.yaml not changed.")
+        sys.exit(1)
+
+    write_version(final)
+    log_info(f"Wrote version: {final}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/python-scripts/bin/release_postgen.py
+++ b/scripts/python-scripts/bin/release_postgen.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Fries_I23
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run wiki steps 4-6: fastlane, Apple platform, and Flatpak/Flathub
+metadata generation for a release.
+
+Entry points: scripts/release_postgen.sh, scripts/release_postgen.cmd.
+This is the single place that knows: Apple notes are stable-only, and
+Flatpak generation has no Windows port.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+IS_WINDOWS = os.name == "nt"
+
+
+def resolve_repo_root() -> Path:
+    script_path = Path(__file__).resolve()
+    for parent in script_path.parents:
+        if (parent / "pubspec.yaml").is_file() and (parent / ".git").exists():
+            return parent
+    raise RuntimeError(
+        f"Failed to resolve repository root from script path: {script_path}"
+    )
+
+
+REPO_ROOT = resolve_repo_root()
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def log_info(message: str) -> None:
+    print(f"[INFO] {message}")
+
+
+def run_script(name: str) -> None:
+    script = SCRIPTS_DIR / (f"{name}.cmd" if IS_WINDOWS else f"{name}.sh")
+    if not script.is_file():
+        log_info(f"Script not found, skipping: {script}")
+        sys.exit(1)
+    log_info(f"Running {script.name}...")
+    result = subprocess.run([str(script)], cwd=REPO_ROOT)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="release_postgen.py",
+        description="Run fastlane/Apple/Flatpak metadata generation for a release.",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--release", action="store_true")
+    mode.add_argument("--pre", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    log_info("[1/3] Fastlane changelogs (Android)...")
+    run_script("gen_changelogs")
+
+    if args.release:
+        log_info("[2/3] Apple platform release notes (stable)...")
+        run_script("gen_changelogs_darwin")
+    else:
+        log_info("[2/3] Skipping Apple platform release notes (pre/beta release).")
+
+    log_info("[3/3] Flatpak/Flathub metainfo...")
+    if IS_WINDOWS:
+        log_info(
+            "Skipping: gen_flatpak_info.sh has no Windows port (depends on "
+            "xmlstarlet/flatpak tooling). Run it on macOS/Linux, or edit the "
+            "metainfo files manually per the wiki."
+        )
+    else:
+        run_script("gen_flatpak_info")
+
+    log_info(
+        "Done. Review changes under fastlane/, ios/macos fastlane, "
+        "configs/flatpak_builder/, flatpak/ before committing."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release_bump.cmd
+++ b/scripts/release_bump.cmd
@@ -1,0 +1,77 @@
+@rem Copyright 2026 Fries_I23
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+@rem Wiki step 1 (Bump App Version) executor: confirms a version string in
+@rem the terminal (logic lives in bin\bump_version.py), then runs
+@rem flutter clean && make aio-full.
+@rem See: docs/wiki/Dev꞉-Push-To-New-Version.md
+@echo off
+setlocal
+
+if /I not "%~1"=="--version" goto usage
+if "%~2"=="" goto usage
+set "SUGGESTED=%~2"
+
+for %%I in ("%~dp0") do set "SCRIPT_DIR=%%~fI"
+for %%I in ("%SCRIPT_DIR%..") do set "REPO_ROOT=%%~fI"
+set "PYTHON_SCRIPTS_DIR=%SCRIPT_DIR%\python-scripts"
+
+where poetry >nul 2>nul
+if errorlevel 1 (
+  echo Poetry is required but not found in PATH.
+  exit /b 1
+)
+
+pushd "%PYTHON_SCRIPTS_DIR%" >nul
+if errorlevel 1 (
+  echo Failed to enter directory: %PYTHON_SCRIPTS_DIR%
+  exit /b 1
+)
+
+set "POETRY_ENV_PATH="
+for /f "usebackq delims=" %%I in (`poetry env info --path 2^>nul`) do set "POETRY_ENV_PATH=%%I"
+if not defined POETRY_ENV_PATH (
+  echo Failed to resolve Poetry environment path.
+  popd >nul
+  exit /b 1
+)
+
+set "POETRY_PYTHON=%POETRY_ENV_PATH%\Scripts\python.exe"
+if not exist "%POETRY_PYTHON%" set "POETRY_PYTHON=%POETRY_ENV_PATH%\bin\python"
+if not exist "%POETRY_PYTHON%" (
+  echo Poetry environment python not found: %POETRY_ENV_PATH%
+  popd >nul
+  exit /b 1
+)
+
+"%POETRY_PYTHON%" bin\bump_version.py --version "%SUGGESTED%"
+if errorlevel 1 (
+  popd >nul
+  exit /b 1
+)
+popd >nul
+
+cd "%REPO_ROOT%"
+echo Running flutter clean...
+call flutter clean
+if errorlevel 1 exit /b 1
+echo Running make aio-full...
+call make aio-full
+if errorlevel 1 exit /b 1
+
+exit /b 0
+
+:usage
+echo Usage: %~nx0 --version ^<x.y.z+a[-pre]^>
+exit /b 2

--- a/scripts/release_bump.cmd
+++ b/scripts/release_bump.cmd
@@ -19,59 +19,21 @@
 @echo off
 setlocal
 
-if /I not "%~1"=="--version" goto usage
-if "%~2"=="" goto usage
-set "SUGGESTED=%~2"
-
 for %%I in ("%~dp0") do set "SCRIPT_DIR=%%~fI"
 for %%I in ("%SCRIPT_DIR%..") do set "REPO_ROOT=%%~fI"
-set "PYTHON_SCRIPTS_DIR=%SCRIPT_DIR%\python-scripts"
 
-where poetry >nul 2>nul
-if errorlevel 1 (
-  echo Poetry is required but not found in PATH.
-  exit /b 1
-)
-
-pushd "%PYTHON_SCRIPTS_DIR%" >nul
-if errorlevel 1 (
-  echo Failed to enter directory: %PYTHON_SCRIPTS_DIR%
-  exit /b 1
-)
-
-set "POETRY_ENV_PATH="
-for /f "usebackq delims=" %%I in (`poetry env info --path 2^>nul`) do set "POETRY_ENV_PATH=%%I"
-if not defined POETRY_ENV_PATH (
-  echo Failed to resolve Poetry environment path.
-  popd >nul
-  exit /b 1
-)
+pushd "%SCRIPT_DIR%\python-scripts"
+for /f "usebackq delims=" %%I in (`poetry env info --path`) do set "POETRY_ENV_PATH=%%I"
+popd
 
 set "POETRY_PYTHON=%POETRY_ENV_PATH%\Scripts\python.exe"
 if not exist "%POETRY_PYTHON%" set "POETRY_PYTHON=%POETRY_ENV_PATH%\bin\python"
-if not exist "%POETRY_PYTHON%" (
-  echo Poetry environment python not found: %POETRY_ENV_PATH%
-  popd >nul
-  exit /b 1
-)
 
-"%POETRY_PYTHON%" bin\bump_version.py --version "%SUGGESTED%"
-if errorlevel 1 (
-  popd >nul
-  exit /b 1
-)
-popd >nul
+"%POETRY_PYTHON%" "%SCRIPT_DIR%\python-scripts\bin\bump_version.py" %*
+if errorlevel 1 exit /b 1
 
 cd "%REPO_ROOT%"
-echo Running flutter clean...
 call flutter clean
 if errorlevel 1 exit /b 1
-echo Running make aio-full...
 call make aio-full
 if errorlevel 1 exit /b 1
-
-exit /b 0
-
-:usage
-echo Usage: %~nx0 --version ^<x.y.z+a[-pre]^>
-exit /b 2

--- a/scripts/release_bump.sh
+++ b/scripts/release_bump.sh
@@ -21,31 +21,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
-PYTHON_SCRIPTS_DIR="$REPO_ROOT/scripts/python-scripts"
 
-if [[ "${1:-}" != "--version" || -z "${2:-}" ]]; then
-	echo "Usage: $0 --version <x.y.z+a[-pre]>" >&2
-	exit 2
-fi
-SUGGESTED="$2"
-
-if ! command -v poetry >/dev/null 2>&1; then
-	echo "Poetry is required but not found in PATH." >&2
-	exit 1
-fi
-
-cd "$PYTHON_SCRIPTS_DIR"
-POETRY_PYTHON="$(poetry env info --path)/bin/python"
-
-if [[ ! -x "$POETRY_PYTHON" ]]; then
-	echo "Poetry environment python not found: $POETRY_PYTHON" >&2
-	exit 1
-fi
-
-"$POETRY_PYTHON" bin/bump_version.py --version "$SUGGESTED"
+POETRY_ENV_PATH="$(cd "$SCRIPT_DIR/python-scripts" && poetry env info --path)"
+"$POETRY_ENV_PATH/bin/python" "$SCRIPT_DIR/python-scripts/bin/bump_version.py" "$@"
 
 cd "$REPO_ROOT"
-echo "Running flutter clean..."
 flutter clean
-echo "Running make aio-full..."
 make aio-full

--- a/scripts/release_bump.sh
+++ b/scripts/release_bump.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2026 Fries_I23
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Wiki step 1 (Bump App Version) executor: confirms a version string in the
+# terminal (logic lives in bin/bump_version.py), then runs
+# flutter clean && make aio-full.
+# See: docs/wiki/Dev꞉-Push-To-New-Version.md
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+PYTHON_SCRIPTS_DIR="$REPO_ROOT/scripts/python-scripts"
+
+if [[ "${1:-}" != "--version" || -z "${2:-}" ]]; then
+	echo "Usage: $0 --version <x.y.z+a[-pre]>" >&2
+	exit 2
+fi
+SUGGESTED="$2"
+
+if ! command -v poetry >/dev/null 2>&1; then
+	echo "Poetry is required but not found in PATH." >&2
+	exit 1
+fi
+
+cd "$PYTHON_SCRIPTS_DIR"
+POETRY_PYTHON="$(poetry env info --path)/bin/python"
+
+if [[ ! -x "$POETRY_PYTHON" ]]; then
+	echo "Poetry environment python not found: $POETRY_PYTHON" >&2
+	exit 1
+fi
+
+"$POETRY_PYTHON" bin/bump_version.py --version "$SUGGESTED"
+
+cd "$REPO_ROOT"
+echo "Running flutter clean..."
+flutter clean
+echo "Running make aio-full..."
+make aio-full

--- a/scripts/release_postgen.cmd
+++ b/scripts/release_postgen.cmd
@@ -1,0 +1,66 @@
+@rem Copyright 2026 Fries_I23
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+@rem Wiki steps 4-6 executor: fastlane (Android), Apple platform release
+@rem notes (stable only), and Flatpak/Flathub metainfo generation.
+@rem Sequencing logic lives in bin\release_postgen.py.
+@rem See: docs/wiki/Dev꞉-Push-To-New-Version.md
+@echo off
+setlocal
+
+if /I "%~1"=="--release" set "MODE=--release"
+if /I "%~1"=="--pre" set "MODE=--pre"
+if not defined MODE goto usage
+
+for %%I in ("%~dp0") do set "SCRIPT_DIR=%%~fI"
+for %%I in ("%SCRIPT_DIR%..") do set "REPO_ROOT=%%~fI"
+set "PYTHON_SCRIPTS_DIR=%SCRIPT_DIR%\python-scripts"
+
+where poetry >nul 2>nul
+if errorlevel 1 (
+  echo Poetry is required but not found in PATH.
+  exit /b 1
+)
+
+pushd "%PYTHON_SCRIPTS_DIR%" >nul
+if errorlevel 1 (
+  echo Failed to enter directory: %PYTHON_SCRIPTS_DIR%
+  exit /b 1
+)
+
+set "POETRY_ENV_PATH="
+for /f "usebackq delims=" %%I in (`poetry env info --path 2^>nul`) do set "POETRY_ENV_PATH=%%I"
+if not defined POETRY_ENV_PATH (
+  echo Failed to resolve Poetry environment path.
+  popd >nul
+  exit /b 1
+)
+
+set "POETRY_PYTHON=%POETRY_ENV_PATH%\Scripts\python.exe"
+if not exist "%POETRY_PYTHON%" set "POETRY_PYTHON=%POETRY_ENV_PATH%\bin\python"
+if not exist "%POETRY_PYTHON%" (
+  echo Poetry environment python not found: %POETRY_ENV_PATH%
+  popd >nul
+  exit /b 1
+)
+
+"%POETRY_PYTHON%" bin\release_postgen.py %MODE%
+set "ERR=%errorlevel%"
+
+popd >nul
+exit /b %ERR%
+
+:usage
+echo Usage: %~nx0 --release ^| --pre
+exit /b 2

--- a/scripts/release_postgen.cmd
+++ b/scripts/release_postgen.cmd
@@ -19,48 +19,14 @@
 @echo off
 setlocal
 
-if /I "%~1"=="--release" set "MODE=--release"
-if /I "%~1"=="--pre" set "MODE=--pre"
-if not defined MODE goto usage
-
 for %%I in ("%~dp0") do set "SCRIPT_DIR=%%~fI"
-for %%I in ("%SCRIPT_DIR%..") do set "REPO_ROOT=%%~fI"
-set "PYTHON_SCRIPTS_DIR=%SCRIPT_DIR%\python-scripts"
 
-where poetry >nul 2>nul
-if errorlevel 1 (
-  echo Poetry is required but not found in PATH.
-  exit /b 1
-)
-
-pushd "%PYTHON_SCRIPTS_DIR%" >nul
-if errorlevel 1 (
-  echo Failed to enter directory: %PYTHON_SCRIPTS_DIR%
-  exit /b 1
-)
-
-set "POETRY_ENV_PATH="
-for /f "usebackq delims=" %%I in (`poetry env info --path 2^>nul`) do set "POETRY_ENV_PATH=%%I"
-if not defined POETRY_ENV_PATH (
-  echo Failed to resolve Poetry environment path.
-  popd >nul
-  exit /b 1
-)
+pushd "%SCRIPT_DIR%\python-scripts"
+for /f "usebackq delims=" %%I in (`poetry env info --path`) do set "POETRY_ENV_PATH=%%I"
+popd
 
 set "POETRY_PYTHON=%POETRY_ENV_PATH%\Scripts\python.exe"
 if not exist "%POETRY_PYTHON%" set "POETRY_PYTHON=%POETRY_ENV_PATH%\bin\python"
-if not exist "%POETRY_PYTHON%" (
-  echo Poetry environment python not found: %POETRY_ENV_PATH%
-  popd >nul
-  exit /b 1
-)
 
-"%POETRY_PYTHON%" bin\release_postgen.py %MODE%
-set "ERR=%errorlevel%"
-
-popd >nul
-exit /b %ERR%
-
-:usage
-echo Usage: %~nx0 --release ^| --pre
-exit /b 2
+"%POETRY_PYTHON%" "%SCRIPT_DIR%\python-scripts\bin\release_postgen.py" %*
+exit /b %errorlevel%

--- a/scripts/release_postgen.sh
+++ b/scripts/release_postgen.sh
@@ -20,26 +20,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
-REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
-PYTHON_SCRIPTS_DIR="$REPO_ROOT/scripts/python-scripts"
 
-MODE="${1:-}"
-if [[ "$MODE" != "--release" && "$MODE" != "--pre" ]]; then
-	echo "Usage: $0 --release | --pre" >&2
-	exit 2
-fi
-
-if ! command -v poetry >/dev/null 2>&1; then
-	echo "Poetry is required but not found in PATH." >&2
-	exit 1
-fi
-
-cd "$PYTHON_SCRIPTS_DIR"
-POETRY_PYTHON="$(poetry env info --path)/bin/python"
-
-if [[ ! -x "$POETRY_PYTHON" ]]; then
-	echo "Poetry environment python not found: $POETRY_PYTHON" >&2
-	exit 1
-fi
-
-"$POETRY_PYTHON" bin/release_postgen.py "$MODE"
+POETRY_ENV_PATH="$(cd "$SCRIPT_DIR/python-scripts" && poetry env info --path)"
+"$POETRY_ENV_PATH/bin/python" "$SCRIPT_DIR/python-scripts/bin/release_postgen.py" "$@"

--- a/scripts/release_postgen.sh
+++ b/scripts/release_postgen.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2026 Fries_I23
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Wiki steps 4-6 executor: fastlane (Android), Apple platform release notes
+# (stable only), and Flatpak/Flathub metainfo generation. Sequencing logic
+# lives in bin/release_postgen.py.
+# See: docs/wiki/Dev꞉-Push-To-New-Version.md
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+PYTHON_SCRIPTS_DIR="$REPO_ROOT/scripts/python-scripts"
+
+MODE="${1:-}"
+if [[ "$MODE" != "--release" && "$MODE" != "--pre" ]]; then
+	echo "Usage: $0 --release | --pre" >&2
+	exit 2
+fi
+
+if ! command -v poetry >/dev/null 2>&1; then
+	echo "Poetry is required but not found in PATH." >&2
+	exit 1
+fi
+
+cd "$PYTHON_SCRIPTS_DIR"
+POETRY_PYTHON="$(poetry env info --path)/bin/python"
+
+if [[ ! -x "$POETRY_PYTHON" ]]; then
+	echo "Poetry environment python not found: $POETRY_PYTHON" >&2
+	exit 1
+fi
+
+"$POETRY_PYTHON" bin/release_postgen.py "$MODE"


### PR DESCRIPTION
## Summary

- Semi-automates wiki steps 1–6 of [Dev: Push To New Version](docs/wiki/Dev꞉-Push-To-New-Version.md): version bump confirmation, `make aio-full` regeneration, and fastlane/Apple/Flatpak metadata generation, each as a thin shell entry (`scripts/release_bump.{sh,cmd}`, `scripts/release_postgen.{sh,cmd}`) backed by Python implementations under `scripts/python-scripts/bin/`.
- Adds `docs/prompts/mhabit-release-flow.md`, an AI-tool-agnostic orchestrator prompt that walks version bump → release-note drafting → metadata generation, stopping for explicit confirmation at each stage and before any commit/tag/push.
- Updates the wiki step 1 (regen via `flutter clean && make aio-full`), step 3 (beta also needs a changelog entry; delete superseded `-pre` entries once a stable release ships), step 4 (renamed F-Droid → Android Platforms, splitting F-Droid stable-only vs Google Play stable+beta scope), matching what `gen_changelogs.sh` already does.

## Test plan

- [x] `bash -n` on `release_bump.sh` / `release_postgen.sh`; `python -m py_compile` on the new Python scripts.
- [x] Exercised `release_bump.sh` accept/abort/replacement-version paths and `release_postgen.sh --release`/`--pre`/bad-arg paths against an isolated sandbox copy (real poetry env, stubbed `flutter`/`make`/generator scripts).
- [ ] Run the real flow end-to-end against a live version bump (next release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)