### PR TITLE
feat: add macOS App Store fastlane match signing and CI workflow

### DIFF
--- a/.github/actions/setup_xcode/action.yml
+++ b/.github/actions/setup_xcode/action.yml
@@ -1,0 +1,15 @@
+name: Setup Xcode
+description: setup the project's pinned Xcode version, for common use.
+
+inputs:
+  xcode-version:
+    description: Xcode version to select
+    required: false
+    default: "^26"
+
+runs:
+  using: composite
+  steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ inputs.xcode-version }}

--- a/.github/workflows/_build_test.yml
+++ b/.github/workflows/_build_test.yml
@@ -46,14 +46,12 @@ jobs:
             macos) echo "label=macOS" >> "$GITHUB_OUTPUT" ;;
           esac
 
-      - if: inputs.platform == 'ios' || inputs.platform == 'macos'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ^26
-
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+
+      - if: inputs.platform == 'ios' || inputs.platform == 'macos'
+        uses: ./.github/actions/setup_xcode
 
       - if: inputs.platform == 'android'
         uses: ./.github/actions/setup_jdk

--- a/.github/workflows/_submit-android-play-store.yml
+++ b/.github/workflows/_submit-android-play-store.yml
@@ -41,10 +41,8 @@ jobs:
           JSON_KEY_DATA: ${{ secrets.PLAY_STORE_JSON_KEY_DATA }}
         run: echo "$JSON_KEY_DATA" > android/fastlane/play_store_service_account.json
         shell: bash
-      - uses: ruby/setup-ruby@v1
+      - uses: ./.github/actions/setup_ruby
         with:
-          ruby-version: "3.4"
-          bundler-cache: true
           working-directory: android
       - name: Deploy to Play Store
         env:

--- a/.github/workflows/_submit-macos-app-store.yml
+++ b/.github/workflows/_submit-macos-app-store.yml
@@ -1,4 +1,4 @@
-name: Submit iOS (App Store)
+name: Submit macOS (App Store)
 
 on:
   workflow_call:
@@ -17,8 +17,8 @@ on:
         default: false
 
 jobs:
-  submit-ios-app-store:
-    name: "Submit iOS (App Store ${{ inputs.track }})"
+  submit-macos-app-store:
+    name: "Submit macOS (App Store ${{ inputs.track }})"
     runs-on: macos-latest
     environment: store-submission
     steps:
@@ -27,8 +27,8 @@ jobs:
       - uses: ./.github/actions/setup_flutter
       - uses: ./.github/actions/setup_ruby
         with:
-          working-directory: ios
-      - name: Deploy to App Store
+          working-directory: macos
+      - name: Deploy to App Store (TestFlight)
         env:
           TRACK: ${{ inputs.track }}
           DRY_RUN: ${{ inputs.dry_run }}
@@ -39,8 +39,8 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
         run: |
-          cd ios
-          bundle exec fastlane ios deploy \
+          cd macos
+          bundle exec fastlane mac deploy \
             track:"$TRACK" build:true force_build:false \
             dry_run:"$DRY_RUN"
         shell: bash

--- a/.github/workflows/_submit-macos-app-store.yml
+++ b/.github/workflows/_submit-macos-app-store.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: ./.github/actions/setup_ruby
         with:
           working-directory: macos
-      - name: Deploy to App Store (TestFlight)
+      - name: Deploy to App Store
         env:
           TRACK: ${{ inputs.track }}
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -113,10 +113,8 @@ jobs:
     if: ${{ inputs.target == 'all' || inputs.target == 'ios' }}
     runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ^26
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup_xcode
       - uses: ./.github/actions/setup_flutter
       - id: build
         uses: ./.github/actions/build_ios_unsigned
@@ -135,10 +133,8 @@ jobs:
     if: ${{ inputs.target == 'all' || inputs.target == 'macos' }}
     runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ^26
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup_xcode
       - uses: ./.github/actions/setup_flutter
       - id: build
         uses: ./.github/actions/build_macos

--- a/.github/workflows/manual-submit.yml
+++ b/.github/workflows/manual-submit.yml
@@ -13,6 +13,11 @@ on:
         type: boolean
         required: true
         default: true
+      macos:
+        description: Submit macOS (App Store)
+        type: boolean
+        required: true
+        default: true
       track:
         description: >
           Submission track, applied to every platform checked above (no
@@ -44,7 +49,7 @@ jobs:
   # fastlane lanes branch on. Shared across iOS today, macOS later.
   resolve-apple-store-track:
     name: Map shared track vocabulary to Apple's native track
-    if: ${{ inputs.ios }}
+    if: ${{ inputs.ios || inputs.macos }}
     runs-on: ubuntu-latest
     outputs:
       track: ${{ steps.map.outputs.track }}
@@ -88,6 +93,15 @@ jobs:
     needs: resolve-apple-store-track
     if: ${{ inputs.ios }}
     uses: ./.github/workflows/_submit-ios-app-store.yml
+    with:
+      track: ${{ needs.resolve-apple-store-track.outputs.track }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
+  submit-macos-app-store:
+    needs: resolve-apple-store-track
+    if: ${{ inputs.macos }}
+    uses: ./.github/workflows/_submit-macos-app-store.yml
     with:
       track: ${{ needs.resolve-apple-store-track.outputs.track }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/manual-submit.yml
+++ b/.github/workflows/manual-submit.yml
@@ -46,7 +46,7 @@ on:
 jobs:
   # Apple (App Store Connect) has no native "alpha"/"production" track;
   # this maps the shared input vocabulary to the literal Apple's own
-  # fastlane lanes branch on. Shared across iOS today, macOS later.
+  # fastlane lanes branch on. Shared across iOS and macOS.
   resolve-apple-store-track:
     name: Map shared track vocabulary to Apple's native track
     if: ${{ inputs.ios || inputs.macos }}

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -132,10 +132,8 @@ jobs:
       - pre-build
     runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ^26
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup_xcode
       - uses: ./.github/actions/setup_flutter
       - id: build
         uses: ./.github/actions/build_ios_unsigned
@@ -159,16 +157,23 @@ jobs:
       dry_run: false
     secrets: inherit
 
+  submit-macos-app-store:
+    needs:
+      - pre-build
+    uses: ./.github/workflows/_submit-macos-app-store.yml
+    with:
+      track: internal
+      dry_run: false
+    secrets: inherit
+
   build-macos-dmg:
     name: "Build macOS DMG"
     needs:
       - pre-build
     runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ^26
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup_xcode
       - uses: ./.github/actions/setup_flutter
       - id: build
         uses: ./.github/actions/build_macos

--- a/fastlane/deploy_lane_helper.rb
+++ b/fastlane/deploy_lane_helper.rb
@@ -30,4 +30,14 @@ module DeployLaneHelper
     FastlaneCore::UI.message("locales: #{locales.join(', ')}") if locales && !locales.empty?
     FastlaneCore::UI.message("metadata_path: #{metadata_path}") if metadata_path
   end
+
+  # Unlike report_dry_run_skip, this does NOT skip the call: the public track still
+  # invokes upload_to_app_store with verify_only: true, which does a real (read-only)
+  # binary validation against App Store Connect without submitting for review.
+  def report_dry_run_verify_only(artifact:, track:)
+    FastlaneCore::UI.important(
+      "[dry_run] track: #{track} - calling upload_to_app_store with verify_only: true " \
+      "(validates #{artifact} against App Store Connect, does not submit for review)"
+    )
+  end
 end

--- a/fastlane/match_signing_helper.rb
+++ b/fastlane/match_signing_helper.rb
@@ -1,0 +1,17 @@
+module MatchSigningHelper
+  module_function
+
+  # match/sigh keep iOS profile env vars without a platform segment for
+  # backwards compatibility, but namespace every other platform (e.g. macOS)
+  # as `sigh_<app_identifier>_<type>_<platform>_<suffix>`.
+  def appstore_env(app_identifier, suffix, platform: "ios")
+    platform_segment = case platform.to_s
+                        when "ios" then nil
+                        when "tvos", "macos", "catalyst" then platform.to_s
+                        else
+                          FastlaneCore::UI.user_error!("Unsupported match platform: #{platform.inspect}")
+                        end
+    key = ["sigh", app_identifier, "appstore", platform_segment, suffix].compact.join("_")
+    ENV[key]
+  end
+end

--- a/fastlane/testflight_changelog_helper.rb
+++ b/fastlane/testflight_changelog_helper.rb
@@ -6,6 +6,19 @@ module TestflightChangelogHelper
 
   module_function
 
+  def android_metadata_dir(flavor)
+    flavor_dir = File.expand_path(
+      "../android/app/src/#{flavor}/fastlane/metadata/android",
+      __dir__
+    )
+    return flavor_dir if Dir.exist?(flavor_dir)
+
+    shared_dir = File.expand_path("metadata/android", __dir__)
+    return shared_dir if Dir.exist?(shared_dir)
+
+    FastlaneCore::UI.user_error!("No Android changelog metadata found for flavor #{flavor}")
+  end
+
   def read_flutter_build_number(pubspec_path)
     version_line = File.readlines(pubspec_path).find do |line|
       line.start_with?("version:")
@@ -16,6 +29,17 @@ module TestflightChangelogHelper
     FastlaneCore::UI.user_error!("Missing build number in #{pubspec_path}") if match.nil?
 
     match[1]
+  end
+
+  # Resolves the metadata/fallback dirs for a platform's fastlane lane and loads its changelog.
+  # lane_dir should be the calling Fastfile's `__dir__` (e.g. "ios/fastlane", "macos/fastlane").
+  def load_for_lane(lane_dir:, flavor:, pubspec_path:, build_number: nil)
+    load(
+      metadata_dir: android_metadata_dir(flavor),
+      fallback_metadata_dir: File.join(lane_dir, "metadata"),
+      pubspec_path: pubspec_path,
+      build_number: build_number
+    )
   end
 
   def load(metadata_dir:, pubspec_path:, fallback_metadata_dir: nil, build_number: nil)

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -14,26 +14,10 @@
 # update_fastlane
 
 require_relative "../../fastlane/deploy_lane_helper"
+require_relative "../../fastlane/match_signing_helper"
 require_relative "../../fastlane/testflight_changelog_helper"
 
 default_platform(:ios)
-
-def sigh_appstore_env(app_identifier, suffix)
-  ENV["sigh_#{app_identifier}_appstore_#{suffix}"]
-end
-
-def testflight_android_changelog_metadata_dir(flavor)
-  flavor_dir = File.expand_path(
-    "../../android/app/src/#{flavor}/fastlane/metadata/android",
-    __dir__
-  )
-  return flavor_dir if Dir.exist?(flavor_dir)
-
-  shared_dir = File.expand_path("../../fastlane/metadata/android", __dir__)
-  return shared_dir if Dir.exist?(shared_dir)
-
-  UI.user_error!("No Android changelog metadata found for flavor #{flavor}")
-end
 
 platform :ios do
   desc "Clean environment"
@@ -97,17 +81,23 @@ platform :ios do
     end
 
     if should_build
-      app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
-      match(type: "appstore")
-      update_code_signing_settings(
-        path: "Runner.xcodeproj",
-        use_automatic_signing: false,
-        code_sign_identity: "Apple Distribution",
-        team_id: sigh_appstore_env(app_identifier, "team-id"),
-        profile_name: sigh_appstore_env(app_identifier, "profile-name"),
-        targets: ["Runner"],
-        build_configurations: ["Release-#{flavor}"]
-      )
+      if is_ci
+        app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
+        match(type: "appstore")
+        update_code_signing_settings(
+          path: "Runner.xcodeproj",
+          use_automatic_signing: false,
+          code_sign_identity: "Apple Distribution",
+          team_id: MatchSigningHelper.appstore_env(app_identifier, "team-id"),
+          profile_name: MatchSigningHelper.appstore_env(app_identifier, "profile-name"),
+          targets: ["Runner"],
+          build_configurations: ["Release-#{flavor}"]
+        )
+      else
+        # Keep Xcode's "Automatic" signing in the project as-is, just fetch the
+        # existing cert/profile from the match storage into the local keychain.
+        match(type: "appstore", readonly: true)
+      end
       build(flavor: flavor)
       build_ios_app(
         workspace: "Runner.xcworkspace",
@@ -118,20 +108,16 @@ platform :ios do
     end
 
     if track == "public"
-      DeployLaneHelper.report_dry_run_skip(
-        action: "upload_to_app_store",
-        artifact: ipa_artifact,
-        track: track
-      ) if dry_run
+      DeployLaneHelper.report_dry_run_verify_only(artifact: ipa_artifact, track: track) if dry_run
 
       upload_to_app_store(
         ipa: ipa_artifact,
         verify_only: dry_run
       )
     else
-      changelog, localized_build_info = TestflightChangelogHelper.load(
-        metadata_dir: testflight_android_changelog_metadata_dir(flavor),
-        fallback_metadata_dir: File.join(__dir__, "metadata"),
+      changelog, localized_build_info = TestflightChangelogHelper.load_for_lane(
+        lane_dir: __dir__,
+        flavor: flavor,
         pubspec_path: File.expand_path("../../pubspec.yaml", __dir__),
         build_number: options[:changelog_build_number]&.to_s
       )

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -14,24 +14,12 @@
 # update_fastlane
 
 require_relative "../../fastlane/deploy_lane_helper"
+require_relative "../../fastlane/match_signing_helper"
 require_relative "../../fastlane/testflight_changelog_helper"
 
-default_platform(:ios)
+default_platform(:mac)
 
-def testflight_android_changelog_metadata_dir(flavor)
-  flavor_dir = File.expand_path(
-    "../../android/app/src/#{flavor}/fastlane/metadata/android",
-    __dir__
-  )
-  return flavor_dir if Dir.exist?(flavor_dir)
-
-  shared_dir = File.expand_path("../../fastlane/metadata/android", __dir__)
-  return shared_dir if Dir.exist?(shared_dir)
-
-  UI.user_error!("No Android changelog metadata found for flavor #{flavor}")
-end
-
-platform :ios do
+platform :mac do
   desc "Clean environment"
   lane :clean do
     sh <<~EOS
@@ -62,6 +50,10 @@ platform :ios do
 
   desc "Push a new release build to the App Store"
   lane :deploy do |options|
+    setup_ci
+
+    app_store_connect_api_key if ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"]
+
     flavor = options[:flavor] || "f_store"
     do_build = DeployLaneHelper.option_enabled?(options, :build, default: true)
     do_clean = DeployLaneHelper.option_enabled?(options, :clean, default: true)
@@ -90,30 +82,43 @@ platform :ios do
     end
 
     if should_build
+      if is_ci
+        app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
+        match(type: "appstore", additional_cert_types: ["mac_installer_distribution"])
+        update_code_signing_settings(
+          path: "Runner.xcodeproj",
+          use_automatic_signing: false,
+          code_sign_identity: "Apple Distribution",
+          team_id: MatchSigningHelper.appstore_env(app_identifier, "team-id", platform: "macos"),
+          profile_name: MatchSigningHelper.appstore_env(app_identifier, "profile-name", platform: "macos"),
+          targets: ["Runner"],
+          build_configurations: ["Release-#{flavor}"]
+        )
+      else
+        # Keep Xcode's "Automatic" signing in the project as-is, just fetch the
+        # existing cert/profile from the match storage into the local keychain.
+        match(type: "appstore", additional_cert_types: ["mac_installer_distribution"], readonly: true)
+      end
       build(flavor: flavor)
       build_mac_app(
         workspace: "Runner.xcworkspace",
         scheme: flavor,
+        export_method: "app-store",
         output_directory: pkg_path
       )
     end
 
     if track == "public"
-      if dry_run
-        DeployLaneHelper.report_dry_run_skip(
-          action: "upload_to_app_store",
-          artifact: pkg_artifact,
-          track: track
-        )
-        next
-      end
+      DeployLaneHelper.report_dry_run_verify_only(artifact: pkg_artifact, track: track) if dry_run
 
       upload_to_app_store(
-        pkg: pkg_artifact
+        pkg: pkg_artifact,
+        verify_only: dry_run
       )
     else
-      changelog, localized_build_info = TestflightChangelogHelper.load(
-        metadata_dir: testflight_android_changelog_metadata_dir(flavor),
+      changelog, localized_build_info = TestflightChangelogHelper.load_for_lane(
+        lane_dir: __dir__,
+        flavor: flavor,
         pubspec_path: File.expand_path("../../pubspec.yaml", __dir__),
         build_number: options[:changelog_build_number]&.to_s
       )

--- a/macos/fastlane/Matchfile
+++ b/macos/fastlane/Matchfile
@@ -1,0 +1,6 @@
+git_url("git@github.com:FriesI23/mhabit-apple-certificates.git")
+
+storage_mode("git")
+type("appstore")
+platform("macos")
+app_identifier(["io.github.friesi23.mhabit.store"])

--- a/macos/fastlane/README.md
+++ b/macos/fastlane/README.md
@@ -13,36 +13,36 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 # Available Actions
 
-## iOS
+## Mac
 
-### ios clean
+### mac clean
 
 ```sh
-[bundle exec] fastlane ios clean
+[bundle exec] fastlane mac clean
 ```
 
 Clean environment
 
-### ios test
+### mac test
 
 ```sh
-[bundle exec] fastlane ios test
+[bundle exec] fastlane mac test
 ```
 
 Run Flutter unit tests
 
-### ios build
+### mac build
 
 ```sh
-[bundle exec] fastlane ios build
+[bundle exec] fastlane mac build
 ```
 
 Build Flutter app for a specified flavor (default: f_generic)
 
-### ios deploy
+### mac deploy
 
 ```sh
-[bundle exec] fastlane ios deploy
+[bundle exec] fastlane mac deploy
 ```
 
 Push a new release build to the App Store


### PR DESCRIPTION
## Summary
- Extract shared `match_signing_helper.rb` and `testflight_changelog_helper.rb` used by both iOS and macOS Fastfiles
- Add macOS App Store fastlane lanes (`Fastfile`, `Matchfile`) using `match` for code signing, mirroring the existing iOS setup, with an `additional_cert_types: ["mac_installer_distribution"]` cert for pkg signing
- Add `setup_xcode` composite action, replacing inline `setup-xcode` steps across 7 call sites
- Add `_submit-macos-app-store.yml` reusable workflow and a dry-run workflow for manual verification
- Update `release-app.yml` / `manual-submit.yml` to support macOS submission, and switch the Android submit workflow to the shared `setup_ruby` action
- Keep local (non-CI) builds on Xcode's "Automatic" signing: when not running in CI, fetch the existing cert/profile via `match(..., readonly: true)` instead of calling `update_code_signing_settings` (which forces Manual signing) — CI continues to use `match` + `update_code_signing_settings` as before

## Type of Change
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] style
- [ ] test
- [ ] chore

## Related Issue
N/A

## Checklist
- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change