### PR TITLE
Preserve unknown sync fields across habit round-trips

### DIFF
--- a/assets/sql/mh_habits.sql
+++ b/assets/sql/mh_habits.sql
@@ -19,5 +19,6 @@ CREATE TABLE IF NOT EXISTS mh_habits (
     target_days INTEGER,
     remind_cutsom TEXT,
     remind_question TEXT,
-    sort_position REAL NOT NULL DEFAULT 9e999
+    sort_position REAL NOT NULL DEFAULT 9e999,
+    sync_extras TEXT
 );

--- a/lib/common/consts.dart
+++ b/lib/common/consts.dart
@@ -52,7 +52,9 @@ const String appSyncFailedZipFile = "app_sync_failed.zip";
 /// - add sync table
 /// ## version 5
 /// - add custom_color and custom_color_tinted columns
-const int appDBVersion = 5;
+/// ## version 6
+/// - add sync_extras column
+const int appDBVersion = 6;
 //#endregion
 
 //#region app-theme

--- a/lib/models/_app_sync_tasks/webdav_app_sync_models.dart
+++ b/lib/models/_app_sync_tasks/webdav_app_sync_models.dart
@@ -341,6 +341,10 @@ class WebDavSyncRecordData implements JsonAdaptor {
 /// (`lib/models/habit_export.dart`).
 ///
 /// {@macro habit_color_keys_relationship}
+///
+/// This class is the single source of truth for JSON key strings. The
+/// sibling enum [WebDavSyncHabitKeys] derives its entries from these
+/// constants so the two are inherently aligned.
 class WebDavSyncHabitKey {
   static const String uuid = 'uuid';
   static const String createT = 'create_t';
@@ -373,31 +377,37 @@ class WebDavSyncHabitKey {
 /// (`lib/models/habit_export.dart`).
 ///
 /// {@macro habit_color_keys_relationship}
+///
+/// Each entry references the corresponding [WebDavSyncHabitKey] constant so
+/// the enum registry stays in sync with the annotation-level source of truth.
+/// When adding a new sync-payload field, add a static const to
+/// [WebDavSyncHabitKey] first, then add an enum entry here.
+///
 enum WebDavSyncHabitKeys {
-  uuid('uuid'),
-  createT('create_t'),
-  modifyT('modify_t'),
-  type('type'),
-  status('status'),
-  name('name'),
-  desc('desc'),
-  color('color'),
-  customColor('custom_color'),
-  customColorTinted('custom_color_tinted'),
-  dailyGoal('daily_goal'),
-  dailyGoalUnit('daily_goal_unit'),
-  dailyGoalExtra('daily_goal_extra'),
-  freqType('freq_type'),
-  freqCustom('freq_custom'),
-  reminder('reminder'),
-  reminderQuest('reminder_quest'),
-  startDate('start_date'),
-  targetDays('target_days'),
-  sortPosition('sort_position'),
-  sessionId('sessionId'),
-  records('records'),
-  convertType('_convert_type'),
-  schemaVersion('_schema_version');
+  uuid(WebDavSyncHabitKey.uuid),
+  createT(WebDavSyncHabitKey.createT),
+  modifyT(WebDavSyncHabitKey.modifyT),
+  type(WebDavSyncHabitKey.type),
+  status(WebDavSyncHabitKey.status),
+  name(WebDavSyncHabitKey.name),
+  desc(WebDavSyncHabitKey.desc),
+  color(WebDavSyncHabitKey.color),
+  customColor(WebDavSyncHabitKey.customColor),
+  customColorTinted(WebDavSyncHabitKey.customColorTinted),
+  dailyGoal(WebDavSyncHabitKey.dailyGoal),
+  dailyGoalUnit(WebDavSyncHabitKey.dailyGoalUnit),
+  dailyGoalExtra(WebDavSyncHabitKey.dailyGoalExtra),
+  freqType(WebDavSyncHabitKey.freqType),
+  freqCustom(WebDavSyncHabitKey.freqCustom),
+  reminder(WebDavSyncHabitKey.reminder),
+  reminderQuest(WebDavSyncHabitKey.reminderQuest),
+  startDate(WebDavSyncHabitKey.startDate),
+  targetDays(WebDavSyncHabitKey.targetDays),
+  sortPosition(WebDavSyncHabitKey.sortPosition),
+  sessionId(WebDavSyncHabitKey.sessionId),
+  records(WebDavSyncHabitKey.records),
+  convertType(WebDavSyncHabitKey.convertType),
+  schemaVersion(WebDavSyncHabitKey.schemaVersion);
 
   const WebDavSyncHabitKeys(this.jsonKey);
 
@@ -409,9 +419,9 @@ enum WebDavSyncHabitKeys {
   /// Derived from the enum registry so it stays aligned with the actual
   /// serialized shape. When adding a new sync-payload field to
   /// [WebDavSyncHabitData], add a new enum entry here.
-  static final Set<String> allKnownKeys = WebDavSyncHabitKeys.values
-      .map((e) => e.jsonKey)
-      .toSet();
+  static final Set<String> allKnownKeys = Set.unmodifiable(
+    WebDavSyncHabitKeys.values.map((e) => e.jsonKey),
+  );
 }
 
 /// Sync-payload (wire) encoding of [HabitColor]: unlike [HabitColor.dbColorType],

--- a/lib/models/_app_sync_tasks/webdav_app_sync_models.dart
+++ b/lib/models/_app_sync_tasks/webdav_app_sync_models.dart
@@ -291,7 +291,7 @@ class WebDavSyncRecordData implements JsonAdaptor {
   factory WebDavSyncRecordData.fromJson(JsonMap json) {
     assert(
       json.isNotEmpty
-          ? json[WebDavSyncHabitKey.convertType] == _convertType
+          ? json[WebDavSyncRecordKey.convertType] == _convertType
           : true,
     );
     return _$WebDavSyncRecordDataFromJson(json);
@@ -366,6 +366,52 @@ class WebDavSyncHabitKey {
   static const String records = 'records';
   static const String convertType = '_convert_type';
   static const String schemaVersion = '_schema_version';
+}
+
+/// WebDAV sync keys. Mirrors color-related entries in [HabitDBCellKey]
+/// (`lib/storage/db/handlers/habit.dart`) and `HabitExportDataKey`
+/// (`lib/models/habit_export.dart`).
+///
+/// {@macro habit_color_keys_relationship}
+enum WebDavSyncHabitKeys {
+  uuid('uuid'),
+  createT('create_t'),
+  modifyT('modify_t'),
+  type('type'),
+  status('status'),
+  name('name'),
+  desc('desc'),
+  color('color'),
+  customColor('custom_color'),
+  customColorTinted('custom_color_tinted'),
+  dailyGoal('daily_goal'),
+  dailyGoalUnit('daily_goal_unit'),
+  dailyGoalExtra('daily_goal_extra'),
+  freqType('freq_type'),
+  freqCustom('freq_custom'),
+  reminder('reminder'),
+  reminderQuest('reminder_quest'),
+  startDate('start_date'),
+  targetDays('target_days'),
+  sortPosition('sort_position'),
+  sessionId('sessionId'),
+  records('records'),
+  convertType('_convert_type'),
+  schemaVersion('_schema_version');
+
+  const WebDavSyncHabitKeys(this.jsonKey);
+
+  final String jsonKey;
+
+  /// All JSON keys that the current schema version recognizes.
+  /// Used by [WebDavSyncHabitData.fromJson] to compute the unknown-key bucket.
+  ///
+  /// Derived from the enum registry so it stays aligned with the actual
+  /// serialized shape. When adding a new sync-payload field to
+  /// [WebDavSyncHabitData], add a new enum entry here.
+  static final Set<String> allKnownKeys = WebDavSyncHabitKeys.values
+      .map((e) => e.jsonKey)
+      .toSet();
 }
 
 /// Sync-payload (wire) encoding of [HabitColor]: unlike [HabitColor.dbColorType],
@@ -462,6 +508,11 @@ class WebDavSyncHabitData implements JsonAdaptor {
   final int? dirty;
   final int? dirtyTotal;
 
+  /// Runtime bucket: carries JSON keys not recognized by the current schema.
+  /// Populated in [fromJson] and merged back in [toJson]; never serialized.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  Map<String, dynamic>? unknown;
+
   static List<List> _recordsToJson(
     Map<HabitRecordUUID, WebDavSyncRecordData> records,
   ) => const NormalizingListConverter().toJson(
@@ -478,7 +529,9 @@ class WebDavSyncHabitData implements JsonAdaptor {
         .nonNulls,
   );
 
-  const WebDavSyncHabitData({
+  // Non-const because [unknown] is populated post-construction by
+  // [fromJson] — it can't be final, so the constructor can't be const.
+  WebDavSyncHabitData({
     this.schemaVersion = 1,
     this.uuid,
     this.createT,
@@ -514,6 +567,7 @@ class WebDavSyncHabitData implements JsonAdaptor {
     int? dirtyTotal,
     String? sessionId,
     Map<HabitRecordUUID, WebDavSyncRecordData> records = const {},
+    Map<String, dynamic>? unknown,
   }) {
     final habitColor = HabitColor.fromRaw(
       colorType: cell.customColor != null
@@ -522,7 +576,7 @@ class WebDavSyncHabitData implements JsonAdaptor {
       customColor: cell.customColor,
       customColorTinted: cell.customColorTinted,
     );
-    return WebDavSyncHabitData(
+    final data = WebDavSyncHabitData(
       schemaVersion: currentSchemaVersion,
       uuid: cell.uuid,
       createT: cell.createT,
@@ -550,6 +604,10 @@ class WebDavSyncHabitData implements JsonAdaptor {
       sessionId: sessionId,
       records: records,
     );
+    if (unknown != null && unknown.isNotEmpty) {
+      data.unknown = unknown;
+    }
+    return data;
   }
 
   factory WebDavSyncHabitData.fromJson(JsonMap json) {
@@ -558,7 +616,14 @@ class WebDavSyncHabitData implements JsonAdaptor {
           ? json[WebDavSyncHabitKey.convertType] == _convertType
           : true,
     );
-    return _$WebDavSyncHabitDataFromJson(json);
+    final data = _$WebDavSyncHabitDataFromJson(json);
+    final unknownKeys = json.keys.where(
+      (k) => !WebDavSyncHabitKeys.allKnownKeys.contains(k),
+    );
+    if (unknownKeys.isNotEmpty) {
+      data.unknown = {for (final k in unknownKeys) k: json[k]};
+    }
+    return data;
   }
 
   HabitDBCell toHabitDBCell() {
@@ -597,6 +662,7 @@ class WebDavSyncHabitData implements JsonAdaptor {
       startDate: startDate,
       targetDays: targetDays,
       sortPosition: sortPostion,
+      syncExtras: unknown != null ? jsonEncode(unknown) : null,
     );
   }
 
@@ -605,6 +671,11 @@ class WebDavSyncHabitData implements JsonAdaptor {
     final json = _$WebDavSyncHabitDataToJson(this)
       ..[WebDavSyncHabitKey.convertType] = _convertType;
     if (schemaVersion <= 1) json.remove(WebDavSyncHabitKey.schemaVersion);
+    if (unknown != null) {
+      for (final entry in unknown!.entries) {
+        json.putIfAbsent(entry.key, () => entry.value);
+      }
+    }
     return json;
   }
 

--- a/lib/models/_app_sync_tasks/webdav_app_sync_models.dart
+++ b/lib/models/_app_sync_tasks/webdav_app_sync_models.dart
@@ -41,6 +41,49 @@ import 'app_sync_task.dart';
 
 part 'webdav_app_sync_models.g.dart';
 
+/// Encodes [unknown] for the DB [syncExtras] column.
+/// Returns `null` when [unknown] is `null` or empty.
+String? encodeSyncExtras(Map<String, dynamic>? unknown) {
+  if (unknown == null || unknown.isEmpty) return null;
+  return jsonEncode(unknown);
+}
+
+/// Decodes [raw] from DB [syncExtras].
+/// Returns `null` for `null`/invalid/empty input.
+Map<String, dynamic>? decodeSyncExtras(String? raw) {
+  if (raw == null) return null;
+  try {
+    final decoded = jsonDecode(raw);
+    return decoded is Map<String, dynamic> && decoded.isNotEmpty
+        ? decoded
+        : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Captures keys from [json] that are not in [knownKeys].
+/// Returns `null` when no unknown keys are present.
+Map<String, dynamic>? captureSyncUnknown(JsonMap json, Set<String> knownKeys) {
+  final unknownKeys = json.keys.where((k) => !knownKeys.contains(k));
+  final unknown = <String, dynamic>{};
+  var count = 0;
+  for (final k in unknownKeys) {
+    unknown[k] = json[k];
+    count++;
+  }
+  return count > 0 ? unknown : null;
+}
+
+/// Merges [unknown] entries into [target] in-place.
+/// Existing keys win ([putIfAbsent] semantics).
+void mergeSyncUnknown(JsonMap target, Map<String, dynamic>? unknown) {
+  if (unknown == null) return;
+  for (final entry in unknown.entries) {
+    target.putIfAbsent(entry.key, () => entry.value);
+  }
+}
+
 /// Matches a habit JSON file name, e.g. 'habit-xxx-yyy-zzz.json'
 final reAppSyncHabitFileName = RegExp(r'^habit-([^/]+)\.json$');
 
@@ -627,12 +670,7 @@ class WebDavSyncHabitData implements JsonAdaptor {
           : true,
     );
     final data = _$WebDavSyncHabitDataFromJson(json);
-    final unknownKeys = json.keys.where(
-      (k) => !WebDavSyncHabitKeys.allKnownKeys.contains(k),
-    );
-    if (unknownKeys.isNotEmpty) {
-      data.unknown = {for (final k in unknownKeys) k: json[k]};
-    }
+    data.unknown = captureSyncUnknown(json, WebDavSyncHabitKeys.allKnownKeys);
     return data;
   }
 
@@ -672,7 +710,7 @@ class WebDavSyncHabitData implements JsonAdaptor {
       startDate: startDate,
       targetDays: targetDays,
       sortPosition: sortPostion,
-      syncExtras: unknown != null ? jsonEncode(unknown) : null,
+      syncExtras: encodeSyncExtras(unknown),
     );
   }
 
@@ -681,11 +719,7 @@ class WebDavSyncHabitData implements JsonAdaptor {
     final json = _$WebDavSyncHabitDataToJson(this)
       ..[WebDavSyncHabitKey.convertType] = _convertType;
     if (schemaVersion <= 1) json.remove(WebDavSyncHabitKey.schemaVersion);
-    if (unknown != null) {
-      for (final entry in unknown!.entries) {
-        json.putIfAbsent(entry.key, () => entry.value);
-      }
-    }
+    mergeSyncUnknown(json, unknown);
     return json;
   }
 

--- a/lib/models/_app_sync_tasks/webdav_app_sync_models.dart
+++ b/lib/models/_app_sync_tasks/webdav_app_sync_models.dart
@@ -41,15 +41,11 @@ import 'app_sync_task.dart';
 
 part 'webdav_app_sync_models.g.dart';
 
-/// Encodes [unknown] for the DB [syncExtras] column.
-/// Returns `null` when [unknown] is `null` or empty.
 String? encodeSyncExtras(Map<String, dynamic>? unknown) {
   if (unknown == null || unknown.isEmpty) return null;
   return jsonEncode(unknown);
 }
 
-/// Decodes [raw] from DB [syncExtras].
-/// Returns `null` for `null`/invalid/empty input.
 Map<String, dynamic>? decodeSyncExtras(String? raw) {
   if (raw == null) return null;
   try {
@@ -62,8 +58,6 @@ Map<String, dynamic>? decodeSyncExtras(String? raw) {
   }
 }
 
-/// Captures keys from [json] that are not in [knownKeys].
-/// Returns `null` when no unknown keys are present.
 Map<String, dynamic>? captureSyncUnknown(JsonMap json, Set<String> knownKeys) {
   final unknownKeys = json.keys.where((k) => !knownKeys.contains(k));
   final unknown = <String, dynamic>{};
@@ -75,7 +69,6 @@ Map<String, dynamic>? captureSyncUnknown(JsonMap json, Set<String> knownKeys) {
   return count > 0 ? unknown : null;
 }
 
-/// Merges [unknown] entries into [target] in-place.
 /// Existing keys win ([putIfAbsent] semantics).
 void mergeSyncUnknown(JsonMap target, Map<String, dynamic>? unknown) {
   if (unknown == null) return;
@@ -385,9 +378,7 @@ class WebDavSyncRecordData implements JsonAdaptor {
 ///
 /// {@macro habit_color_keys_relationship}
 ///
-/// This class is the single source of truth for JSON key strings. The
-/// sibling enum [WebDavSyncHabitKeys] derives its entries from these
-/// constants so the two are inherently aligned.
+/// Single source of truth for JSON keys; [WebDavSyncHabitKeys] derives from this.
 class WebDavSyncHabitKey {
   static const String uuid = 'uuid';
   static const String createT = 'create_t';
@@ -415,17 +406,8 @@ class WebDavSyncHabitKey {
   static const String schemaVersion = '_schema_version';
 }
 
-/// WebDAV sync keys. Mirrors color-related entries in [HabitDBCellKey]
-/// (`lib/storage/db/handlers/habit.dart`) and `HabitExportDataKey`
-/// (`lib/models/habit_export.dart`).
-///
-/// {@macro habit_color_keys_relationship}
-///
-/// Each entry references the corresponding [WebDavSyncHabitKey] constant so
-/// the enum registry stays in sync with the annotation-level source of truth.
 /// When adding a new sync-payload field, add a static const to
 /// [WebDavSyncHabitKey] first, then add an enum entry here.
-///
 enum WebDavSyncHabitKeys {
   uuid(WebDavSyncHabitKey.uuid),
   createT(WebDavSyncHabitKey.createT),
@@ -456,12 +438,6 @@ enum WebDavSyncHabitKeys {
 
   final String jsonKey;
 
-  /// All JSON keys that the current schema version recognizes.
-  /// Used by [WebDavSyncHabitData.fromJson] to compute the unknown-key bucket.
-  ///
-  /// Derived from the enum registry so it stays aligned with the actual
-  /// serialized shape. When adding a new sync-payload field to
-  /// [WebDavSyncHabitData], add a new enum entry here.
   static final Set<String> allKnownKeys = Set.unmodifiable(
     WebDavSyncHabitKeys.values.map((e) => e.jsonKey),
   );
@@ -561,8 +537,7 @@ class WebDavSyncHabitData implements JsonAdaptor {
   final int? dirty;
   final int? dirtyTotal;
 
-  /// Runtime bucket: carries JSON keys not recognized by the current schema.
-  /// Populated in [fromJson] and merged back in [toJson]; never serialized.
+  /// Runtime bucket for JSON keys not recognized by the current schema.
   @JsonKey(includeFromJson: false, includeToJson: false)
   Map<String, dynamic>? unknown;
 
@@ -582,8 +557,6 @@ class WebDavSyncHabitData implements JsonAdaptor {
         .nonNulls,
   );
 
-  // Non-const because [unknown] is populated post-construction by
-  // [fromJson] — it can't be final, so the constructor can't be const.
   WebDavSyncHabitData({
     this.schemaVersion = 1,
     this.uuid,
@@ -675,13 +648,7 @@ class WebDavSyncHabitData implements JsonAdaptor {
   }
 
   HabitDBCell toHabitDBCell() {
-    // Unlike `fromHabitDBCell`'s `cell.color!` (a locally-saved `HabitDBCell`
-    // always has a non-null `color`, by construction), `color` here comes
-    // from a deserialized sync payload `validate()` only requires `color` to
-    // be in 1-10 *when present* — it never requires `color`/`customColor` to
-    // jointly be non-null. A legacy or malformed payload with both missing
-    // would pass `validate()` but crash on a bare `color!`, so fall back to
-    // `cc1` (the same placeholder used for the custom-color path) instead.
+    // Sync payload may lack color; fall back to cc1 to avoid null crash.
     final habitColor = HabitColor.fromRaw(
       colorType: customColor != null
           ? HabitColorType.cc1

--- a/lib/storage/db/db_helper.dart
+++ b/lib/storage/db/db_helper.dart
@@ -153,6 +153,19 @@ class _DBHelper implements DBHelper {
         );
       }
     }
+    if (oldVersion < 6) {
+      final tableInfo = await db.rawQuery(
+        'PRAGMA table_info(${TableName.habits})',
+      );
+      if (!tableInfo.any(
+        (column) => column['name'] == HabitDBCellKey.syncExtras,
+      )) {
+        await db.execute(
+          "ALTER TABLE ${TableName.habits} "
+          "ADD COLUMN ${HabitDBCellKey.syncExtras} TEXT",
+        );
+      }
+    }
   }
 
   Future<Database> _openDB(String dbPath) async {

--- a/lib/storage/db/handlers/habit.dart
+++ b/lib/storage/db/handlers/habit.dart
@@ -65,6 +65,7 @@ class HabitDBCellKey {
   static const String remindCustom = 'remind_cutsom';
   static const String remindQuestion = 'remind_question';
   static const String sortPosition = 'sort_position';
+  static const String syncExtras = 'sync_extras';
 
   /// `color`/`customColor`/`customColorTinted` always travel together as one
   /// semantic unit: a habit's color is either a built-in `color` code, or a
@@ -130,6 +131,8 @@ class HabitDBCell with DBCell {
   final String? remindQuestion;
   @JsonKey(name: HabitDBCellKey.sortPosition)
   final HabitSortPostion? sortPosition;
+  @JsonKey(name: HabitDBCellKey.syncExtras)
+  final String? syncExtras;
 
   const HabitDBCell({
     this.id,
@@ -153,6 +156,7 @@ class HabitDBCell with DBCell {
     this.remindCustom,
     this.remindQuestion,
     this.sortPosition,
+    this.syncExtras,
   });
 
   factory HabitDBCell.fromJson(Map<String, Object?> cell) =>

--- a/lib/storage/db/handlers/habit.g.dart
+++ b/lib/storage/db/handlers/habit.g.dart
@@ -38,6 +38,7 @@ abstract class _$HabitDBCellCWProxy {
     String? remindCustom,
     String? remindQuestion,
     HabitSortPostion? sortPosition,
+    String? syncExtras,
   });
 }
 
@@ -78,6 +79,7 @@ class _$HabitDBCellCWProxyImpl implements _$HabitDBCellCWProxy {
     Object? remindCustom = const $CopyWithPlaceholder(),
     Object? remindQuestion = const $CopyWithPlaceholder(),
     Object? sortPosition = const $CopyWithPlaceholder(),
+    Object? syncExtras = const $CopyWithPlaceholder(),
   }) {
     return HabitDBCell(
       id: id == const $CopyWithPlaceholder()
@@ -164,6 +166,10 @@ class _$HabitDBCellCWProxyImpl implements _$HabitDBCellCWProxy {
           ? _value.sortPosition
           // ignore: cast_nullable_to_non_nullable
           : sortPosition as HabitSortPostion?,
+      syncExtras: syncExtras == const $CopyWithPlaceholder()
+          ? _value.syncExtras
+          // ignore: cast_nullable_to_non_nullable
+          : syncExtras as String?,
     );
   }
 }
@@ -201,6 +207,7 @@ HabitDBCell _$HabitDBCellFromJson(Map<String, dynamic> json) => HabitDBCell(
   remindCustom: json['remind_cutsom'] as String?,
   remindQuestion: json['remind_question'] as String?,
   sortPosition: json['sort_position'] as num?,
+  syncExtras: json['sync_extras'] as String?,
 );
 
 Map<String, dynamic> _$HabitDBCellToJson(HabitDBCell instance) =>
@@ -226,4 +233,5 @@ Map<String, dynamic> _$HabitDBCellToJson(HabitDBCell instance) =>
       'remind_cutsom': ?instance.remindCustom,
       'remind_question': ?instance.remindQuestion,
       'sort_position': ?instance.sortPosition,
+      'sync_extras': ?instance.syncExtras,
     };

--- a/lib/storage/db/handlers/sync.dart
+++ b/lib/storage/db/handlers/sync.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
 import 'package:collection/collection.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -506,13 +508,18 @@ class SyncDBHelper extends DBHelperHandler {
             final dirtyTotal = result[dirtyTotalKey] as int?;
             final lastMarkId = result[lastMarkKey] as String?;
             final lastConfigId = result[configIdKey] as String?;
+            final cell = HabitDBCell.fromJson(result);
+            final unknown = cell.syncExtras != null
+                ? jsonDecode(cell.syncExtras!) as Map<String, dynamic>?
+                : null;
             return WebDavSyncHabitData.fromHabitDBCell(
-              HabitDBCell.fromJson(result),
+              cell,
               dirty: dirty,
               dirtyTotal: dirtyTotal,
               sessionId: ((dirty ?? 0) > 0 || lastConfigId != configId)
                   ? sessionId
                   : lastMarkId,
+              unknown: unknown,
             );
           });
       if (!withRecords || habit == null) return habit;
@@ -543,13 +550,18 @@ class SyncDBHelper extends DBHelperHandler {
               );
             }),
           );
-      return habit.copyWith(
+      final unknown = habit.unknown;
+      final result = habit.copyWith(
         records: Map.fromEntries(
           records
               .map((e) => e.uuid != null ? MapEntry(e.uuid!, e) : null)
               .nonNulls,
         ),
       );
+      if (unknown != null && unknown.isNotEmpty) {
+        result.unknown = unknown;
+      }
+      return result;
     });
   }
 

--- a/lib/storage/db/handlers/sync.dart
+++ b/lib/storage/db/handlers/sync.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:convert';
-
 import 'package:collection/collection.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -509,9 +507,7 @@ class SyncDBHelper extends DBHelperHandler {
             final lastMarkId = result[lastMarkKey] as String?;
             final lastConfigId = result[configIdKey] as String?;
             final cell = HabitDBCell.fromJson(result);
-            final unknown = cell.syncExtras != null
-                ? jsonDecode(cell.syncExtras!) as Map<String, dynamic>?
-                : null;
+            final unknown = decodeSyncExtras(cell.syncExtras);
             return WebDavSyncHabitData.fromHabitDBCell(
               cell,
               dirty: dirty,

--- a/lib/storage/db/handlers/sync.dart
+++ b/lib/storage/db/handlers/sync.dart
@@ -274,9 +274,16 @@ class SyncDBHelper extends DBHelperHandler {
     int syncCount = 0;
     if (habitSyncInfo.lastMark != data.sessionId) {
       if (habitSyncInfo.lastSesionUUID != data.sessionId) {
+        final habitDbMap = data
+            .toHabitDBCell()
+            .copyWith(id: null, uuid: null)
+            .toJson();
+        if (data.unknown == null || data.unknown!.isEmpty) {
+          habitDbMap[HabitDBCellKey.syncExtras] = null;
+        }
         count += await db.update(
           TableName.habits,
-          data.toHabitDBCell().copyWith(id: null, uuid: null).toJson(),
+          habitDbMap,
           where: "${HabitDBCellKey.uuid} = ?",
           whereArgs: [habitUUID],
         );

--- a/test/unit/models/webdav_app_sync_models_test.dart
+++ b/test/unit/models/webdav_app_sync_models_test.dart
@@ -47,6 +47,9 @@ Map<String, Object?> _legacyToJson(HabitDBCell cell) => {
   'color': cell.color,
 };
 
+String? _futureGroupIdFromJson(Map<String, Object?> json) =>
+    json['group_id'] as String?;
+
 void main() {
   group('WebDavSyncHabitData custom_color', () {
     test('fromJson on legacy payload without custom_color key', () {
@@ -373,6 +376,25 @@ void main() {
         'a': 1,
         'b': [2, 3],
       });
+    });
+
+    test('future field survives old-schema forwarder round-trip', () {
+      final serverPayload = {
+        '_convert_type': 'habit_',
+        'uuid': 'future-forward-uuid',
+        'color': HabitColorType.cc6.dbCode,
+        'group_id': 'future-group',
+      };
+
+      final oldSchemaClient = WebDavSyncHabitData.fromJson(serverPayload);
+      final cell = oldSchemaClient.toHabitDBCell();
+      final forwarded = WebDavSyncHabitData.fromHabitDBCell(
+        cell,
+        unknown: decodeSyncExtras(cell.syncExtras),
+      ).toJson();
+
+      expect(forwarded['group_id'], 'future-group');
+      expect(_futureGroupIdFromJson(forwarded), 'future-group');
     });
   });
 

--- a/test/unit/models/webdav_app_sync_models_test.dart
+++ b/test/unit/models/webdav_app_sync_models_test.dart
@@ -407,8 +407,6 @@ void main() {
           WebDavSyncHabitKey.schemaVersion,
         };
 
-        // 1:1 count check — if this fails, an enum entry or class const was
-        // added/removed on only one side.
         expect(
           classKeyValues.length,
           WebDavSyncHabitKeys.values.length,
@@ -416,9 +414,6 @@ void main() {
               'WebDavSyncHabitKey and WebDavSyncHabitKeys are out of sync — '
               'did you forget to add/remove a constant on both sides?',
         );
-
-        // Value alignment check — each class const derives from the enum so
-        // values must match.
         expect(classKeyValues, WebDavSyncHabitKeys.allKnownKeys);
       },
     );
@@ -472,7 +467,6 @@ void main() {
       expect(data.unknown, isNotNull);
       expect(data.unknown!['group_id'], 'g-inject');
       expect(data.unknown!['extra'], true);
-      // toJson includes unknown fields
       final json = data.toJson();
       expect(json['group_id'], 'g-inject');
       expect(json['extra'], true);
@@ -507,16 +501,11 @@ void main() {
         unknown: unknown,
       );
 
-      // Known fields preserved
       expect(restored.uuid, 'full-roundtrip');
       expect(restored.name, 'Original');
-
-      // Unknown fields preserved
       expect(restored.unknown, isNotNull);
       expect(restored.unknown!['group_id'], 'g-full');
       expect(restored.unknown!['custom_attr'], [1, 2, 3]);
-
-      // Restored toJson includes unknown fields
       final restoredJson = restored.toJson();
       expect(restoredJson['group_id'], 'g-full');
       expect(restoredJson['custom_attr'], [1, 2, 3]);

--- a/test/unit/models/webdav_app_sync_models_test.dart
+++ b/test/unit/models/webdav_app_sync_models_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mhabit/models/_app_sync_tasks/webdav_app_sync_models.dart';
 import 'package:mhabit/models/habit_form.dart';
@@ -186,12 +188,12 @@ void main() {
     });
 
     test('toJson omits _schema_version when schemaVersion == 1', () {
-      const data = WebDavSyncHabitData(schemaVersion: 1);
+      final data = WebDavSyncHabitData(schemaVersion: 1);
       expect(data.toJson(), isNot(contains('_schema_version')));
     });
 
     test('toJson includes _schema_version when schemaVersion >= 2', () {
-      const data = WebDavSyncHabitData(
+      final data = WebDavSyncHabitData(
         schemaVersion: WebDavSyncHabitData.currentSchemaVersion,
       );
       expect(data.toJson()['_schema_version'], 2);
@@ -204,7 +206,7 @@ void main() {
     });
 
     test('validate() does not throw for a future schema version', () {
-      const data = WebDavSyncHabitData(schemaVersion: 99);
+      final data = WebDavSyncHabitData(schemaVersion: 99);
       expect(data.validate, returnsNormally);
     });
   });
@@ -281,6 +283,217 @@ void main() {
       expect(redownloaded.customColor, isNull);
       expect(redownloaded.schemaVersion, 1);
       expect(redownloaded.validate, returnsNormally);
+    });
+  });
+
+  group('WebDavSyncHabitData _unknown bucket', () {
+    test('fromJson captures unknown keys into _unknown', () {
+      final data = WebDavSyncHabitData.fromJson({
+        '_convert_type': 'habit_',
+        'color': HabitColorType.cc3.dbCode,
+        'group_id': 'g-abc-123',
+        'future_field': 42,
+      });
+      expect(data.unknown, isNotNull);
+      expect(data.unknown!['group_id'], 'g-abc-123');
+      expect(data.unknown!['future_field'], 42);
+    });
+
+    test('fromJson with only known keys leaves _unknown null', () {
+      final data = WebDavSyncHabitData.fromJson({
+        '_convert_type': 'habit_',
+        'color': HabitColorType.cc5.dbCode,
+        'uuid': 'test-uuid',
+        'name': 'Test Habit',
+      });
+      expect(data.unknown, isNull);
+    });
+
+    test('toJson merges _unknown back into output', () {
+      final data = WebDavSyncHabitData.fromJson({
+        '_convert_type': 'habit_',
+        'color': HabitColorType.cc3.dbCode,
+        'uuid': 'test-uuid',
+        'group_id': 'g-xyz',
+        'future_field': 'hello',
+      });
+      final json = data.toJson();
+      expect(json['group_id'], 'g-xyz');
+      expect(json['future_field'], 'hello');
+    });
+
+    test('known field wins over _unknown in toJson', () {
+      final data = WebDavSyncHabitData.fromJson({
+        '_convert_type': 'habit_',
+        'color': HabitColorType.cc4.dbCode,
+        'uuid': 'test-uuid',
+      });
+      data.unknown = {'uuid': 'evil-override', 'group_id': 'g-ok'};
+      final json = data.toJson();
+      expect(json['uuid'], 'test-uuid');
+      expect(json['group_id'], 'g-ok');
+    });
+
+    test('_unknown does not appear as a JSON key', () {
+      final data = WebDavSyncHabitData.fromJson({
+        '_convert_type': 'habit_',
+        'color': HabitColorType.cc2.dbCode,
+        'group_id': 'g-test',
+      });
+      final json = data.toJson();
+      expect(json.containsKey('_unknown'), isFalse);
+    });
+
+    test('empty _unknown map is no-op in toJson', () {
+      final data = WebDavSyncHabitData.fromJson({
+        '_convert_type': 'habit_',
+        'color': HabitColorType.cc3.dbCode,
+      });
+      data.unknown = {};
+      final json = data.toJson();
+      expect(json['color'], HabitColorType.cc3.dbCode);
+      expect(json.length, greaterThanOrEqualTo(2));
+    });
+
+    test('_unknown survives fromJson → toJson round-trip', () {
+      final originalJson = {
+        '_convert_type': 'habit_',
+        'color': HabitColorType.cc6.dbCode,
+        'uuid': 'roundtrip-uuid',
+        'name': 'Roundtrip',
+        'group_id': 'g-roundtrip',
+        'extra_nested': {
+          'a': 1,
+          'b': [2, 3],
+        },
+      };
+      final data = WebDavSyncHabitData.fromJson(originalJson);
+      final roundtripped = WebDavSyncHabitData.fromJson(data.toJson());
+      expect(roundtripped.unknown, isNotNull);
+      expect(roundtripped.unknown!['group_id'], 'g-roundtrip');
+      expect(roundtripped.unknown!['extra_nested'], {
+        'a': 1,
+        'b': [2, 3],
+      });
+    });
+  });
+
+  group('WebDavSyncHabitKey.allKnownKeys', () {
+    test('allKnownKeys includes every WebDavSyncHabitData JSON key', () {
+      expect(
+        WebDavSyncHabitKeys.allKnownKeys,
+        containsAll([
+          WebDavSyncHabitKey.uuid,
+          WebDavSyncHabitKey.name,
+          WebDavSyncHabitKey.color,
+          WebDavSyncHabitKey.customColor,
+          WebDavSyncHabitKey.records,
+          WebDavSyncHabitKey.sessionId,
+          WebDavSyncHabitKey.convertType,
+          WebDavSyncHabitKey.schemaVersion,
+        ]),
+      );
+    });
+
+    test('key missing from allKnownKeys is captured by _unknown', () {
+      final knownKeySet = WebDavSyncHabitKeys.allKnownKeys;
+      const nonexistentKey = '_this_key_definitely_does_not_exist_';
+      expect(knownKeySet.contains(nonexistentKey), isFalse);
+
+      final data = WebDavSyncHabitData.fromJson({
+        '_convert_type': 'habit_',
+        nonexistentKey: 'surprise',
+      });
+      expect(data.unknown, isNotNull);
+      expect(data.unknown![nonexistentKey], 'surprise');
+    });
+  });
+
+  group('WebDavSyncHabitData syncExtras cell round-trip', () {
+    test('toHabitDBCell encodes _unknown into syncExtras', () {
+      final data = WebDavSyncHabitData.fromJson({
+        '_convert_type': 'habit_',
+        'color': HabitColorType.cc3.dbCode,
+        'uuid': 'test-uuid',
+        'group_id': 'g-encode',
+      });
+      final cell = data.toHabitDBCell();
+      expect(cell.syncExtras, isNotNull);
+      expect(cell.syncExtras, contains('group_id'));
+      expect(cell.syncExtras, contains('g-encode'));
+    });
+
+    test('toHabitDBCell with null _unknown sets syncExtras to null', () {
+      final data = WebDavSyncHabitData.fromJson({
+        '_convert_type': 'habit_',
+        'color': HabitColorType.cc4.dbCode,
+        'uuid': 'no-unknown',
+      });
+      final cell = data.toHabitDBCell();
+      expect(cell.syncExtras, isNull);
+    });
+
+    test('fromHabitDBCell with unknown injects _unknown', () {
+      final cell = HabitDBCell(
+        uuid: 'test-uuid',
+        color: HabitColorType.cc4.dbCode,
+        syncExtras: '{"group_id":"g-inject","extra":true}',
+      );
+      final unknown = jsonDecode(cell.syncExtras!) as Map<String, dynamic>;
+      final data = WebDavSyncHabitData.fromHabitDBCell(cell, unknown: unknown);
+      expect(data.unknown, isNotNull);
+      expect(data.unknown!['group_id'], 'g-inject');
+      expect(data.unknown!['extra'], true);
+      // toJson includes unknown fields
+      final json = data.toJson();
+      expect(json['group_id'], 'g-inject');
+      expect(json['extra'], true);
+    });
+
+    test('fromHabitDBCell without unknown leaves _unknown null', () {
+      final cell = HabitDBCell(
+        uuid: 'test-uuid',
+        color: HabitColorType.cc5.dbCode,
+      );
+      final data = WebDavSyncHabitData.fromHabitDBCell(cell);
+      expect(data.unknown, isNull);
+    });
+
+    test('full cell round-trip preserves unknown fields', () {
+      final original = WebDavSyncHabitData.fromJson({
+        '_convert_type': 'habit_',
+        'color': HabitColorType.cc2.dbCode,
+        'uuid': 'full-roundtrip',
+        'name': 'Original',
+        'group_id': 'g-full',
+        'custom_attr': [1, 2, 3],
+      });
+
+      // toHabitDBCell → decode syncExtras
+      final cell = original.toHabitDBCell();
+      final unknown = cell.syncExtras != null
+          ? jsonDecode(cell.syncExtras!) as Map<String, dynamic>
+          : null;
+
+      // fromHabitDBCell with unknown
+      final restored = WebDavSyncHabitData.fromHabitDBCell(
+        cell,
+        unknown: unknown,
+      );
+
+      // Known fields preserved
+      expect(restored.uuid, 'full-roundtrip');
+      expect(restored.name, 'Original');
+
+      // Unknown fields preserved
+      expect(restored.unknown, isNotNull);
+      expect(restored.unknown!['group_id'], 'g-full');
+      expect(restored.unknown!['custom_attr'], [1, 2, 3]);
+
+      // Restored toJson includes unknown fields
+      final restoredJson = restored.toJson();
+      expect(restoredJson['group_id'], 'g-full');
+      expect(restoredJson['custom_attr'], [1, 2, 3]);
     });
   });
 }

--- a/test/unit/models/webdav_app_sync_models_test.dart
+++ b/test/unit/models/webdav_app_sync_models_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:convert';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mhabit/models/_app_sync_tasks/webdav_app_sync_models.dart';
 import 'package:mhabit/models/habit_form.dart';
@@ -469,7 +467,7 @@ void main() {
         color: HabitColorType.cc4.dbCode,
         syncExtras: '{"group_id":"g-inject","extra":true}',
       );
-      final unknown = jsonDecode(cell.syncExtras!) as Map<String, dynamic>;
+      final unknown = decodeSyncExtras(cell.syncExtras)!;
       final data = WebDavSyncHabitData.fromHabitDBCell(cell, unknown: unknown);
       expect(data.unknown, isNotNull);
       expect(data.unknown!['group_id'], 'g-inject');
@@ -501,9 +499,7 @@ void main() {
 
       // toHabitDBCell → decode syncExtras
       final cell = original.toHabitDBCell();
-      final unknown = cell.syncExtras != null
-          ? jsonDecode(cell.syncExtras!) as Map<String, dynamic>
-          : null;
+      final unknown = decodeSyncExtras(cell.syncExtras);
 
       // fromHabitDBCell with unknown
       final restored = WebDavSyncHabitData.fromHabitDBCell(

--- a/test/unit/models/webdav_app_sync_models_test.dart
+++ b/test/unit/models/webdav_app_sync_models_test.dart
@@ -378,22 +378,52 @@ void main() {
     });
   });
 
-  group('WebDavSyncHabitKey.allKnownKeys', () {
-    test('allKnownKeys includes every WebDavSyncHabitData JSON key', () {
-      expect(
-        WebDavSyncHabitKeys.allKnownKeys,
-        containsAll([
+  group('WebDavSyncHabitKey ↔ WebDavSyncHabitKeys alignment', () {
+    test(
+      'every WebDavSyncHabitKeys entry has a matching WebDavSyncHabitKey const',
+      () {
+        const classKeyValues = <String>{
           WebDavSyncHabitKey.uuid,
+          WebDavSyncHabitKey.createT,
+          WebDavSyncHabitKey.modifyT,
+          WebDavSyncHabitKey.type,
+          WebDavSyncHabitKey.status,
           WebDavSyncHabitKey.name,
+          WebDavSyncHabitKey.desc,
           WebDavSyncHabitKey.color,
           WebDavSyncHabitKey.customColor,
-          WebDavSyncHabitKey.records,
+          WebDavSyncHabitKey.customColorTinted,
+          WebDavSyncHabitKey.dailyGoal,
+          WebDavSyncHabitKey.dailyGoalUnit,
+          WebDavSyncHabitKey.dailyGoalExtra,
+          WebDavSyncHabitKey.freqType,
+          WebDavSyncHabitKey.freqCustom,
+          WebDavSyncHabitKey.reminder,
+          WebDavSyncHabitKey.reminderQuest,
+          WebDavSyncHabitKey.startDate,
+          WebDavSyncHabitKey.targetDays,
+          WebDavSyncHabitKey.sortPosition,
           WebDavSyncHabitKey.sessionId,
+          WebDavSyncHabitKey.records,
           WebDavSyncHabitKey.convertType,
           WebDavSyncHabitKey.schemaVersion,
-        ]),
-      );
-    });
+        };
+
+        // 1:1 count check — if this fails, an enum entry or class const was
+        // added/removed on only one side.
+        expect(
+          classKeyValues.length,
+          WebDavSyncHabitKeys.values.length,
+          reason:
+              'WebDavSyncHabitKey and WebDavSyncHabitKeys are out of sync — '
+              'did you forget to add/remove a constant on both sides?',
+        );
+
+        // Value alignment check — each class const derives from the enum so
+        // values must match.
+        expect(classKeyValues, WebDavSyncHabitKeys.allKnownKeys);
+      },
+    );
 
     test('key missing from allKnownKeys is captured by _unknown', () {
       final knownKeySet = WebDavSyncHabitKeys.allKnownKeys;

--- a/test/unit/storage/db/sync_roundtrip_test.dart
+++ b/test/unit/storage/db/sync_roundtrip_test.dart
@@ -180,12 +180,9 @@ void main() {
       expect(restored!.uuid, 'full-db-roundtrip');
       expect(restored.name, 'Original');
 
-      // Unknown fields survived the DB round-trip
       expect(restored.unknown, isNotNull);
       expect(restored.unknown!['group_id'], 'g-full');
       expect(restored.unknown!['custom_attr'], [1, 2, 3]);
-
-      // toJson includes unknown fields
       final restoredJson = restored.toJson();
       expect(restoredJson['group_id'], 'g-full');
       expect(restoredJson['custom_attr'], [1, 2, 3]);

--- a/test/unit/storage/db/sync_roundtrip_test.dart
+++ b/test/unit/storage/db/sync_roundtrip_test.dart
@@ -187,5 +187,85 @@ void main() {
       expect(restoredJson['group_id'], 'g-full');
       expect(restoredJson['custom_attr'], [1, 2, 3]);
     });
+
+    test('second download without unknown clears stale sync_extras', () async {
+      final firstDownload = WebDavSyncHabitData.fromJson({
+        ..._basePayload('clear-stale-uuid', 'Stale Extras'),
+        'sessionId': 'server-session-1',
+        'group_id': 'g-stale',
+      });
+      await syncHelper.syncHabitDataToDb(firstDownload);
+
+      final secondDownload = WebDavSyncHabitData.fromJson({
+        ..._basePayload('clear-stale-uuid', 'Stale Extras'),
+        'sessionId': 'server-session-2',
+      });
+      await syncHelper.syncHabitDataToDb(secondDownload);
+
+      final rows = await viewModel.local.db.rawQuery(
+        'SELECT sync_extras FROM mh_habits WHERE uuid = ?',
+        ['clear-stale-uuid'],
+      );
+      expect(rows, hasLength(1));
+      expect(rows.first['sync_extras'], isNull);
+
+      final restored = await syncHelper.loadHabitDataFromBb(
+        'clear-stale-uuid',
+        withRecords: false,
+        configId: 'test-config',
+        sessionId: 'test-session',
+      );
+
+      expect(restored, isNotNull);
+      expect(restored!.unknown, isNull);
+      expect(restored.toJson().containsKey('group_id'), isFalse);
+    });
+
+    test('second download with partial unknown prunes removed fields', () async {
+      // First download: two unknown fields.
+      final firstDownload = WebDavSyncHabitData.fromJson({
+        ..._basePayload('partial-prune-uuid', 'Partial Prune'),
+        'sessionId': 'server-session-1',
+        'removed_field': 'will-go',
+        'kept_field': 99,
+      });
+      await syncHelper.syncHabitDataToDb(firstDownload);
+
+      // Second download: 'removed_field' is gone from server, 'kept_field' remains.
+      final secondDownload = WebDavSyncHabitData.fromJson({
+        ..._basePayload('partial-prune-uuid', 'Partial Prune'),
+        'sessionId': 'server-session-2',
+        'kept_field': 99,
+      });
+      await syncHelper.syncHabitDataToDb(secondDownload);
+
+      final rows = await viewModel.local.db.rawQuery(
+        'SELECT sync_extras FROM mh_habits WHERE uuid = ?',
+        ['partial-prune-uuid'],
+      );
+      expect(rows, hasLength(1));
+      final extrasJson = rows.first['sync_extras'] as String?;
+      expect(extrasJson, isNotNull);
+      final extras = jsonDecode(extrasJson!) as Map<String, dynamic>;
+      expect(extras, hasLength(1));
+      expect(extras['kept_field'], 99);
+      expect(extras.containsKey('removed_field'), isFalse);
+
+      final restored = await syncHelper.loadHabitDataFromBb(
+        'partial-prune-uuid',
+        withRecords: false,
+        configId: 'test-config',
+        sessionId: 'test-session',
+      );
+
+      expect(restored, isNotNull);
+      expect(restored!.unknown, isNotNull);
+      expect(restored.unknown!.containsKey('removed_field'), isFalse);
+      expect(restored.unknown!['kept_field'], 99);
+
+      final restoredJson = restored.toJson();
+      expect(restoredJson.containsKey('removed_field'), isFalse);
+      expect(restoredJson['kept_field'], 99);
+    });
   });
 }

--- a/test/unit/storage/db/sync_roundtrip_test.dart
+++ b/test/unit/storage/db/sync_roundtrip_test.dart
@@ -14,6 +14,7 @@
 
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mhabit/models/_app_sync_tasks/webdav_app_sync_models.dart';
 import 'package:mhabit/models/habit_form.dart';
@@ -53,12 +54,14 @@ void main() {
     late SyncDBHelper syncHelper;
 
     setUp(() async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
       viewModel = DBHelperViewModel();
       await viewModel.init();
       syncHelper = SyncDBHelper(viewModel.local);
     });
 
     tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
       viewModel.dispose();
     });
 

--- a/test/unit/storage/db/sync_roundtrip_test.dart
+++ b/test/unit/storage/db/sync_roundtrip_test.dart
@@ -1,0 +1,191 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mhabit/models/_app_sync_tasks/webdav_app_sync_models.dart';
+import 'package:mhabit/models/habit_form.dart';
+import 'package:mhabit/storage/db/handlers/sync.dart';
+import 'package:mhabit/storage/db_helper_provider.dart';
+
+/// Minimum required fields for [WebDavSyncHabitData.fromJson] to produce a
+/// valid [HabitDBCell] that satisfies DB NOT NULL constraints.
+Map<String, Object?> _basePayload(String uuid, String name) => {
+  '_convert_type': 'habit_',
+  'uuid': uuid,
+  'name': name,
+  'color': HabitColorType.cc3.dbCode,
+  'type': 0,
+  'status': 0,
+  'daily_goal': 1,
+  'daily_goal_unit': 'times',
+  'start_date': 1,
+};
+
+/// Minimum columns required for a raw SQL insert into mh_habits.
+Map<String, Object?> _baseDbRow(String uuid, String name) => {
+  'uuid': uuid,
+  'name': name,
+  'color': HabitColorType.cc3.dbCode,
+  'type_': 0,
+  'status': 0,
+  'daily_goal': 1,
+  'daily_goal_unit': 'times',
+  'start_date': 1,
+  'sort_position': 1,
+};
+
+void main() {
+  group('Sync round-trip DB integration', () {
+    late DBHelperViewModel viewModel;
+    late SyncDBHelper syncHelper;
+
+    setUp(() async {
+      viewModel = DBHelperViewModel();
+      await viewModel.init();
+      syncHelper = SyncDBHelper(viewModel.local);
+    });
+
+    tearDown(() {
+      viewModel.dispose();
+    });
+
+    test('syncHabitDataToDb stores unknown in sync_extras column', () async {
+      final data = WebDavSyncHabitData.fromJson({
+        ..._basePayload('download-test-uuid', 'Download Test'),
+        'group_id': 'g-db-test',
+        'future_field': 42,
+      });
+
+      await syncHelper.syncHabitDataToDb(data);
+
+      final rows = await viewModel.local.db.rawQuery(
+        'SELECT sync_extras FROM mh_habits WHERE uuid = ?',
+        ['download-test-uuid'],
+      );
+      expect(rows, hasLength(1));
+      final extrasJson = rows.first['sync_extras'] as String?;
+      expect(extrasJson, isNotNull);
+      final extras = jsonDecode(extrasJson!) as Map<String, dynamic>;
+      expect(extras['group_id'], 'g-db-test');
+      expect(extras['future_field'], 42);
+    });
+
+    test(
+      'syncHabitDataToDb with no unknown sets sync_extras to NULL',
+      () async {
+        final data = WebDavSyncHabitData.fromJson(
+          _basePayload('no-unknown-uuid', 'No Unknown'),
+        );
+
+        await syncHelper.syncHabitDataToDb(data);
+
+        final rows = await viewModel.local.db.rawQuery(
+          'SELECT sync_extras FROM mh_habits WHERE uuid = ?',
+          ['no-unknown-uuid'],
+        );
+        expect(rows, hasLength(1));
+        expect(rows.first['sync_extras'], isNull);
+      },
+    );
+
+    test('loadHabitDataFromBb passes syncExtras as unknown', () async {
+      // Seed: insert habit + sync row directly via raw SQL
+      await viewModel.local.db.insert('mh_habits', {
+        ..._baseDbRow('upload-test-uuid', 'Upload Test'),
+        'sync_extras': jsonEncode({'group_id': 'g-upload', 'extra': 42}),
+      });
+      await viewModel.local.db.insert('mh_sync', {
+        'habit_uuid': 'upload-test-uuid',
+        'dirty': 0,
+        'dirty_total': 0,
+      });
+
+      final data = await syncHelper.loadHabitDataFromBb(
+        'upload-test-uuid',
+        withRecords: false,
+        configId: 'test-config',
+        sessionId: 'test-session',
+      );
+
+      expect(data, isNotNull);
+      expect(data!.unknown, isNotNull);
+      expect(data.unknown!['group_id'], 'g-upload');
+      expect(data.unknown!['extra'], 42);
+
+      final json = data.toJson();
+      expect(json['group_id'], 'g-upload');
+      expect(json['extra'], 42);
+    });
+
+    test(
+      'loadHabitDataFromBb with null syncExtras returns null unknown',
+      () async {
+        await viewModel.local.db.insert('mh_habits', {
+          ..._baseDbRow('null-extras-uuid', 'Null Extras'),
+          'sync_extras': null,
+        });
+        await viewModel.local.db.insert('mh_sync', {
+          'habit_uuid': 'null-extras-uuid',
+          'dirty': 0,
+          'dirty_total': 0,
+        });
+
+        final data = await syncHelper.loadHabitDataFromBb(
+          'null-extras-uuid',
+          withRecords: false,
+          configId: 'test-config',
+          sessionId: 'test-session',
+        );
+
+        expect(data, isNotNull);
+        expect(data!.unknown, isNull);
+      },
+    );
+
+    test('full DB round-trip preserves unknown fields', () async {
+      final original = WebDavSyncHabitData.fromJson({
+        ..._basePayload('full-db-roundtrip', 'Original'),
+        'group_id': 'g-full',
+        'custom_attr': [1, 2, 3],
+      });
+
+      // Download path: write to DB
+      await syncHelper.syncHabitDataToDb(original);
+
+      // Upload path: read back from DB
+      final restored = await syncHelper.loadHabitDataFromBb(
+        'full-db-roundtrip',
+        withRecords: false,
+        configId: 'test-config',
+        sessionId: 'test-session',
+      );
+
+      expect(restored, isNotNull);
+      expect(restored!.uuid, 'full-db-roundtrip');
+      expect(restored.name, 'Original');
+
+      // Unknown fields survived the DB round-trip
+      expect(restored.unknown, isNotNull);
+      expect(restored.unknown!['group_id'], 'g-full');
+      expect(restored.unknown!['custom_attr'], [1, 2, 3]);
+
+      // toJson includes unknown fields
+      final restoredJson = restored.toJson();
+      expect(restoredJson['group_id'], 'g-full');
+      expect(restoredJson['custom_attr'], [1, 2, 3]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
This PR adds end-to-end unknown-field preservation for habit WebDAV sync payloads so older clients do not drop fields introduced by newer clients during full-file upload round-trips.

## What changed
- Added `sync_extras` to the habits table schema and upgraded DB version from v5 to v6.
- Added v5->v6 migration in DB upgrade logic with column-existence guard.
- Extended `HabitDBCell` with `syncExtras` mapping.
- Added runtime unknown-field bucket handling in `WebDavSyncHabitData`:
  - capture unknown keys in `fromJson`
  - merge unknown keys back in `toJson`
  - support DB round-trip via `fromHabitDBCell(..., unknown:)` and `toHabitDBCell()`
- Wired upload/download DB path in `SyncDBHelper.loadHabitDataFromBb`:
  - decode `sync_extras`
  - inject unknown bucket
  - preserve unknown bucket after `copyWith(records: ...)`
- Added tests:
  - model tests for unknown-bucket behavior and round-trip
  - DB integration tests for sync_extras write/read and full DB round-trip

## Why
Without this, older app versions can overwrite server payloads and silently lose fields they do not recognize.

## Verification
- `make aio`
- `make test` (612 tests passed)

## Scope
This PR focuses on habit sync unknown-field round-trip safety and its DB persistence path only.