### PR TITLE
feat(ci): add Android Play Store submission pipeline

### DIFF
--- a/.github/workflows/_submit-android-play-store.yml
+++ b/.github/workflows/_submit-android-play-store.yml
@@ -1,0 +1,59 @@
+name: Submit Android (Play Store)
+
+on:
+  workflow_call:
+    inputs:
+      track:
+        description: Play Store track
+        type: string
+        required: false
+        default: internal
+      dry_run:
+        description: Run as a validate_only dry run instead of a real submission
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  submit-android-play-store:
+    name: "Submit Android (Play Store ${{ inputs.track }})"
+    runs-on: ubuntu-latest
+    environment: store-submission
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup_jdk
+      - uses: ./.github/actions/setup_flutter
+      - name: Write key.properties (Play Store keystore)
+        env:
+          KEY_PASSWORD: ${{ secrets.PLAY_STORE_SIGN_KEY_PASSWORD }}
+          STORE_PASSWORD: ${{ secrets.PLAY_STORE_SIGN_STORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.PLAY_STORE_SIGN_KEY_ALIAS }}
+          KEY_JKS_BASE64: ${{ secrets.PLAY_STORE_SIGN_KEY_JKS }}
+        run: |
+          echo "keyPassword=$KEY_PASSWORD" > android/key.properties
+          echo "storePassword=$STORE_PASSWORD" >> android/key.properties
+          echo "keyAlias=$KEY_ALIAS" >> android/key.properties
+          echo "storeFile=key.jks" >> android/key.properties
+          echo "$KEY_JKS_BASE64" | base64 --decode > android/app/key.jks
+        shell: bash
+      - name: Write Play Console service-account json
+        env:
+          JSON_KEY_DATA: ${{ secrets.PLAY_STORE_JSON_KEY_DATA }}
+        run: echo "$JSON_KEY_DATA" > android/fastlane/play_store_service_account.json
+        shell: bash
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+          working-directory: android
+      - name: Deploy to Play Store
+        env:
+          TRACK: ${{ inputs.track }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          cd android
+          bundle exec fastlane android deploy_play_store \
+            track:"$TRACK" build:true force_build:false \
+            metadata:false changelog:false images:false screenshots:false \
+            dry_run:"$DRY_RUN"
+        shell: bash

--- a/.github/workflows/manual-submit-android.yml
+++ b/.github/workflows/manual-submit-android.yml
@@ -1,0 +1,25 @@
+name: Manual Submit Android
+
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: Play Store track
+        type: choice
+        required: true
+        default: internal
+        options:
+          - internal
+      dry_run:
+        description: Run as a validate_only dry run (no real submission)
+        type: boolean
+        required: true
+        default: true
+
+jobs:
+  submit-android-play-store:
+    uses: ./.github/workflows/_submit-android-play-store.yml
+    with:
+      track: ${{ inputs.track }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit

--- a/.github/workflows/manual-submit-android.yml
+++ b/.github/workflows/manual-submit-android.yml
@@ -10,6 +10,9 @@ on:
         default: internal
         options:
           - internal
+          - alpha
+          - beta
+          - production
       dry_run:
         description: Run as a validate_only dry run (no real submission)
         type: boolean

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -117,6 +117,15 @@ jobs:
             ${{ steps.build.outputs.apk-x64-path }}
           token: ${{ secrets.APP_RELEASE_TOKEN }}
 
+  submit-android-play-store:
+    needs:
+      - pre-build
+    uses: ./.github/workflows/_submit-android-play-store.yml
+    with:
+      track: internal
+      dry_run: false
+    secrets: inherit
+
   build-ios:
     name: "Build Unsigned iOS IPA"
     needs:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -122,7 +122,7 @@ jobs:
       - pre-build
     uses: ./.github/workflows/_submit-android-play-store.yml
     with:
-      track: internal
+      track: ${{ needs.pre-build.outputs.pre-release == 'true' && 'beta' || 'production' }}
       dry_run: false
     secrets: inherit
 

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -14,6 +14,7 @@ key.properties
 **/*.keystore
 **/*.jks
 **/fastlane/table-habit-*.json
+**/fastlane/play_store_service_account.json
 
 # fastlane specific
 **/fastlane/report.xml

--- a/android/fastlane/Appfile
+++ b/android/fastlane/Appfile
@@ -1,4 +1,4 @@
 # fastlane supply required
-json_key_file("fastlane/table-habit-50c879e44acb.json")
+json_key_file("fastlane/play_store_service_account.json")
 
 package_name("io.github.friesi23.mhabit")

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -75,7 +75,7 @@ platform :android do
         track: track,
         metadata_path: meta_path
       )
-      next
+      upload_params[:validate_only] = true
     end
 
     supply(upload_params)
@@ -103,7 +103,11 @@ platform :android do
     upload_params = {
       sync_image_upload: true,
       metadata_path: meta_path,
-      aab: aab_path
+      aab: aab_path,
+      skip_upload_metadata: !DeployLaneHelper.option_enabled?(options, :metadata, default: true),
+      skip_upload_changelogs: !DeployLaneHelper.option_enabled?(options, :changelog, default: true),
+      skip_upload_images: !DeployLaneHelper.option_enabled?(options, :images, default: true),
+      skip_upload_screenshots: !DeployLaneHelper.option_enabled?(options, :screenshots, default: true)
     }
     upload_params[:track] = track if track
 
@@ -126,7 +130,7 @@ platform :android do
         track: track,
         metadata_path: meta_path
       )
-      next
+      upload_params[:validate_only] = true
     end
 
     upload_to_play_store(upload_params)


### PR DESCRIPTION
## Summary

Adds a reusable workflow (_submit-android-play-store.yml) that writesthe Play Store keystore and service-account credentials from thestore-submission Environment, builds the f_store flavor via fastlane,and runs the deploy_play_store lane. Wired into release-app.yml forreal tag-triggered releases and into a new manual-submit-android.ymlfor on-demand dry runs, both passing secrets via `secrets: inherit`.

Fastfile's deploy_play_store/update_play_store lanes gainedskip_upload_* options so the CI service account (read + internaltrack only) doesn't need broader store-listing permissions, anddry_run now does a real validate_only call against Google Playinstead of skipping the upload locally.

## Type of Change
<!-- Check the one that matches this PR's commit type -->
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] style
- [ ] test
- [x] chore

## Related Issue
<!-- e.g. Fixes #123, Closes #123, Related to #123 -->

## Checklist
<!-- Optional — check what applies -->
- [x] Ran `make aio && make test` locally
- [x] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change

---

> _Templates_: [weblate.md](?template=weblate.md)
