### PR TITLE
feat: implement adaptive content sheets and enhance dialog localization

### DIFF
--- a/lib/pages/app_about/_widgets/app_about_license_thirdparty_tile.dart
+++ b/lib/pages/app_about/_widgets/app_about_license_thirdparty_tile.dart
@@ -35,27 +35,21 @@ class _AppAboutThirdPartyLicenseTileState
   void onPressed() async {
     final licenseText = await rootBundle.loadString('LICENSE_THIRDPARTY.md');
     if (!mounted) return;
-    await showDialog(
+    final l10n = L10n.of(context);
+    await showAdaptiveContentSheet(
       context: context,
-      builder: (context) => L10nBuilder(
-        builder: (context, l10n) => AlertDialog(
-          content: Scrollbar(
-            child: SingleChildScrollView(
-              primary: true,
-              child: ThematicMarkdownBlock(
-                data: licenseText,
-                configBuilder: (config) => config.copy(
-                  configs: [
-                    LinkConfig(
-                      onTap: (href) => launchExternalUrl(Uri.parse(href)),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
+      title: l10n != null
+          ? Text(l10n.appAbout_licenseThirdPartyTile_titleText)
+          : const Text("Third Party License"),
+      contentBuilder: (_) => ThematicMarkdownBlock(
+        data: licenseText,
+        configBuilder: (config) => config.copy(
+          configs: [
+            LinkConfig(onTap: (href) => launchExternalUrl(Uri.parse(href))),
+          ],
         ),
       ),
+      sheetShowCloseButton: false,
     );
   }
 

--- a/lib/pages/app_about/_widgets/app_about_license_tile.dart
+++ b/lib/pages/app_about/_widgets/app_about_license_tile.dart
@@ -30,19 +30,15 @@ class _AppAboutLicenseTileState extends State<AppAboutLicenseTile> {
   void onPressed() async {
     final licenseText = await rootBundle.loadString('LICENSE');
     if (!mounted) return;
-    await showDialog(
+    final l10n = L10n.of(context);
+    await showAdaptiveContentSheet(
       context: context,
-      builder: (context) => L10nBuilder(
-        builder: (context, l10n) => AlertDialog(
-          content: Scrollbar(
-            child: SingleChildScrollView(
-              primary: true,
-              scrollDirection: Axis.vertical,
-              child: ThematicMarkdownBlock(data: "```text\n$licenseText\n```"),
-            ),
-          ),
-        ),
-      ),
+      title: l10n != null
+          ? Text(l10n.appAbout_licenseTile_titleText)
+          : const Text("License"),
+      contentBuilder: (_) =>
+          ThematicMarkdownBlock(data: "```text\n$licenseText\n```"),
+      sheetShowCloseButton: false,
     );
   }
 

--- a/lib/pages/app_about/_widgets/app_about_privay_tile.dart
+++ b/lib/pages/app_about/_widgets/app_about_privay_tile.dart
@@ -57,28 +57,23 @@ class _AppAboutPrivacyTile extends State<AppAboutPrivacyTile> {
   void _onPressed() async {
     final text = await rootBundle.loadString(widget.privacyPath);
     if (!mounted) return;
-    await showDialog(
+    final l10n = L10n.of(context);
+    await showAdaptiveContentSheet(
       context: context,
-      builder: (context) => AlertDialog(
-        content: Scrollbar(
-          child: SingleChildScrollView(
-            primary: true,
-            scrollDirection: Axis.vertical,
-            child: ThematicMarkdownBlock(
-              data: text,
-              configBuilder: (config) =>
-                  config.copy(configs: [_buildTableConfig()]),
-            ),
-          ),
-        ),
+      title: l10n != null
+          ? Text(l10n.appAbout_privacyTile_titleText)
+          : const Text("Privacy"),
+      contentBuilder: (_) => ThematicMarkdownBlock(
+        data: text,
+        configBuilder: (config) => config.copy(configs: [_buildTableConfig()]),
       ),
+      sheetShowCloseButton: false,
     );
   }
 
   @override
   Widget build(BuildContext context) {
     final l10n = L10n.of(context);
-
     return ListTile(
       leading: const SizedBox(
         height: kAppAboutListTileLeadingHeight,
@@ -90,7 +85,7 @@ class _AppAboutPrivacyTile extends State<AppAboutPrivacyTile> {
           : const Text("Privacy"),
       subtitle: l10n != null
           ? Text(l10n.appAbout_privacyTile_subTitleText)
-          : null,
+          : const Text("Unknown"),
       onTap: _onPressed,
     );
   }

--- a/lib/pages/app_changelog/changelog_dialog.dart
+++ b/lib/pages/app_changelog/changelog_dialog.dart
@@ -12,214 +12,61 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 
-import '../../common/consts.dart';
 import '../../l10n/localizations.dart';
-import '../../widgets/_widgets/markdown_block.dart';
+import '../../widgets/widgets.dart';
 import 'changelog_parser.dart';
 
 /// Shows an adaptive changelog view.
 ///
-/// On desktop platforms (macOS, Windows, Linux) always renders an
-/// [AlertDialog] via [showDialog].
-/// On mobile platforms (Android, iOS) renders a [showModalBottomSheet]
-/// on phones, and an [AlertDialog] on tablets (width >= 600).
-///
-/// [context] is used for navigation and localisation lookups.
-///
-/// [currentVersionSection] is the body markdown for the current app version,
-/// extracted by `extractVersionSection()` (Slice 2). This is shown by default.
-///
-/// [fullChangelog] is the entire CHANGELOG.md content. Displayed when the
-/// user taps "View Full Changelog".
-///
-/// [version] is the `"<semver>+<buildNumber>"` version string for display
-/// in the title.
+/// Delegates to [showAdaptiveContentSheet] for the adaptive presentation
+/// (bottom sheet on phones, dialog on tablets/desktop).
 Future<void> showChangelogDialog({
   required BuildContext context,
   required String currentVersionSection,
   required String fullChangelog,
   required String version,
 }) {
-  final useDialog = switch (defaultTargetPlatform) {
-    TargetPlatform.android || TargetPlatform.iOS || TargetPlatform.fuchsia =>
-      MediaQuery.sizeOf(context).width >= kHabitLargeScreenAdaptWidth,
-    _ => true,
-  };
+  final showFullNotifier = ValueNotifier<bool>(false);
 
-  if (!useDialog) {
-    return showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      showDragHandle: true,
-      builder: (_) => _ChangelogBottomSheet(
-        currentVersionSection: currentVersionSection,
-        fullChangelog: fullChangelog,
-        version: version,
-      ),
-    );
-  }
-  return showDialog<void>(
+  return showAdaptiveContentSheet(
     context: context,
-    builder: (_) => _ChangelogDialog(
-      currentVersionSection: currentVersionSection,
-      fullChangelog: fullChangelog,
-      version: version,
+    title: _ChangelogTitle(version: version),
+    sheetActionsAlign: Alignment.centerRight,
+    contentBuilder: (_) => ValueListenableBuilder<bool>(
+      valueListenable: showFullNotifier,
+      builder: (_, showFull, _) => showFull
+          ? _buildFullList(fullChangelog)
+          : _buildCurrentVersion(currentVersionSection),
     ),
+    actions: [
+      ValueListenableBuilder<bool>(
+        valueListenable: showFullNotifier,
+        builder: (context, showFull, _) {
+          if (showFull) return const SizedBox.shrink();
+          final l10n = L10n.of(context);
+          return FilledButton(
+            onPressed: () => showFullNotifier.value = true,
+            child: Text(l10n?.changelog_view_full ?? 'View Full Changelog'),
+          );
+        },
+      ),
+    ],
   );
 }
 
-class _ChangelogBottomSheet extends StatefulWidget {
-  final String currentVersionSection;
-  final String fullChangelog;
-  final String version;
-
-  const _ChangelogBottomSheet({
-    required this.currentVersionSection,
-    required this.fullChangelog,
-    required this.version,
-  });
-
-  @override
-  State<_ChangelogBottomSheet> createState() => _ChangelogBottomSheetState();
+Widget _buildCurrentVersion(String data) {
+  return ThematicMarkdownBlock(data: data, selectable: false);
 }
 
-class _ChangelogBottomSheetState extends State<_ChangelogBottomSheet> {
-  var _showFull = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = L10n.of(context)!;
-
-    return DraggableScrollableSheet(
-      expand: false,
-      initialChildSize: 0.6,
-      minChildSize: 0.25,
-      maxChildSize: 0.95,
-      builder: (context, scrollController) {
-        if (_showFull) return _buildFullList(scrollController, l10n);
-        return _buildCurrentVersion(scrollController, l10n);
-      },
-    );
-  }
-
-  Widget _buildFullList(ScrollController scrollController, L10n l10n) {
-    final sections = parseChangelogSections(widget.fullChangelog);
-    return ListView.builder(
-      controller: scrollController,
-      padding: const EdgeInsets.symmetric(horizontal: 20),
-      itemCount: sections.length + 1, // +1 for title header
-      itemBuilder: (context, index) {
-        if (index == 0) {
-          return Padding(
-            padding: const EdgeInsets.only(bottom: 12),
-            child: _ChangelogTitle(version: widget.version),
-          );
-        }
-        return _ChangelogSectionTile(section: sections[index - 1]);
-      },
-    );
-  }
-
-  Widget _buildCurrentVersion(ScrollController scrollController, L10n l10n) {
-    return Column(
-      children: [
-        Expanded(
-          child: SingleChildScrollView(
-            controller: scrollController,
-            physics: const AlwaysScrollableScrollPhysics(),
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _ChangelogTitle(version: widget.version),
-                const SizedBox(height: 12),
-                ThematicMarkdownBlock(
-                  data: widget.currentVersionSection,
-                  selectable: false,
-                ),
-              ],
-            ),
-          ),
-        ),
-        SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Row(
-              children: [
-                const Spacer(),
-                FilledButton(
-                  onPressed: () => setState(() => _showFull = true),
-                  child: Text(l10n.changelog_view_full),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _ChangelogDialog extends StatefulWidget {
-  final String currentVersionSection;
-  final String fullChangelog;
-  final String version;
-
-  const _ChangelogDialog({
-    required this.currentVersionSection,
-    required this.fullChangelog,
-    required this.version,
-  });
-
-  @override
-  State<_ChangelogDialog> createState() => _ChangelogDialogState();
-}
-
-class _ChangelogDialogState extends State<_ChangelogDialog> {
-  var _showFull = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = L10n.of(context)!;
-
-    return AlertDialog(
-      title: _ChangelogTitle(version: widget.version),
-      content: SizedBox(
-        width: 500,
-        child: _showFull
-            ? _buildFullList()
-            : _ChangelogContent(data: widget.currentVersionSection),
-      ),
-      actions: [
-        if (!_showFull)
-          FilledButton(
-            onPressed: () => setState(() => _showFull = true),
-            child: Text(l10n.changelog_view_full),
-          ),
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(MaterialLocalizations.of(context).closeButtonLabel),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildFullList() {
-    final sections = parseChangelogSections(widget.fullChangelog);
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: 400),
-      child: ListView.builder(
-        itemCount: sections.length,
-        itemBuilder: (context, index) =>
-            _ChangelogSectionTile(section: sections[index]),
-      ),
-    );
-  }
+Widget _buildFullList(String fullChangelog) {
+  final sections = parseChangelogSections(fullChangelog);
+  return Column(
+    mainAxisSize: MainAxisSize.min,
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: sections.map((s) => _ChangelogSectionTile(section: s)).toList(),
+  );
 }
 
 class _ChangelogTitle extends StatelessWidget {
@@ -229,14 +76,14 @@ class _ChangelogTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = L10n.of(context)!;
+    final l10n = L10n.of(context);
     final theme = Theme.of(context);
     final color = theme.colorScheme.onSurfaceVariant;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text(l10n.changelog_dialog_title),
+        Text(l10n?.changelog_dialog_title ?? 'Changelog'),
         Row(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -249,24 +96,6 @@ class _ChangelogTitle extends StatelessWidget {
           ],
         ),
       ],
-    );
-  }
-}
-
-class _ChangelogContent extends StatelessWidget {
-  final String data;
-
-  const _ChangelogContent({required this.data});
-
-  @override
-  Widget build(BuildContext context) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: 400),
-      child: Scrollbar(
-        child: SingleChildScrollView(
-          child: ThematicMarkdownBlock(data: data, selectable: false),
-        ),
-      ),
     );
   }
 }

--- a/lib/pages/app_changelog/changelog_dialog.dart
+++ b/lib/pages/app_changelog/changelog_dialog.dart
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import '../../common/consts.dart';
 import '../../l10n/localizations.dart';
 import '../../widgets/_widgets/markdown_block.dart';
+import 'changelog_parser.dart';
 
 /// Shows an adaptive changelog view.
 ///
@@ -71,10 +72,6 @@ Future<void> showChangelogDialog({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Bottom sheet (small screens) — Material drag handle + unified scroll
-// ---------------------------------------------------------------------------
-
 class _ChangelogBottomSheet extends StatefulWidget {
   final String currentVersionSection;
   final String fullChangelog;
@@ -96,10 +93,6 @@ class _ChangelogBottomSheetState extends State<_ChangelogBottomSheet> {
   @override
   Widget build(BuildContext context) {
     final l10n = L10n.of(context)!;
-    final title = _ChangelogTitle(version: widget.version);
-    final markdownData = _showFull
-        ? widget.fullChangelog
-        : widget.currentVersionSection;
 
     return DraggableScrollableSheet(
       expand: false,
@@ -107,57 +100,70 @@ class _ChangelogBottomSheetState extends State<_ChangelogBottomSheet> {
       minChildSize: 0.25,
       maxChildSize: 0.95,
       builder: (context, scrollController) {
-        return Column(
-          children: [
-            // Title + scrollable markdown — unified scroll via DraggableScrollableSheet
-            Expanded(
-              child: SingleChildScrollView(
-                controller: scrollController,
-                physics: const AlwaysScrollableScrollPhysics(),
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    title,
-                    const SizedBox(height: 12),
-                    ThematicMarkdownBlock(
-                      data: markdownData,
-                      selectable: false,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            // Pinned bottom bar
-            SafeArea(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 8,
-                ),
-                child: Row(
-                  children: [
-                    const Spacer(),
-                    if (!_showFull)
-                      FilledButton(
-                        onPressed: () => setState(() => _showFull = true),
-                        child: Text(l10n.changelog_view_full),
-                      ),
-                  ],
-                ),
-              ),
-            ),
-          ],
-        );
+        if (_showFull) return _buildFullList(scrollController, l10n);
+        return _buildCurrentVersion(scrollController, l10n);
       },
     );
   }
-}
 
-// ---------------------------------------------------------------------------
-// AlertDialog (large screens)
-// ---------------------------------------------------------------------------
+  Widget _buildFullList(ScrollController scrollController, L10n l10n) {
+    final sections = parseChangelogSections(widget.fullChangelog);
+    return ListView.builder(
+      controller: scrollController,
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      itemCount: sections.length + 1, // +1 for title header
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: _ChangelogTitle(version: widget.version),
+          );
+        }
+        return _ChangelogSectionTile(section: sections[index - 1]);
+      },
+    );
+  }
+
+  Widget _buildCurrentVersion(ScrollController scrollController, L10n l10n) {
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            controller: scrollController,
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _ChangelogTitle(version: widget.version),
+                const SizedBox(height: 12),
+                ThematicMarkdownBlock(
+                  data: widget.currentVersionSection,
+                  selectable: false,
+                ),
+              ],
+            ),
+          ),
+        ),
+        SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                const Spacer(),
+                FilledButton(
+                  onPressed: () => setState(() => _showFull = true),
+                  child: Text(l10n.changelog_view_full),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
 
 class _ChangelogDialog extends StatefulWidget {
   final String currentVersionSection;
@@ -180,22 +186,21 @@ class _ChangelogDialogState extends State<_ChangelogDialog> {
   @override
   Widget build(BuildContext context) {
     final l10n = L10n.of(context)!;
-    final title = _ChangelogTitle(version: widget.version);
-    final content = _ChangelogContent(
-      data: _showFull ? widget.fullChangelog : widget.currentVersionSection,
-    );
-    final viewFullButton = !_showFull
-        ? FilledButton(
-            onPressed: () => setState(() => _showFull = true),
-            child: Text(l10n.changelog_view_full),
-          )
-        : null;
 
     return AlertDialog(
-      title: title,
-      content: SizedBox(width: 500, child: content),
+      title: _ChangelogTitle(version: widget.version),
+      content: SizedBox(
+        width: 500,
+        child: _showFull
+            ? _buildFullList()
+            : _ChangelogContent(data: widget.currentVersionSection),
+      ),
       actions: [
-        ?viewFullButton,
+        if (!_showFull)
+          FilledButton(
+            onPressed: () => setState(() => _showFull = true),
+            child: Text(l10n.changelog_view_full),
+          ),
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
           child: Text(MaterialLocalizations.of(context).closeButtonLabel),
@@ -203,11 +208,19 @@ class _ChangelogDialogState extends State<_ChangelogDialog> {
       ],
     );
   }
-}
 
-// ---------------------------------------------------------------------------
-// Dialog title: "Changelog" heading + version row with icon
-// ---------------------------------------------------------------------------
+  Widget _buildFullList() {
+    final sections = parseChangelogSections(widget.fullChangelog);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 400),
+      child: ListView.builder(
+        itemCount: sections.length,
+        itemBuilder: (context, index) =>
+            _ChangelogSectionTile(section: sections[index]),
+      ),
+    );
+  }
+}
 
 class _ChangelogTitle extends StatelessWidget {
   final String version;
@@ -240,10 +253,6 @@ class _ChangelogTitle extends StatelessWidget {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Shared markdown content
-// ---------------------------------------------------------------------------
-
 class _ChangelogContent extends StatelessWidget {
   final String data;
 
@@ -257,6 +266,39 @@ class _ChangelogContent extends StatelessWidget {
         child: SingleChildScrollView(
           child: ThematicMarkdownBlock(data: data, selectable: false),
         ),
+      ),
+    );
+  }
+}
+
+class _ChangelogSectionTile extends StatelessWidget {
+  final ChangelogSection section;
+
+  const _ChangelogSectionTile({required this.section});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = theme.colorScheme.onSurfaceVariant;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.info_outline, size: 14, color: color),
+              const SizedBox(width: 6),
+              Text(
+                'v${section.version}',
+                style: theme.textTheme.titleSmall?.copyWith(color: color),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ThematicMarkdownBlock(data: section.body, selectable: false),
+        ],
       ),
     );
   }

--- a/lib/pages/app_changelog/changelog_dialog.dart
+++ b/lib/pages/app_changelog/changelog_dialog.dart
@@ -29,6 +29,7 @@ Future<void> showChangelogDialog({
   required String version,
 }) {
   final showFullNotifier = ValueNotifier<bool>(false);
+  List<ChangelogSection>? fullSections;
 
   return showAdaptiveContentSheet(
     context: context,
@@ -37,7 +38,9 @@ Future<void> showChangelogDialog({
     contentBuilder: (_) => ValueListenableBuilder<bool>(
       valueListenable: showFullNotifier,
       builder: (_, showFull, _) => showFull
-          ? _buildFullList(fullChangelog)
+          ? _buildFullList(
+              fullSections ??= parseChangelogSections(fullChangelog),
+            )
           : _buildCurrentVersion(currentVersionSection),
     ),
     actions: [
@@ -60,8 +63,7 @@ Widget _buildCurrentVersion(String data) {
   return ThematicMarkdownBlock(data: data, selectable: false);
 }
 
-Widget _buildFullList(String fullChangelog) {
-  final sections = parseChangelogSections(fullChangelog);
+Widget _buildFullList(List<ChangelogSection> sections) {
   return Column(
     mainAxisSize: MainAxisSize.min,
     crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/pages/app_changelog/changelog_parser.dart
+++ b/lib/pages/app_changelog/changelog_parser.dart
@@ -44,15 +44,12 @@ List<ChangelogSection> parseChangelogSections(String content) {
   final nodes = md.Document().parse(content);
   final sections = <ChangelogSection>[];
 
-  for (var i = 0; i < nodes.length; i++) {
-    final node = nodes[i];
-    if (node case md.Element(tag: 'h2')) {
-      final version = node.textContent.trim();
-      final bodyNodes = _collectSectionNodes(nodes, i + 1);
-      final body = _renderNodesToMarkdown(bodyNodes);
-      sections.add(ChangelogSection(version: version, body: body));
-    }
-  }
+  _forEachVersionSection(nodes, (version, bodyStart) {
+    final bodyNodes = _collectSectionNodes(nodes, bodyStart);
+    final body = _renderNodesToMarkdown(bodyNodes);
+    sections.add(ChangelogSection(version: version, body: body));
+    return true;
+  });
 
   return sections;
 }
@@ -66,10 +63,17 @@ List<ChangelogSection> parseChangelogSections(String content) {
 /// Returns the section body (list items etc.) as markdown text without the
 /// `## <version>` heading, or `null` when no matching heading is found.
 String? extractVersionSection(String content, String version) {
-  for (final section in parseChangelogSections(content)) {
-    if (section.version == version) return section.body;
-  }
-  return null;
+  final nodes = md.Document().parse(content);
+  String? section;
+
+  _forEachVersionSection(nodes, (heading, bodyStart) {
+    if (heading != version) return true;
+    final bodyNodes = _collectSectionNodes(nodes, bodyStart);
+    section = _renderNodesToMarkdown(bodyNodes);
+    return false;
+  });
+
+  return section;
 }
 
 /// Loads a changelog asset from [path] and returns the body markdown for
@@ -157,6 +161,19 @@ List<md.Node> _collectSectionNodes(List<md.Node> nodes, int start) {
     result.add(node);
   }
   return result;
+}
+
+void _forEachVersionSection(
+  List<md.Node> nodes,
+  bool Function(String version, int bodyStart) visitor,
+) {
+  for (var i = 0; i < nodes.length; i++) {
+    final node = nodes[i];
+    if (node case md.Element(tag: 'h2')) {
+      final keepWalking = visitor(node.textContent.trim(), i + 1);
+      if (!keepWalking) return;
+    }
+  }
 }
 
 String _renderNodesToMarkdown(List<md.Node> nodes) {

--- a/lib/pages/app_changelog/changelog_parser.dart
+++ b/lib/pages/app_changelog/changelog_parser.dart
@@ -18,6 +18,45 @@ import 'package:markdown/markdown.dart' as md;
 import '../../assets/assets.dart';
 import '../../extensions/asset_bundle_extensions.dart';
 
+/// A single version section parsed from a changelog.
+///
+/// [version] is the `## <version>` heading text (e.g. `"1.25.3+168"`).
+/// [body] is the section body rendered back to markdown, or empty string
+/// when the section has no body content.
+final class ChangelogSection {
+  final String version;
+  final String body;
+
+  const ChangelogSection({required this.version, required this.body});
+}
+
+/// Parses [content] into a list of [ChangelogSection]s, one per `## ` h2
+/// heading.
+///
+/// Each section spans from its `## <version>` heading to the next `## `
+/// heading (or EOF). The section body is rendered back to markdown via the
+/// same `_renderNodesToMarkdown` pipeline used by [extractVersionSection].
+///
+/// [content] should be the raw CHANGELOG.md text. Callers that have already
+/// stripped the preamble via [stripChangelogPreamble] can pass the result
+/// directly.
+List<ChangelogSection> parseChangelogSections(String content) {
+  final nodes = md.Document().parse(content);
+  final sections = <ChangelogSection>[];
+
+  for (var i = 0; i < nodes.length; i++) {
+    final node = nodes[i];
+    if (node case md.Element(tag: 'h2')) {
+      final version = node.textContent.trim();
+      final bodyNodes = _collectSectionNodes(nodes, i + 1);
+      final body = _renderNodesToMarkdown(bodyNodes);
+      sections.add(ChangelogSection(version: version, body: body));
+    }
+  }
+
+  return sections;
+}
+
 /// Extracts the body markdown for [version] from raw [content].
 ///
 /// [content] is the full text of a changelog file.
@@ -27,11 +66,10 @@ import '../../extensions/asset_bundle_extensions.dart';
 /// Returns the section body (list items etc.) as markdown text without the
 /// `## <version>` heading, or `null` when no matching heading is found.
 String? extractVersionSection(String content, String version) {
-  final nodes = md.Document().parse(content);
-  final headingIdx = _findVersionHeading(nodes, version);
-  if (headingIdx == null) return null;
-  final sectionNodes = _collectSectionNodes(nodes, headingIdx + 1);
-  return _renderNodesToMarkdown(sectionNodes);
+  for (final section in parseChangelogSections(content)) {
+    if (section.version == version) return section.body;
+  }
+  return null;
 }
 
 /// Loads a changelog asset from [path] and returns the body markdown for
@@ -110,17 +148,6 @@ String? _tryBetaHeading(String content, String base) {
 String stripChangelogPreamble(String content) {
   final match = RegExp(r'^## ', multiLine: true).firstMatch(content);
   return match != null ? content.substring(match.start) : content;
-}
-
-int? _findVersionHeading(List<md.Node> nodes, String version) {
-  for (final (index, node) in nodes.indexed) {
-    if (node case md.Element(
-      tag: 'h2',
-    ) when node.textContent.trim() == version) {
-      return index;
-    }
-  }
-  return null;
 }
 
 List<md.Node> _collectSectionNodes(List<md.Node> nodes, int start) {

--- a/lib/pages/common/_widgets/donate_dialog.dart
+++ b/lib/pages/common/_widgets/donate_dialog.dart
@@ -85,7 +85,7 @@ class DonateContent extends StatefulWidget {
 }
 
 class _DonateContentState extends State<DonateContent> {
-  Future<bool> _onLaunchExternelUrl(String urlString) async {
+  Future<bool> _onLaunchExternalUrl(String urlString) async {
     return launchExternalUrl(Uri.parse(urlString));
   }
 
@@ -166,7 +166,7 @@ class _DonateContentState extends State<DonateContent> {
           constraints: const BoxConstraints(maxWidth: 320),
           child: BuyMeACoffeeButton(
             buyMeACoffeeName: widget.donateBuyMeACoffeeToken,
-            onLaunchURL: _onLaunchExternelUrl,
+            onLaunchURL: _onLaunchExternalUrl,
             onDonation: () => _onDonation(DonateWay.buyMeACoffee),
           ),
         ),
@@ -184,7 +184,7 @@ class _DonateContentState extends State<DonateContent> {
           ),
         PayPalButton(
           paypalButtonId: widget.donatePaypalToken,
-          onLaunchURL: _onLaunchExternelUrl,
+          onLaunchURL: _onLaunchExternalUrl,
           onDonation: () => _onDonation(DonateWay.paypal),
         ),
       ],

--- a/lib/pages/common/_widgets/donate_dialog.dart
+++ b/lib/pages/common/_widgets/donate_dialog.dart
@@ -212,7 +212,7 @@ class _DonateContentState extends State<DonateContent> {
                 child: CryptoDonateButton(
                   cryptoType: t,
                   address: addr,
-                  onPressed: addr != ''
+                  onPressed: addr.isNotEmpty
                       ? () => _onCopyCryptoAddressToClipboard(t)
                       : null,
                 ),

--- a/lib/pages/common/_widgets/donate_dialog.dart
+++ b/lib/pages/common/_widgets/donate_dialog.dart
@@ -36,9 +36,13 @@ Future<DonateDialogResult?> showDonateDialog(
   String alipayQRCodePath = 'assets/images/donate-alipay.jpg',
   String wechatPayQRCodePath = 'assets/images/donate-wechatpay.png',
 }) async {
-  return showDialog<DonateDialogResult>(
+  final l10n = L10n.of(context);
+  return showAdaptiveContentSheet<DonateDialogResult>(
     context: context,
-    builder: (context) => DonateDialog(
+    showCloseButton: false,
+    title: l10n != null ? Text(l10n.appAbout_donateTile_titleText) : null,
+    dialogWidth: 800,
+    contentBuilder: (_) => DonateContent(
       donateBuyMeACoffeeToken: donateBuyMeACoffeeToken,
       donatePaypalToken: donatePaypalToken,
       btcAddress: btcAddress,
@@ -52,7 +56,7 @@ Future<DonateDialogResult?> showDonateDialog(
   );
 }
 
-class DonateDialog extends StatefulWidget {
+class DonateContent extends StatefulWidget {
   final String donateBuyMeACoffeeToken;
   final String donatePaypalToken;
   final String btcAddress;
@@ -63,7 +67,7 @@ class DonateDialog extends StatefulWidget {
   final String alipayQRCodePath;
   final String wechatPayQRCodePath;
 
-  const DonateDialog({
+  const DonateContent({
     super.key,
     required this.donateBuyMeACoffeeToken,
     required this.donatePaypalToken,
@@ -77,10 +81,10 @@ class DonateDialog extends StatefulWidget {
   });
 
   @override
-  State<DonateDialog> createState() => _DonateDialogState();
+  State<DonateContent> createState() => _DonateContentState();
 }
 
-class _DonateDialogState extends State<DonateDialog> {
+class _DonateContentState extends State<DonateContent> {
   Future<bool> _onLaunchExternelUrl(String urlString) async {
     return launchExternalUrl(Uri.parse(urlString));
   }
@@ -149,132 +153,160 @@ class _DonateDialogState extends State<DonateDialog> {
       }
     }
 
-    Iterable<Widget> buildBuyMeACoffeeList(BuildContext context) => [
-      if (l10n != null)
-        ListTile(
-          title: Text(l10n.donateWay_buyMeACoffee),
-          contentPadding: EdgeInsets.zero,
-          visualDensity: VisualDensity.compact,
+    Widget buildBuyMeACoffeeList() => Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (l10n != null)
+          ListTile(
+            title: Text(l10n.donateWay_buyMeACoffee),
+            contentPadding: EdgeInsets.zero,
+            visualDensity: VisualDensity.compact,
+          ),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 320),
+          child: BuyMeACoffeeButton(
+            buyMeACoffeeName: widget.donateBuyMeACoffeeToken,
+            onLaunchURL: _onLaunchExternelUrl,
+            onDonation: () => _onDonation(DonateWay.buyMeACoffee),
+          ),
         ),
-      BuyMeACoffeeButton(
-        buyMeACoffeeName: widget.donateBuyMeACoffeeToken,
-        onLaunchURL: _onLaunchExternelUrl,
-        onDonation: () => _onDonation(DonateWay.buyMeACoffee),
-      ),
-    ];
+      ],
+    );
 
-    Iterable<Widget> buildPaypalList(BuildContext context) => [
-      if (l10n != null)
-        ListTile(
-          title: Text(l10n.donateWay_paypal),
-          contentPadding: EdgeInsets.zero,
-          visualDensity: VisualDensity.compact,
+    Widget buildPaypalList() => Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (l10n != null)
+          ListTile(
+            title: Text(l10n.donateWay_paypal),
+            contentPadding: EdgeInsets.zero,
+            visualDensity: VisualDensity.compact,
+          ),
+        PayPalButton(
+          paypalButtonId: widget.donatePaypalToken,
+          onLaunchURL: _onLaunchExternelUrl,
+          onDonation: () => _onDonation(DonateWay.paypal),
         ),
-      PayPalButton(
-        paypalButtonId: widget.donatePaypalToken,
-        onLaunchURL: _onLaunchExternelUrl,
-        onDonation: () => _onDonation(DonateWay.paypal),
-      ),
-    ];
+      ],
+    );
 
-    Iterable<Widget> buildAlipayList(BuildContext context) => [
-      if (l10n != null)
-        ListTile(
-          title: Text(l10n.donateWay_alipay),
-          contentPadding: EdgeInsets.zero,
-          visualDensity: VisualDensity.compact,
+    Widget buildCryptoButtonList() => Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (l10n != null)
+          ListTile(
+            title: Text(l10n.donateWay_cryptoCurrency),
+            contentPadding: EdgeInsets.zero,
+            visualDensity: VisualDensity.compact,
+          ),
+        Wrap(
+          spacing: 8.0,
+          children: List<Widget>.generate(
+            CryptoDonateButtonType.values.length,
+            (index) {
+              final t = CryptoDonateButtonType.values[index];
+              final addr = getCryptoAddress(t);
+              return Tooltip(
+                triggerMode: TooltipTriggerMode.longPress,
+                message: getCryptoLabel(t, l10n),
+                child: CryptoDonateButton(
+                  cryptoType: t,
+                  address: addr,
+                  onPressed: addr != ''
+                      ? () => _onCopyCryptoAddressToClipboard(t)
+                      : null,
+                ),
+              );
+            },
+          ),
         ),
-      Image.asset(widget.alipayQRCodePath, width: 300),
-    ];
+      ],
+    );
 
-    Iterable<Widget> buildWechatPayList(BuildContext context) => [
-      if (l10n != null)
-        ListTile(
-          title: Text(l10n.donateWay_wechatPay),
-          contentPadding: EdgeInsets.zero,
-          visualDensity: VisualDensity.compact,
-        ),
-      Image.asset(widget.wechatPayQRCodePath, width: 300),
-    ];
+    Widget buildQRSection() {
+      final hasAlipay = donateWays.contains(DonateWay.alipay);
+      final hasWechat = donateWays.contains(DonateWay.wechatPay);
+      if (!hasAlipay && !hasWechat) return const SizedBox.shrink();
 
-    Iterable<Widget> buildCryptoButtonList(BuildContext context) => [
-      if (l10n != null)
-        ListTile(
-          title: Text(l10n.donateWay_cryptoCurrency),
-          contentPadding: EdgeInsets.zero,
-          visualDensity: VisualDensity.compact,
-        ),
-      Wrap(
-        spacing: 8.0,
-        children: List<Widget>.generate(CryptoDonateButtonType.values.length, (
-          index,
-        ) {
-          final t = CryptoDonateButtonType.values[index];
-          final addr = getCryptoAddress(t);
-          return Tooltip(
-            triggerMode: TooltipTriggerMode.longPress,
-            message: getCryptoLabel(t, l10n),
-            child: CryptoDonateButton(
-              cryptoType: t,
-              address: addr,
-              onPressed: addr != ''
-                  ? () => _onCopyCryptoAddressToClipboard(t)
-                  : null,
-            ),
+      return AppUiLayoutBuilder(
+        builder: (context, layoutType, _) {
+          final wide = layoutType == UiLayoutType.l;
+          final screenWidth = MediaQuery.sizeOf(context).width;
+          final qrSize = wide
+              ? 300.0
+              : (screenWidth * 0.55).clamp(180.0, 280.0);
+
+          Widget qrImage(String path) => Image.asset(
+            path,
+            width: qrSize,
+            height: qrSize,
+            fit: BoxFit.fill,
           );
-        }),
-      ),
-    ];
+          Widget alipayQR() => qrImage(widget.alipayQRCodePath);
+          Widget wechatQR() => qrImage(widget.wechatPayQRCodePath);
 
-    Iterable<Widget> buildFirstQRGroup(BuildContext context) {
-      switch (MediaQuery.orientationOf(context)) {
-        case Orientation.portrait:
-          return [
-            if (donateWays.contains(DonateWay.alipay))
-              ...buildAlipayList(context),
-            if (donateWays.contains(DonateWay.wechatPay))
-              ...buildWechatPayList(context),
-          ];
-        case Orientation.landscape:
-          return [
-            if (l10n != null)
-              ListTile(
-                title: Text(l10n.donateWay_firstQRGroup),
-                contentPadding: EdgeInsets.zero,
-                visualDensity: VisualDensity.compact,
-              ),
-            if (l10n != null)
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (donateWays.contains(DonateWay.alipay))
-                    Image.asset(widget.alipayQRCodePath, height: 300),
-                  if (donateWays.contains(DonateWay.wechatPay))
-                    const SizedBox(width: 8.0),
-                  if (donateWays.contains(DonateWay.wechatPay))
-                    Image.asset(widget.wechatPayQRCodePath, height: 300),
-                ],
-              ),
-          ];
-      }
+          if (wide) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (l10n != null)
+                  ListTile(
+                    title: Text(l10n.donateWay_firstQRGroup),
+                    contentPadding: EdgeInsets.zero,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                Wrap(
+                  spacing: 8.0,
+                  runSpacing: 6.0,
+                  children: [
+                    if (hasAlipay) alipayQR(),
+                    if (hasWechat) wechatQR(),
+                  ],
+                ),
+              ],
+            );
+          }
+
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (hasAlipay) ...[
+                if (l10n != null)
+                  ListTile(
+                    title: Text(l10n.donateWay_alipay),
+                    contentPadding: EdgeInsets.zero,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                alipayQR(),
+              ],
+              if (hasWechat) ...[
+                if (l10n != null)
+                  ListTile(
+                    title: Text(l10n.donateWay_wechatPay),
+                    contentPadding: EdgeInsets.zero,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                wechatQR(),
+              ],
+            ],
+          );
+        },
+      );
     }
 
-    return AlertDialog(
-      scrollable: true,
-      title: l10n != null ? Text(l10n.appAbout_donateTile_titleText) : null,
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (donateWays.contains(DonateWay.cryptoCurrencyAll))
-            ...buildCryptoButtonList(context),
-          if (donateWays.contains(DonateWay.buyMeACoffee))
-            ...buildBuyMeACoffeeList(context),
-          if (donateWays.contains(DonateWay.paypal) &&
-              widget.donatePaypalToken.isNotEmpty)
-            ...buildPaypalList(context),
-          ...buildFirstQRGroup(context),
-        ],
-      ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (donateWays.contains(DonateWay.cryptoCurrencyAll))
+          buildCryptoButtonList(),
+        if (donateWays.contains(DonateWay.buyMeACoffee))
+          buildBuyMeACoffeeList(),
+        if (donateWays.contains(DonateWay.paypal) &&
+            widget.donatePaypalToken.isNotEmpty)
+          buildPaypalList(),
+        buildQRSection(),
+        const SizedBox(height: 8),
+      ],
     );
   }
 }

--- a/lib/widgets/_widgets/adaptive_content_sheet.dart
+++ b/lib/widgets/_widgets/adaptive_content_sheet.dart
@@ -26,12 +26,15 @@ import 'enhanced_safe_area.dart';
 /// content identically in both modes — it should not include its own scroll
 /// view.
 ///
-/// On small screens (< [kHabitLargeScreenAdaptWidth] px on mobile):
-///   [showModalBottomSheet] + [DraggableScrollableSheet].
-/// On large screens: [showDialog] + [AlertDialog].
+/// On Android, iOS, and Fuchsia, dialog mode is used only when
+/// [computeLayoutType] resolves a large layout with both the width and height
+/// thresholds enabled. Otherwise this uses [showModalBottomSheet] with a
+/// [DraggableScrollableSheet]. On other platforms, this always uses
+/// [showDialog] with an [AlertDialog].
 ///
-/// [actions] are placed in a bottom area (sheet) or prepended to
-/// [AlertDialog.actions] (dialog).  [showCloseButton] controls the default
+/// [actions] are placed in a bottom area (sheet) or appended before the
+/// default close button in [AlertDialog.actions] (dialog).
+/// [showCloseButton] controls the default
 /// close button.  [sheetActionsAlign] and [sheetTitleAlignment] control
 /// layout in the sheet scaffold.
 ///
@@ -57,6 +60,14 @@ Future<T?> showAdaptiveContentSheet<T>({
   double dialogMaxContentHeight = 400,
   bool dialogShowScrollbar = true,
 }) {
+  assert(
+    0 <= sheetMinChildSize &&
+        sheetMinChildSize <= sheetInitialChildSize &&
+        sheetInitialChildSize <= sheetMaxChildSize &&
+        sheetMaxChildSize <= 1,
+    'sheet child sizes must satisfy 0 <= min <= initial <= max <= 1',
+  );
+
   final viewSize = MediaQuery.sizeOf(context);
   final appLayoutType = computeLayoutType(
     width: viewSize.width,
@@ -236,7 +247,7 @@ class _AdaptiveSheet extends StatelessWidget {
   }
 }
 
-class _AdaptiveAlertDialog extends StatelessWidget {
+class _AdaptiveAlertDialog extends StatefulWidget {
   final Widget? title;
   final Widget child;
   final double? width;
@@ -256,29 +267,51 @@ class _AdaptiveAlertDialog extends StatelessWidget {
   });
 
   @override
+  State<_AdaptiveAlertDialog> createState() => _AdaptiveAlertDialogState();
+}
+
+class _AdaptiveAlertDialogState extends State<_AdaptiveAlertDialog> {
+  late final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final scrolledChild = SingleChildScrollView(child: child);
+    final scrolledChild = SingleChildScrollView(
+      controller: _scrollController,
+      child: widget.child,
+    );
     return AlertDialog(
-      title: title,
-      content: width != null
+      title: widget.title,
+      content: widget.width != null
           ? SizedBox(
-              width: width,
+              width: widget.width,
               child: ConstrainedBox(
-                constraints: BoxConstraints(maxHeight: maxContentHeight),
-                child: showScrollbar
-                    ? Scrollbar(child: scrolledChild)
+                constraints: BoxConstraints(maxHeight: widget.maxContentHeight),
+                child: widget.showScrollbar
+                    ? Scrollbar(
+                        controller: _scrollController,
+                        child: scrolledChild,
+                      )
                     : scrolledChild,
               ),
             )
           : ConstrainedBox(
-              constraints: BoxConstraints(maxHeight: maxContentHeight),
-              child: showScrollbar
-                  ? Scrollbar(child: scrolledChild)
+              constraints: BoxConstraints(maxHeight: widget.maxContentHeight),
+              child: widget.showScrollbar
+                  ? Scrollbar(
+                      controller: _scrollController,
+                      child: scrolledChild,
+                    )
                   : scrolledChild,
             ),
       actions: [
-        if (actions != null) ...actions!,
-        if (showCloseButton)
+        if (widget.actions != null) ...widget.actions!,
+        if (widget.showCloseButton)
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
             child: Text(MaterialLocalizations.of(context).closeButtonLabel),

--- a/lib/widgets/_widgets/adaptive_content_sheet.dart
+++ b/lib/widgets/_widgets/adaptive_content_sheet.dart
@@ -1,0 +1,289 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
+import 'package:flutter/material.dart';
+
+import '../../common/consts.dart';
+import '../../common/utils.dart';
+import 'enhanced_safe_area.dart';
+
+/// Shows an adaptive content sheet or dialog based on screen size.
+///
+/// The scaffold handles the platform decision, [title] (fixed top), scroll
+/// wrapping, actions, and a close button.  [contentBuilder] builds the inner
+/// content identically in both modes — it should not include its own scroll
+/// view.
+///
+/// On small screens (< [kHabitLargeScreenAdaptWidth] px on mobile):
+///   [showModalBottomSheet] + [DraggableScrollableSheet].
+/// On large screens: [showDialog] + [AlertDialog].
+///
+/// [actions] are placed in a bottom area (sheet) or prepended to
+/// [AlertDialog.actions] (dialog).  [showCloseButton] controls the default
+/// close button.  [sheetActionsAlign] and [sheetTitleAlignment] control
+/// layout in the sheet scaffold.
+///
+/// Mode‑specific parameters use `sheet*` / `dialog*` prefixes.
+Future<T?> showAdaptiveContentSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder contentBuilder,
+  Widget? title,
+  List<Widget>? actions,
+  bool showCloseButton = true,
+  bool? sheetShowCloseButton,
+  // Sheet scaffold
+  double sheetInitialChildSize = 0.6,
+  double sheetMinChildSize = 0.25,
+  double sheetMaxChildSize = 0.95,
+  bool sheetShowDragHandle = true,
+  ScrollPhysics? sheetScrollPhysics,
+  EdgeInsetsGeometry? sheetPadding,
+  AlignmentGeometry sheetActionsAlign = AlignmentDirectional.centerEnd,
+  AlignmentGeometry sheetTitleAlignment = Alignment.centerLeft,
+  // Dialog scaffold
+  double? dialogWidth = 500,
+  double dialogMaxContentHeight = 400,
+  bool dialogShowScrollbar = true,
+}) {
+  final viewSize = MediaQuery.sizeOf(context);
+  final appLayoutType = computeLayoutType(
+    width: viewSize.width,
+    height: viewSize.height,
+    largeScreenWidth: kHabitLargeScreenAdaptWidth,
+    largeScreenHeight: kHabitLargeScreenAdaptHeight,
+    ignoreHeight: false,
+    defaultType: UiLayoutType.s,
+  );
+
+  final useDialog = switch (defaultTargetPlatform) {
+    TargetPlatform.android ||
+    TargetPlatform.iOS ||
+    TargetPlatform.fuchsia => appLayoutType == UiLayoutType.l,
+    _ => true,
+  };
+
+  return switch (useDialog) {
+    true => showDialog<T>(
+      context: context,
+      builder: (dialogContext) => _AdaptiveAlertDialog(
+        title: title,
+        width: dialogWidth,
+        maxContentHeight: dialogMaxContentHeight,
+        showScrollbar: dialogShowScrollbar,
+        showCloseButton: showCloseButton,
+        actions: actions,
+        child: contentBuilder(dialogContext),
+      ),
+    ),
+    false => showModalBottomSheet<T>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      showDragHandle: sheetShowDragHandle,
+      builder: (sheetContext) => _AdaptiveSheet(
+        title: title,
+        initialChildSize: sheetInitialChildSize,
+        minChildSize: sheetMinChildSize,
+        maxChildSize: sheetMaxChildSize,
+        scrollPhysics: sheetScrollPhysics,
+        padding: sheetPadding,
+        sheetShowCloseButton: sheetShowCloseButton ?? showCloseButton,
+        actions: actions,
+        actionsAlign: sheetActionsAlign,
+        titleAlignment: sheetTitleAlignment,
+        child: contentBuilder(sheetContext),
+      ),
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scaffold widgets
+// ---------------------------------------------------------------------------
+
+class _AdaptiveSheet extends StatelessWidget {
+  final Widget? title;
+  final Widget child;
+  final double initialChildSize;
+  final double minChildSize;
+  final double maxChildSize;
+  final ScrollPhysics? scrollPhysics;
+  final EdgeInsetsGeometry? padding;
+  final bool sheetShowCloseButton;
+  final List<Widget>? actions;
+  final AlignmentGeometry actionsAlign;
+  final AlignmentGeometry titleAlignment;
+
+  const _AdaptiveSheet({
+    required this.title,
+    required this.child,
+    required this.initialChildSize,
+    required this.minChildSize,
+    required this.maxChildSize,
+    this.scrollPhysics,
+    this.padding,
+    this.sheetShowCloseButton = true,
+    this.actions,
+    this.actionsAlign = Alignment.center,
+    this.titleAlignment = Alignment.centerLeft,
+  });
+
+  bool get _hasActions =>
+      sheetShowCloseButton || (actions?.isNotEmpty ?? false);
+
+  @override
+  Widget build(BuildContext context) {
+    final sheetPadding = padding ?? const EdgeInsets.symmetric(horizontal: 20);
+    final sheetPhysics = scrollPhysics ?? const AlwaysScrollableScrollPhysics();
+    final resolvedSheetPadding = sheetPadding.resolve(
+      Directionality.of(context),
+    );
+    final actionsPadding = EdgeInsets.only(
+      left: resolvedSheetPadding.left,
+      right: resolvedSheetPadding.right,
+      top: 8,
+      bottom: 8,
+    );
+
+    Widget buildTitle() {
+      if (title == null) return const SizedBox.shrink();
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(alignment: titleAlignment, child: title!),
+          const SizedBox(height: 12),
+        ],
+      );
+    }
+
+    Widget buildCloseButton() {
+      return TextButton(
+        onPressed: () => Navigator.of(context).pop(),
+        child: Text(MaterialLocalizations.of(context).closeButtonLabel),
+      );
+    }
+
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: initialChildSize,
+      minChildSize: minChildSize,
+      maxChildSize: maxChildSize,
+      builder: (_, scrollController) {
+        if (!_hasActions) {
+          return Padding(
+            padding: sheetPadding,
+            child: SingleChildScrollView(
+              controller: scrollController,
+              physics: sheetPhysics,
+              child: EnhancedSafeArea.only(
+                bottom: true,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [buildTitle(), child],
+                ),
+              ),
+            ),
+          );
+        }
+
+        return EnhancedSafeArea.only(
+          bottom: true,
+          child: Padding(
+            padding: sheetPadding,
+            child: Column(
+              children: [
+                buildTitle(),
+                Expanded(
+                  child: SingleChildScrollView(
+                    controller: scrollController,
+                    physics: sheetPhysics,
+                    child: child,
+                  ),
+                ),
+                Padding(
+                  padding: actionsPadding,
+                  child: Align(
+                    alignment: actionsAlign,
+                    child: OverflowBar(
+                      alignment: MainAxisAlignment.end,
+                      spacing: 8,
+                      overflowAlignment: OverflowBarAlignment.end,
+                      children: [
+                        if (actions != null) ...actions!,
+                        if (sheetShowCloseButton) buildCloseButton(),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _AdaptiveAlertDialog extends StatelessWidget {
+  final Widget? title;
+  final Widget child;
+  final double? width;
+  final double maxContentHeight;
+  final bool showScrollbar;
+  final bool showCloseButton;
+  final List<Widget>? actions;
+
+  const _AdaptiveAlertDialog({
+    required this.title,
+    required this.child,
+    this.width,
+    required this.maxContentHeight,
+    required this.showScrollbar,
+    this.showCloseButton = true,
+    this.actions,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scrolledChild = SingleChildScrollView(child: child);
+    return AlertDialog(
+      title: title,
+      content: width != null
+          ? SizedBox(
+              width: width,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(maxHeight: maxContentHeight),
+                child: showScrollbar
+                    ? Scrollbar(child: scrolledChild)
+                    : scrolledChild,
+              ),
+            )
+          : ConstrainedBox(
+              constraints: BoxConstraints(maxHeight: maxContentHeight),
+              child: showScrollbar
+                  ? Scrollbar(child: scrolledChild)
+                  : scrolledChild,
+            ),
+      actions: [
+        if (actions != null) ...actions!,
+        if (showCloseButton)
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(MaterialLocalizations.of(context).closeButtonLabel),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/_widgets/enhanced_safe_area.dart
+++ b/lib/widgets/_widgets/enhanced_safe_area.dart
@@ -36,6 +36,18 @@ class EnhancedSafeArea extends StatelessWidget {
     required this.child,
   });
 
+  const EnhancedSafeArea.withDefault({
+    super.key,
+    this.left = true,
+    this.top = true,
+    this.right = true,
+    this.bottom = true,
+    this.minimum = EdgeInsets.zero,
+    this.maintainBottomViewPadding = false,
+    this.withSliver = false,
+    required this.child,
+  });
+
   const EnhancedSafeArea.all({
     super.key,
     required this.left,

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export '_widgets/adaptive_content_sheet.dart';
 export '_widgets/animated_linear_progress.dart';
 export '_widgets/animated_reorderable_list.dart';
 export '_widgets/app_ui_layout_builder.dart';

--- a/test/unit/pages/app_changelog/changelog_dialog_test.dart
+++ b/test/unit/pages/app_changelog/changelog_dialog_test.dart
@@ -88,11 +88,16 @@ void main() {
         await tester.tap(find.text('View Full Changelog'));
         await tester.pumpAndSettle();
 
-        // Content should now be the full changelog
+        // Content should now show parsed section body (lazy list item)
         final block = find.byWidgetPredicate(
-          (w) => w is ThematicMarkdownBlock && w.data == _fullChangelog,
+          (w) => w is ThematicMarkdownBlock && w.data == '- old item',
         );
         expect(block, findsOneWidget);
+        // Original current-version content should be gone
+        final oldBlock = find.byWidgetPredicate(
+          (w) => w is ThematicMarkdownBlock && w.data == _currentVersionSection,
+        );
+        expect(oldBlock, findsNothing);
         expect(find.text('View Full Changelog'), findsNothing);
       },
     );

--- a/test/unit/pages/app_changelog/changelog_dialog_test.dart
+++ b/test/unit/pages/app_changelog/changelog_dialog_test.dart
@@ -151,7 +151,7 @@ void main() {
       expect(find.text('Changelog'), findsOneWidget);
       expect(find.text('v$_version'), findsOneWidget);
       // AlertDialog close button should not be present
-      expect(find.text('Close'), findsNothing);
+      expect(find.text('Close'), findsOneWidget);
       // Fullscreen close icon should not be present
       expect(find.byIcon(Icons.close), findsNothing);
     });

--- a/test/unit/pages/app_changelog/changelog_dialog_test.dart
+++ b/test/unit/pages/app_changelog/changelog_dialog_test.dart
@@ -150,7 +150,7 @@ void main() {
       // Bottom sheet content should be visible
       expect(find.text('Changelog'), findsOneWidget);
       expect(find.text('v$_version'), findsOneWidget);
-      // AlertDialog close button should not be present
+      // Bottom sheet actions should include the close button
       expect(find.text('Close'), findsOneWidget);
       // Fullscreen close icon should not be present
       expect(find.byIcon(Icons.close), findsNothing);

--- a/test/unit/pages/app_changelog/changelog_parser_test.dart
+++ b/test/unit/pages/app_changelog/changelog_parser_test.dart
@@ -241,4 +241,37 @@ Second paragraph.
       expect(result, isNull);
     });
   });
+
+  group('parseChangelogSections', () {
+    // 16: Parses all sections from sample changelog
+    test('parses all sections from sample changelog', () {
+      final sections = parseChangelogSections(_sampleChangelog);
+      expect(sections.length, 7);
+      expect(sections[0].version, '1.25.3+168');
+      expect(sections[0].body, contains('- Update Hebrew translation'));
+      expect(sections[1].version, '1.25.1+164');
+      expect(sections[2].version, '1.24.5+161');
+      expect(sections[3].version, '1.24.4+160-pre');
+      expect(sections[4].version, '1.24.3+159');
+      expect(sections[5].version, '1.0.1');
+      expect(sections[6].version, '1.0.0');
+    });
+
+    // 17: Handles empty body sections
+    test('handles empty body sections', () {
+      final sections = parseChangelogSections(_sparseChangelog);
+      expect(sections.length, 2);
+      expect(sections[0].version, '1.0.0');
+      expect(sections[0].body, isEmpty);
+      expect(sections[1].version, '1.0.1');
+      expect(sections[1].body, isNotEmpty);
+    });
+
+    // 18: Returns empty list for content without h2 headings
+    test('returns empty list for content without h2 headings', () {
+      const content = '# Only h1\n\n- item';
+      final sections = parseChangelogSections(content);
+      expect(sections, isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Extract a reusable `AdaptiveContentSheet` widget and refactor existing dialogs (`DonateDialog`, `ChangelogDialog`, `LicenseTile`, `PrivacyTile`, `LicenseThirdPartyTile`) to use it. Also enhance the changelog parser to support section-based parsing, improving the changelog dialog's rendering logic.

### Key changes

- **`AdaptiveContentSheet`** (`lib/widgets/_widgets/adaptive_content_sheet.dart`): New reusable widget that provides consistent bottom-sheet / full-page adaptive layout for content-heavy dialogs.
- **Dialog refactoring**: `DonateDialog`, `ChangelogDialog`, `AboutLicenseTile`, `AboutLicenseThirdPartyTile`, `AboutPrivacyTile` now use `AdaptiveContentSheet`, reducing duplication and improving visual consistency across platforms.
- **Changelog parser** (`lib/pages/app_changelog/changelog_parser.dart`): Added section-based parsing to better handle structured changelog entries.
- **Localization updates**: Updated ARB files to support the new dialog content.

## Type of Change

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] style
- [ ] test
- [ ] chore

## Related Issue

N/A

## Checklist

- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change
