### PR TITLE
Synchronize Android animation scale with Flutter

### DIFF
--- a/android/app/src/main/kotlin/io/github/friesi23/mhabit/AnimationScaleStreamHandler.kt
+++ b/android/app/src/main/kotlin/io/github/friesi23/mhabit/AnimationScaleStreamHandler.kt
@@ -67,7 +67,7 @@ class AnimationScaleStreamHandler(
             Settings.Global.getFloat(
                 resolver, Settings.Global.ANIMATOR_DURATION_SCALE
             ).toDouble()
-        } catch (_: Settings.SettingNotFoundException) {
+        } catch (_: Exception) {
             1.0
         }
     }

--- a/android/app/src/main/kotlin/io/github/friesi23/mhabit/AnimationScaleStreamHandler.kt
+++ b/android/app/src/main/kotlin/io/github/friesi23/mhabit/AnimationScaleStreamHandler.kt
@@ -36,7 +36,7 @@ class AnimationScaleStreamHandler(
 
         val o = object : ContentObserver(Handler(Looper.getMainLooper())) {
             override fun onChange(selfChange: Boolean, changeUri: Uri?) {
-                if (changeUri != uri) return
+                if (changeUri != null && changeUri != uri) return
                 if (!closed) sink?.success(readScale())
             }
         }

--- a/android/app/src/main/kotlin/io/github/friesi23/mhabit/AnimationScaleStreamHandler.kt
+++ b/android/app/src/main/kotlin/io/github/friesi23/mhabit/AnimationScaleStreamHandler.kt
@@ -1,0 +1,74 @@
+package io.github.friesi23.mhabit
+
+import android.content.ContentResolver
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
+import io.flutter.plugin.common.EventChannel
+
+/**
+ * Listens to [Settings.Global.ANIMATOR_DURATION_SCALE] and streams
+ * changes through an [EventChannel] to the Flutter side.
+ *
+ * Call [dispose] when the hosting Activity is destroyed to ensure
+ * the ContentObserver is unregistered even if the Flutter engine
+ * cancels the stream late.
+ */
+class AnimationScaleStreamHandler(
+    private val resolver: ContentResolver
+) : EventChannel.StreamHandler {
+
+    private var observer: ContentObserver? = null
+    private var sink: EventChannel.EventSink? = null
+    private var closed = false
+
+    // -- StreamHandler -------------------------------------------------
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        cleanup()  // tear down any previous observer before re-registering
+        sink = events
+        closed = false
+
+        val uri = Settings.Global.getUriFor(Settings.Global.ANIMATOR_DURATION_SCALE)
+        events?.success(readScale())
+
+        val o = object : ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean, changeUri: Uri?) {
+                if (changeUri != uri) return
+                if (!closed) sink?.success(readScale())
+            }
+        }
+        observer = o
+        resolver.registerContentObserver(uri, false, o)
+    }
+
+    override fun onCancel(arguments: Any?) {
+        cleanup()
+    }
+
+    // -- Lifecycle -----------------------------------------------------
+
+    /** Safe to call multiple times — idempotent. */
+    fun dispose() = cleanup()
+
+    // -- Internal ------------------------------------------------------
+
+    private fun cleanup() {
+        closed = true
+        observer?.let { resolver.unregisterContentObserver(it) }
+        observer = null
+        sink = null
+    }
+
+    private fun readScale(): Double {
+        return try {
+            Settings.Global.getFloat(
+                resolver, Settings.Global.ANIMATOR_DURATION_SCALE
+            ).toDouble()
+        } catch (_: Settings.SettingNotFoundException) {
+            1.0
+        }
+    }
+}

--- a/android/app/src/main/kotlin/io/github/friesi23/mhabit/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/friesi23/mhabit/MainActivity.kt
@@ -1,6 +1,30 @@
 package io.github.friesi23.mhabit
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
 
-class MainActivity: FlutterActivity() {
+class MainActivity : FlutterActivity() {
+    companion object {
+        private const val ANIMATION_SCALE_CHANNEL = "global.app.animation/scale_stream"
+    }
+
+    private var animationScaleHandler: AnimationScaleStreamHandler? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        animationScaleHandler = AnimationScaleStreamHandler(contentResolver)
+
+        EventChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            ANIMATION_SCALE_CHANNEL
+        ).setStreamHandler(animationScaleHandler!!)
+    }
+
+    override fun onDestroy() {
+        animationScaleHandler?.dispose()
+        animationScaleHandler = null
+        super.onDestroy()
+    }
 }

--- a/android/app/src/main/kotlin/io/github/friesi23/mhabit/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/friesi23/mhabit/MainActivity.kt
@@ -14,12 +14,14 @@ class MainActivity : FlutterActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
-        animationScaleHandler = AnimationScaleStreamHandler(contentResolver)
+        animationScaleHandler?.dispose()
+        val handler = AnimationScaleStreamHandler(contentResolver)
+        animationScaleHandler = handler
 
         EventChannel(
             flutterEngine.dartExecutor.binaryMessenger,
             ANIMATION_SCALE_CHANNEL
-        ).setStreamHandler(animationScaleHandler!!)
+        ).setStreamHandler(handler)
     }
 
     override fun onDestroy() {

--- a/lib/entries/app/entry.dart
+++ b/lib/entries/app/entry.dart
@@ -36,6 +36,7 @@ import '../../pages/habits_display/page.dart' show HabitsDisplayPage;
 import '../../providers/app_ui/app_debugger.dart';
 import '../../providers/app_ui/app_language.dart';
 import '../../providers/app_ui/app_theme.dart';
+import '../../providers/support/animation_scale_sync.dart';
 import '../../providers/workflow/app_reminder.dart';
 import '../../providers/workflow/app_sync.dart';
 import '../../providers/workflow/habits_manager.dart';
@@ -219,9 +220,13 @@ class _AppEntry extends StatelessWidget {
               .select<AppThemeViewModel, (AppThemeType, AppThemeColor, Color)>(
                 (vm) => (vm.themeType, vm.themeColor, vm.mainColor),
               );
+          final disableAnimations = context.select<AnimationScaleSync, bool>(
+            (vm) => vm.disableAnimations,
+          );
           return AppRootView(
             themeMode: transToMaterialThemeType(themeMode),
             language: language,
+            disableAnimations: disableAnimations,
             lightThemeBuilder: () {
               final customColor = lightCustomColors;
               final mainColor = getThemeColor(

--- a/lib/entries/app/providers.dart
+++ b/lib/entries/app/providers.dart
@@ -29,6 +29,7 @@ import '../../providers/app_ui/app_theme.dart';
 import '../../providers/app_ui/custom_color_history.dart';
 import '../../providers/app_ui/habit_op_config.dart';
 import '../../providers/app_ui/habits_record_scroll_behavior.dart';
+import '../../providers/support/animation_scale_sync.dart';
 import '../../providers/support/global.dart';
 import '../../providers/workflow/app_event.dart';
 import '../../providers/workflow/app_notify_config.dart';
@@ -51,6 +52,10 @@ class AppProviders extends SingleChildStatelessWidget {
       create: (context) => NotificationChannelData(),
     ),
     ChangeNotifierProvider<AppEventBus>(create: (context) => AppEventBus()),
+    ChangeNotifierProvider<AnimationScaleSync>(
+      lazy: false,
+      create: (context) => AnimationScaleSync.create(),
+    ),
   ];
 
   Iterable<SingleChildWidget> _buildReminderWorkflowSupportProviders() => [

--- a/lib/entries/common/app_root_view.dart
+++ b/lib/entries/common/app_root_view.dart
@@ -25,6 +25,7 @@ class AppRootView extends StatelessWidget {
   final Widget? child;
   final ThemeData Function()? lightThemeBuilder;
   final ThemeData Function()? darkThemeBuilder;
+  final bool disableAnimations;
 
   const AppRootView({
     super.key,
@@ -33,6 +34,7 @@ class AppRootView extends StatelessWidget {
     this.lightThemeBuilder,
     this.darkThemeBuilder,
     this.child,
+    this.disableAnimations = false,
   });
 
   const AppRootView.withDefault({
@@ -42,6 +44,7 @@ class AppRootView extends StatelessWidget {
     this.lightThemeBuilder,
     this.darkThemeBuilder,
     this.child,
+    this.disableAnimations = false,
   });
 
   @override
@@ -57,7 +60,13 @@ class AppRootView extends StatelessWidget {
       locale: language,
       shortcuts: WidgetsApp.defaultShortcuts,
       actions: WidgetsApp.defaultActions,
-      builder: (context, child) => UnfocusOnTap(child: child),
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          disableAnimations:
+              disableAnimations || MediaQuery.disableAnimationsOf(context),
+        ),
+        child: UnfocusOnTap(child: child),
+      ),
       home: child,
       localizationsDelegates: appLocalizationsDelegates,
       supportedLocales: appSupportedLocales,

--- a/lib/providers/support/_animation_scale_sync/android_animation_scale_sync.dart
+++ b/lib/providers/support/_animation_scale_sync/android_animation_scale_sync.dart
@@ -1,0 +1,114 @@
+// Copyright 2025 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:flutter/scheduler.dart' show SchedulerBinding, timeDilation;
+import 'package:flutter/services.dart' show EventChannel;
+
+import '../../../logging/helper.dart';
+import '../animation_scale_sync.dart';
+
+const _channelName = 'global.app.animation/scale_stream';
+
+class AndroidAnimationScaleSync extends AnimationScaleSync {
+  StreamSubscription<dynamic>? _subscription;
+
+  /// Raw Android animation scale (may be 0 when animations are disabled).
+  double _scale = 1.0;
+
+  /// The last [timeDilation] value we wrote, or null when we are not
+  /// controlling timeDilation (scale=0 or not yet written).
+  double? _lastWrittenDilation;
+  bool _isOverridden = false;
+  bool _disposed = false;
+
+  AndroidAnimationScaleSync() {
+    const channel = EventChannel(_channelName);
+    _subscription = channel.receiveBroadcastStream().listen(
+      _onScaleChanged,
+      onError: (Object error) {
+        appLog.debugger.error(
+          '$runtimeType.receiveBroadcastStream',
+          ex: [error],
+        );
+      },
+    );
+    // Persistent callback is the idiomatic Flutter pattern for per-frame
+    // monitoring.  The _disposed guard is sufficient because this object
+    // is a single app-lifetime instance.
+    SchedulerBinding.instance.addPersistentFrameCallback(_onFrame);
+  }
+
+  @override
+  double get scale => _scale;
+
+  @override
+  bool get disableAnimations => _scale <= 0.0;
+
+  @override
+  bool get isOverridden => _isOverridden;
+
+  void _onScaleChanged(dynamic value) {
+    if (value is! num) return;
+    final prevScale = _scale;
+    _scale = value.toDouble();
+    appLog.debugger.debug(
+      'AndroidAnimationScaleSync._onScaleChanged',
+      ex: [_scale],
+    );
+    if (_scale <= 0.0) {
+      // Animations off — yield timeDilation, use disableAnimations.
+      _lastWrittenDilation = null;
+      _isOverridden = false;
+    } else {
+      if (prevScale <= 0.0 && _scale > 0.0) {
+        // Transitioning from off → on: check for active debug override.
+        _isOverridden = timeDilation != 1.0;
+      }
+      if (!_isOverridden) {
+        _lastWrittenDilation = _scale;
+        timeDilation = _scale;
+      }
+    }
+    notifyListeners();
+  }
+
+  void _onFrame(Duration _) {
+    if (_disposed) return;
+    final lastWritten = _lastWrittenDilation;
+    if (lastWritten == null) return;
+
+    if (timeDilation == 1.0) {
+      if (_isOverridden) {
+        _isOverridden = false;
+        _lastWrittenDilation = _scale;
+        timeDilation = _scale;
+        notifyListeners();
+      }
+    } else if (timeDilation != lastWritten) {
+      if (!_isOverridden) {
+        _isOverridden = true;
+        notifyListeners();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _subscription?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/providers/support/_animation_scale_sync/android_animation_scale_sync.dart
+++ b/lib/providers/support/_animation_scale_sync/android_animation_scale_sync.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/scheduler.dart' show SchedulerBinding, timeDilation;
 import 'package:flutter/services.dart' show EventChannel;
 
@@ -70,6 +71,9 @@ class AndroidAnimationScaleSync extends AnimationScaleSync {
     );
     if (_scale <= 0.0) {
       // Animations off — yield timeDilation, use disableAnimations.
+      if (_lastWrittenDilation != null && !_isOverridden) {
+        timeDilation = 1.0;
+      }
       _lastWrittenDilation = null;
       _isOverridden = false;
     } else {
@@ -107,8 +111,17 @@ class AndroidAnimationScaleSync extends AnimationScaleSync {
 
   @override
   void dispose() {
+    if (_disposed) return;
     _disposed = true;
     _subscription?.cancel();
     super.dispose();
   }
+
+  // -- Test hooks -------------------------------------------------------
+
+  @visibleForTesting
+  void testReceiveScale(double value) => _onScaleChanged(value);
+
+  @visibleForTesting
+  void testTickFrame() => _onFrame(Duration.zero);
 }

--- a/lib/providers/support/_animation_scale_sync/stub_animation_scale_sync.dart
+++ b/lib/providers/support/_animation_scale_sync/stub_animation_scale_sync.dart
@@ -1,0 +1,21 @@
+// Copyright 2025 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '../animation_scale_sync.dart';
+
+/// No-op implementation for non-Android platforms.
+class StubAnimationScaleSync extends AnimationScaleSync {
+  @override
+  double get scale => 1.0;
+}

--- a/lib/providers/support/animation_scale_sync.dart
+++ b/lib/providers/support/animation_scale_sync.dart
@@ -1,0 +1,55 @@
+// Copyright 2025 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/foundation.dart';
+
+import '_animation_scale_sync/android_animation_scale_sync.dart';
+import '_animation_scale_sync/stub_animation_scale_sync.dart';
+
+/// Bridge that syncs the Android system animation scale to Flutter's
+/// [timeDilation].
+///
+/// When the Android scale is 0 (animations disabled) [disableAnimations]
+/// is set to true instead of writing to [timeDilation], which Flutter
+/// requires to be > 0.
+///
+/// Flutter debug tools take priority: when they modify [timeDilation]
+/// the Android scale is tracked but not applied until the override is
+/// released.
+abstract class AnimationScaleSync extends ChangeNotifier {
+  /// Generative constructor for subclass use.
+  AnimationScaleSync();
+
+  /// The Android-reported animation scale (1.0 = normal speed).
+  double get scale;
+
+  /// Whether the Android system has animations disabled (scale = 0).
+  ///
+  /// Consumer should apply this to [MediaQueryData.disableAnimations]
+  /// so Flutter widgets skip animations entirely.
+  bool get disableAnimations => false;
+
+  /// Whether an external source (e.g. Flutter debug tools) currently
+  /// controls [timeDilation] instead of this bridge.
+  bool get isOverridden => false;
+
+  /// Creates the platform-appropriate implementation.
+  ///
+  /// On Android returns [AndroidAnimationScaleSync]; on all other platforms
+  /// returns [StubAnimationScaleSync].
+  factory AnimationScaleSync.create() => switch (defaultTargetPlatform) {
+    TargetPlatform.android => AndroidAnimationScaleSync(),
+    _ => StubAnimationScaleSync(),
+  };
+}

--- a/test/unit/providers/support/animation_scale_sync_test.dart
+++ b/test/unit/providers/support/animation_scale_sync_test.dart
@@ -1,0 +1,224 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/scheduler.dart' show timeDilation;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mhabit/providers/support/_animation_scale_sync/android_animation_scale_sync.dart';
+import 'package:mhabit/providers/support/_animation_scale_sync/stub_animation_scale_sync.dart';
+import 'package:mhabit/providers/support/animation_scale_sync.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('StubAnimationScaleSync', () {
+    test('returns default values', () {
+      final sync = StubAnimationScaleSync();
+      expect(sync.scale, 1.0);
+      expect(sync.disableAnimations, isFalse);
+      expect(sync.isOverridden, isFalse);
+    });
+  });
+
+  group('AnimationScaleSync.create', () {
+    test('returns a valid AnimationScaleSync', () {
+      final sync = AnimationScaleSync.create();
+      expect(sync, isA<AnimationScaleSync>());
+      expect(sync.scale, 1.0);
+      expect(sync.disableAnimations, isFalse);
+      expect(sync.isOverridden, isFalse);
+    });
+  });
+
+  group('AndroidAnimationScaleSync', () {
+    late AndroidAnimationScaleSync sync;
+    late double savedTimeDilation;
+
+    setUp(() {
+      savedTimeDilation = timeDilation;
+      timeDilation = 1.0;
+      sync = AndroidAnimationScaleSync();
+    });
+
+    tearDown(() {
+      sync.dispose();
+      timeDilation = savedTimeDilation;
+    });
+
+    // -- Initial state ------------------------------------------------
+
+    test('initial state is default', () {
+      expect(sync.scale, 1.0);
+      expect(sync.disableAnimations, isFalse);
+      expect(sync.isOverridden, isFalse);
+    });
+
+    // -- Normal scale changes -----------------------------------------
+
+    test('applies normal scale to timeDilation', () {
+      sync.testReceiveScale(2.0);
+
+      expect(sync.scale, 2.0);
+      expect(timeDilation, 2.0);
+      expect(sync.disableAnimations, isFalse);
+      expect(sync.isOverridden, isFalse);
+    });
+
+    test('applies fractional scale to timeDilation', () {
+      sync.testReceiveScale(0.5);
+
+      expect(sync.scale, 0.5);
+      expect(timeDilation, 0.5);
+      expect(sync.disableAnimations, isFalse);
+    });
+
+    // -- Scale = 0 (disable animations) -------------------------------
+
+    test('scale=0 sets disableAnimations but does not write timeDilation', () {
+      sync.testReceiveScale(0.0);
+
+      expect(sync.scale, 0.0);
+      expect(sync.disableAnimations, isTrue);
+      // Must stay 1.0 — Flutter requires timeDilation > 0
+      expect(timeDilation, 1.0);
+    });
+
+    test(
+      'resets timeDilation to 1.0 when scale drops to 0 after bridge-set',
+      () {
+        sync.testReceiveScale(2.0);
+        expect(timeDilation, 2.0);
+
+        sync.testReceiveScale(0.0);
+        expect(timeDilation, 1.0);
+        expect(sync.disableAnimations, isTrue);
+      },
+    );
+
+    // -- Disable → re-enable transitions ------------------------------
+
+    test('transition 2.0 → 0 → 1.5 applies new scale correctly', () {
+      sync.testReceiveScale(2.0);
+      expect(timeDilation, 2.0);
+
+      sync.testReceiveScale(0.0);
+      expect(timeDilation, 1.0);
+      expect(sync.disableAnimations, isTrue);
+
+      sync.testReceiveScale(1.5);
+      expect(timeDilation, 1.5);
+      expect(sync.disableAnimations, isFalse);
+      expect(sync.isOverridden, isFalse);
+    });
+
+    test('transition 0 → scale re-enables animations', () {
+      sync.testReceiveScale(0.0);
+      expect(sync.disableAnimations, isTrue);
+
+      sync.testReceiveScale(1.0);
+      expect(sync.disableAnimations, isFalse);
+      expect(sync.scale, 1.0);
+    });
+
+    // -- External override detection ----------------------------------
+
+    test('detects external override via frame callback', () {
+      sync.testReceiveScale(2.0);
+      expect(timeDilation, 2.0);
+
+      timeDilation = 3.0; // external tool changes it
+      sync.testTickFrame();
+      expect(sync.isOverridden, isTrue);
+    });
+
+    test('releases override when timeDilation returns to 1.0', () {
+      sync.testReceiveScale(2.0);
+      timeDilation = 3.0;
+      sync.testTickFrame();
+      expect(sync.isOverridden, isTrue);
+
+      timeDilation = 1.0;
+      sync.testTickFrame();
+      expect(sync.isOverridden, isFalse);
+      expect(timeDilation, 2.0); // bridge reapplies scale
+    });
+
+    test('override prevents new scale from being applied', () {
+      sync.testReceiveScale(2.0);
+      timeDilation = 3.0;
+      sync.testTickFrame();
+      expect(sync.isOverridden, isTrue);
+
+      sync.testReceiveScale(1.5);
+      expect(timeDilation, 3.0); // still overridden
+      expect(sync.scale, 1.5); // but scale is tracked
+    });
+
+    test('does not stomp external override when scale goes to 0', () {
+      sync.testReceiveScale(2.0);
+      timeDilation = 3.0;
+      sync.testTickFrame();
+      expect(sync.isOverridden, isTrue);
+
+      sync.testReceiveScale(0.0);
+      // External override preserved — we only reset when we had control
+      expect(timeDilation, 3.0);
+      expect(sync.disableAnimations, isTrue);
+      // After disable, override flag is cleared
+    });
+
+    // -- Listener notifications ---------------------------------------
+
+    test('notifies listeners on scale change', () {
+      var notified = false;
+      sync.addListener(() => notified = true);
+
+      sync.testReceiveScale(2.0);
+      expect(notified, isTrue);
+    });
+
+    test('notifies listeners on override detected', () {
+      sync.testReceiveScale(2.0);
+      var notified = false;
+      sync.addListener(() => notified = true);
+
+      timeDilation = 3.0;
+      sync.testTickFrame();
+      expect(notified, isTrue);
+    });
+
+    test('notifies listeners on override released', () {
+      sync.testReceiveScale(2.0);
+      timeDilation = 3.0;
+      sync.testTickFrame();
+
+      var notified = false;
+      sync.addListener(() => notified = true);
+
+      timeDilation = 1.0;
+      sync.testTickFrame();
+      expect(notified, isTrue);
+    });
+
+    // -- Dispose -----------------------------------------------------
+
+    test('dispose stops frame callback from detecting overrides', () {
+      sync.testReceiveScale(2.0);
+      sync.dispose();
+
+      timeDilation = 3.0;
+      sync.testTickFrame();
+      expect(sync.isOverridden, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
<!-- What does this PR change, and why -->

Sync Android animation scale setting to Flutter's timeDilation and expose disableAnimations flag.

## Type of Change
- [x] feat

## Related Issue
<!-- e.g. Fixes #123, Closes #123, Related to #123 -->

## Checklist
- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change

---

closed: #180