### PR TITLE
fix: replace regex-based beta heading matching with AST prefix matching

### DIFF
--- a/lib/pages/app_about/_widgets/app_about_version_tile.dart
+++ b/lib/pages/app_about/_widgets/app_about_version_tile.dart
@@ -48,7 +48,11 @@ class _AppAboutVersionTileState extends State<AppAboutVersionTile> {
     if (!mounted) return;
 
     final version = AppInfo().changelogVersion;
-    final section = extractVersionSectionWithFallback(content, version);
+    final section = extractVersionSectionWithFallback(
+      content,
+      version,
+      useLatestFallback: true,
+    );
     final fullChangelog = stripChangelogPreamble(content);
 
     if (!mounted) return;

--- a/lib/pages/app_changelog/changelog_parser.dart
+++ b/lib/pages/app_changelog/changelog_parser.dart
@@ -135,13 +135,26 @@ String? extractVersionSectionWithFallback(String content, String version) {
   };
 }
 
-// Looks for a CHANGELOG h2 heading that starts with [base]-.
+// Looks for a CHANGELOG h2 heading that starts with [base]- and returns
+// the section body rendered back to markdown.
+//
+// Unlike the old regex-based implementation, this performs prefix matching
+// directly against the markdown AST, avoiding consistency issues between
+// regex-captured text and AST-extracted text (which can differ on some
+// platforms or when the file contains invisible characters).
 String? _tryBetaHeading(String content, String base) {
-  final m = RegExp(
-    '^## +(${RegExp.escape(base)}-\\w+)',
-    multiLine: true,
-  ).firstMatch(content);
-  return m != null ? extractVersionSection(content, m.group(1)!) : null;
+  final nodes = md.Document().parse(content);
+  final prefix = '$base-';
+  for (var i = 0; i < nodes.length; i++) {
+    final node = nodes[i];
+    if (node case md.Element(tag: 'h2')) {
+      final text = node.textContent.trim();
+      if (!text.startsWith(prefix)) continue;
+      final bodyNodes = _collectSectionNodes(nodes, i + 1);
+      return _renderNodesToMarkdown(bodyNodes);
+    }
+  }
+  return null;
 }
 
 /// Strips the preamble (title, links) from raw CHANGELOG.md [content],

--- a/lib/pages/app_changelog/changelog_parser.dart
+++ b/lib/pages/app_changelog/changelog_parser.dart
@@ -170,7 +170,7 @@ String? extractVersionSectionWithFallback(
   if (strippedResult != null) return strippedResult;
 
   // 3. Semver-only match (ignores build number).
-  final semverResult = _tryMatchBySemver(content, version);
+  final semverResult = _tryMatchBySemver(content, base);
   if (semverResult != null) return semverResult;
 
   // 4. Ultimate fallback (manual triggers only).

--- a/lib/pages/app_changelog/changelog_parser.dart
+++ b/lib/pages/app_changelog/changelog_parser.dart
@@ -144,9 +144,9 @@ String? _findAndRenderFirstSection(
 /// base with a different `-suffix`.
 ///
 /// Fallback levels (from most to least specific):
-///   1. Exact match — [`extractVersionSection`]
-///   2. Stripped suffix / beta heading — [`_tryBetaHeading`]
-///   3. Semver-only — [`_tryMatchBySemver`] (ignores build number —
+///   1. Exact match — [extractVersionSection]
+///   2. Stripped suffix / beta heading — [_tryBetaHeading]
+///   3. Semver-only — [_tryMatchBySemver] (ignores build number —
 ///      handles app-store-transformed versionCodes like F-Droid ABI prefix)
 ///   4. Latest section — only when [useLatestFallback] is `true`
 ///      (first h2 in content; for manual triggers like About page)

--- a/lib/pages/app_changelog/changelog_parser.dart
+++ b/lib/pages/app_changelog/changelog_parser.dart
@@ -118,44 +118,89 @@ Future<String?> loadChangelogForVersion(
   return (base: version, suffix: null);
 }
 
-/// Like [extractVersionSection], but with fallback: strips flavor suffix
-/// from the code version, or matches CHANGELOG headings that share the same
-/// base with a different `-suffix`.
-String? extractVersionSectionWithFallback(String content, String version) {
-  // 1. Exact match.
-  final section = extractVersionSection(content, version);
-  if (section != null) return section;
-
-  final (:base, :suffix) = _splitVersion(version);
-
-  return switch (suffix) {
-    final _? =>
-      extractVersionSection(content, base) ?? _tryBetaHeading(content, base),
-    _ => _tryBetaHeading(content, base),
-  };
-}
-
-// Looks for a CHANGELOG h2 heading that starts with [base]- and returns
-// the section body rendered back to markdown.
-//
-// Unlike the old regex-based implementation, this performs prefix matching
-// directly against the markdown AST, avoiding consistency issues between
-// regex-captured text and AST-extracted text (which can differ on some
-// platforms or when the file contains invisible characters).
-String? _tryBetaHeading(String content, String base) {
+/// Finds the first h2 heading matching [predicate], collects its body
+/// nodes, and renders them back to markdown.
+///
+/// Returns `null` when no h2 heading satisfies [predicate].
+String? _findAndRenderFirstSection(
+  String content,
+  bool Function(String headingText) predicate,
+) {
   final nodes = md.Document().parse(content);
-  final prefix = '$base-';
   for (var i = 0; i < nodes.length; i++) {
     final node = nodes[i];
     if (node case md.Element(tag: 'h2')) {
       final text = node.textContent.trim();
-      if (!text.startsWith(prefix)) continue;
+      if (!predicate(text)) continue;
       final bodyNodes = _collectSectionNodes(nodes, i + 1);
       return _renderNodesToMarkdown(bodyNodes);
     }
   }
   return null;
 }
+
+/// Like [extractVersionSection], but with fallback: strips flavor suffix
+/// from the code version, or matches CHANGELOG headings that share the same
+/// base with a different `-suffix`.
+///
+/// Fallback levels (from most to least specific):
+///   1. Exact match — [`extractVersionSection`]
+///   2. Stripped suffix / beta heading — [`_tryBetaHeading`]
+///   3. Semver-only — [`_tryMatchBySemver`] (ignores build number —
+///      handles app-store-transformed versionCodes like F-Droid ABI prefix)
+///   4. Latest section — only when [useLatestFallback] is `true`
+///      (first h2 in content; for manual triggers like About page)
+String? extractVersionSectionWithFallback(
+  String content,
+  String version, {
+  bool useLatestFallback = false,
+}) {
+  // 1. Exact match.
+  final section = extractVersionSection(content, version);
+  if (section != null) return section;
+
+  final (:base, :suffix) = _splitVersion(version);
+
+  // 2. Stripped suffix / beta heading.
+  final strippedResult = switch (suffix) {
+    final _? =>
+      extractVersionSection(content, base) ?? _tryBetaHeading(content, base),
+    _ => _tryBetaHeading(content, base),
+  };
+  if (strippedResult != null) return strippedResult;
+
+  // 3. Semver-only match (ignores build number).
+  final semverResult = _tryMatchBySemver(content, version);
+  if (semverResult != null) return semverResult;
+
+  // 4. Ultimate fallback (manual triggers only).
+  return useLatestFallback ? _tryLatestSection(content) : null;
+}
+
+/// Looks for a CHANGELOG h2 heading that starts with [base]-.
+///
+/// Handles the case where the code version is stable (e.g. 1.25.5+170)
+/// but the CHANGELOG heading has a pre-release suffix (1.25.5+170-pre).
+String? _tryBetaHeading(String content, String base) =>
+    _findAndRenderFirstSection(content, (t) => t.startsWith('$base-'));
+
+/// Matches any h2 heading whose semver part equals [version]'s semver,
+/// ignoring the build number.
+///
+/// Handles cases where app stores transform the build number
+/// (e.g. F-Droid ARM64 prefix: 170 → 2170).
+String? _tryMatchBySemver(String content, String version) {
+  final plusIdx = version.indexOf('+');
+  if (plusIdx == -1) return null;
+  final semver = version.substring(0, plusIdx);
+  return _findAndRenderFirstSection(content, (t) => t.startsWith('$semver+'));
+}
+
+/// Returns the body of the first h2 section — the latest changelog entry.
+///
+/// Ultimate fallback when no other version-matching strategy succeeds.
+String? _tryLatestSection(String content) =>
+    _findAndRenderFirstSection(content, (_) => true);
 
 /// Strips the preamble (title, links) from raw CHANGELOG.md [content],
 /// returning only the version heading lines and their body content.

--- a/lib/pages/habits_display/_widgets/changelog_banner_sliver.dart
+++ b/lib/pages/habits_display/_widgets/changelog_banner_sliver.dart
@@ -64,16 +64,23 @@ class ChangelogBanner extends StatefulWidget {
 /// Handles version lookup, CHANGELOG loading, and flavor-suffix fallback
 /// (delegated to [loadChangelogForVersion]).
 /// Optionally override [version] and provide [onDismiss] callback.
+/// Set [useLatestFallback] to `true` to show the latest changelog section
+/// when version matching fails (manual triggers only).
 Future<void> showChangelogBanner(
   BuildContext context, {
   String? version,
   VoidCallback? onDismiss,
+  bool useLatestFallback = false,
 }) async {
   final l10n = L10n.of(context)!;
   final path = l10n.appAbout_versionTile_changeLogPath;
   final v = version ?? AppInfo().changelogVersion;
   final raw = await rootBundle.loadChangelog(path);
-  final section = extractVersionSectionWithFallback(raw, v);
+  final section = extractVersionSectionWithFallback(
+    raw,
+    v,
+    useLatestFallback: useLatestFallback,
+  );
   if (section == null || !context.mounted) return;
   ChangelogBanner.of(context).show(
     changelogContent: section,

--- a/lib/pages/habits_display/_widgets/changelog_banner_sliver.dart
+++ b/lib/pages/habits_display/_widgets/changelog_banner_sliver.dart
@@ -61,8 +61,8 @@ class ChangelogBanner extends StatefulWidget {
 
 /// Loads CHANGELOG.md and shows the banner for the current app version.
 ///
-/// Handles version lookup, CHANGELOG loading, and flavor-suffix fallback
-/// (delegated to [loadChangelogForVersion]).
+/// Handles version lookup, CHANGELOG loading, and version-section extraction
+/// (delegated to [extractVersionSectionWithFallback]).
 /// Optionally override [version] and provide [onDismiss] callback.
 /// Set [useLatestFallback] to `true` to show the latest changelog section
 /// when version matching fails (manual triggers only).

--- a/lib/pages/habits_display/_widgets/habit_display_develop_list.dart
+++ b/lib/pages/habits_display/_widgets/habit_display_develop_list.dart
@@ -86,7 +86,7 @@ class _HabitDisplayDevelopSliverList
       visualDensity: VisualDensity.compact,
       leading: const Icon(Icons.celebration_outlined),
       title: const Text('Show Changelog Banner'),
-      onTap: () => showChangelogBanner(context),
+      onTap: () => showChangelogBanner(context, useLatestFallback: true),
     );
   }
 

--- a/test/unit/pages/app_changelog/changelog_parser_test.dart
+++ b/test/unit/pages/app_changelog/changelog_parser_test.dart
@@ -337,7 +337,23 @@ Second paragraph.
       expect(result, isNot(contains('- Pre-release content')));
     });
 
-    // 22: Semver fallback returns null, but latest-section fallback kicks in
+    // 22: Flavor suffix + wrong build number → semver fallback
+    //     1.25.4-dev+2170 → base 1.25.4+2170 → semver 1.25.4 → match 1.25.4+169
+    test('strips flavor suffix before semver fallback', () {
+      const content = '''
+## 1.25.4+169
+
+- Content for 169
+''';
+      final result = extractVersionSectionWithFallback(
+        content,
+        '1.25.4-dev+2170',
+      );
+      expect(result, isNotNull);
+      expect(result!, contains('- Content for 169'));
+    });
+
+    // 23: Semver fallback returns null, but latest-section fallback kicks in
     test('falls back to latest section when no heading matches at all', () {
       const content = '''
 ## 1.25.5+170
@@ -358,7 +374,7 @@ Second paragraph.
       expect(result, isNot(contains('- Older content')));
     });
 
-    // 23: Latest-section fallback with content containing only one heading
+    // 24: Latest-section fallback with content containing only one heading
     test(
       'returns only section when content has a single heading and no match',
       () {

--- a/test/unit/pages/app_changelog/changelog_parser_test.dart
+++ b/test/unit/pages/app_changelog/changelog_parser_test.dart
@@ -230,15 +230,21 @@ Second paragraph.
       expect(result, isNot(contains('- Pre-release content')));
     });
 
-    // 15: No match returns null
-    test('returns null when no heading matches', () {
+    // 15: Latest-section fallback when no heading matches
+    test('falls back to latest section when no heading matches', () {
       const content = '''
 ## 1.25.3+168
 
 - Only old version
 ''';
-      final result = extractVersionSectionWithFallback(content, '1.25.4+169');
-      expect(result, isNull);
+      // 1.25.4+169 doesn't exist → falls back to latest (1.25.3+168)
+      final result = extractVersionSectionWithFallback(
+        content,
+        '1.25.4+169',
+        useLatestFallback: true,
+      );
+      expect(result, isNotNull);
+      expect(result!, contains('- Only old version'));
     });
 
     // 16: Beta heading with multi-hyphen suffix (e.g. -pre-release)
@@ -288,6 +294,88 @@ Second paragraph.
       expect(result!, contains('- 功能：实现自适应内容面板'));
       expect(result, isNot(contains('- 旧版本内容')));
     });
+
+    // 19: Semver-only fallback — wrong build number (e.g. F-Droid prefix)
+    //     1.25.5+2170 → no heading matches → falls through to semver "1.25.5"
+    test('matches by semver when build number has wrong prefix', () {
+      const content = '''
+## 1.25.5+170-pre
+
+- 功能：自适应内容面板
+''';
+      final result = extractVersionSectionWithFallback(content, '1.25.5+2170');
+      expect(result, isNotNull);
+      expect(result!, contains('- 功能：自适应内容面板'));
+    });
+
+    // 20: Semver fallback versus pre-release heading
+    test('matches by semver against pre-release heading', () {
+      const content = '''
+## 1.25.5+170-pre
+
+- Pre-release content
+''';
+      final result = extractVersionSectionWithFallback(content, '1.25.5+9999');
+      expect(result, isNotNull);
+      expect(result!, contains('- Pre-release content'));
+    });
+
+    // 21: Exact match is still preferred (even with semver fallback available)
+    test('exact match preferred over semver fallback', () {
+      const content = '''
+## 1.25.5+170
+
+- Exact match content
+
+## 1.25.5+170-pre
+
+- Pre-release content
+''';
+      final result = extractVersionSectionWithFallback(content, '1.25.5+170');
+      expect(result, isNotNull);
+      expect(result!, contains('- Exact match content'));
+      expect(result, isNot(contains('- Pre-release content')));
+    });
+
+    // 22: Semver fallback returns null, but latest-section fallback kicks in
+    test('falls back to latest section when no heading matches at all', () {
+      const content = '''
+## 1.25.5+170
+
+- Some content
+
+## 1.25.4+169
+
+- Older content
+''';
+      final result = extractVersionSectionWithFallback(
+        content,
+        '2.0.0',
+        useLatestFallback: true,
+      );
+      expect(result, isNotNull);
+      expect(result!, contains('- Some content'));
+      expect(result, isNot(contains('- Older content')));
+    });
+
+    // 23: Latest-section fallback with content containing only one heading
+    test(
+      'returns only section when content has a single heading and no match',
+      () {
+        const content = '''
+## 1.25.5+170
+
+- Lone section
+''';
+        final result = extractVersionSectionWithFallback(
+          content,
+          '9.9.9+9',
+          useLatestFallback: true,
+        );
+        expect(result, isNotNull);
+        expect(result!, contains('- Lone section'));
+      },
+    );
   });
 
   group('parseChangelogSections', () {

--- a/test/unit/pages/app_changelog/changelog_parser_test.dart
+++ b/test/unit/pages/app_changelog/changelog_parser_test.dart
@@ -240,6 +240,54 @@ Second paragraph.
       final result = extractVersionSectionWithFallback(content, '1.25.4+169');
       expect(result, isNull);
     });
+
+    // 16: Beta heading with multi-hyphen suffix (e.g. -pre-release)
+    //     Regression: old \w+ regex failed on suffixes containing '-'
+    test('matches beta heading with multi-hyphen suffix', () {
+      const content = '''
+## 1.25.5+170-pre-release
+
+- Multi-hyphen suffix content
+''';
+      final result = extractVersionSectionWithFallback(content, '1.25.5+170');
+      expect(result, isNotNull);
+      expect(result!, contains('- Multi-hyphen suffix content'));
+    });
+
+    // 17: Beta heading with dotted suffix (e.g. -rc.1)
+    //     Regression: old \w+ regex failed on suffixes containing '.'
+    test('matches beta heading with dotted suffix', () {
+      const content = '''
+## 1.25.5+170-rc.1
+
+- Release candidate content
+''';
+      final result = extractVersionSectionWithFallback(content, '1.25.5+170');
+      expect(result, isNotNull);
+      expect(result!, contains('- Release candidate content'));
+    });
+
+    // 18: Chinese preamble with ASCII version headings
+    //     Simulates zh.md: h1 in Chinese + CHANGELOG link before first h2
+    test('matches version with Chinese preamble and CHANGELOG link', () {
+      const content = '''
+# 更新日志
+
+[中文](./docs/CHANGELOG/zh.md)
+
+## 1.25.5+170-pre
+
+- 功能：实现自适应内容面板
+
+## 1.25.4+169-pre
+
+- 旧版本内容
+''';
+      final result = extractVersionSectionWithFallback(content, '1.25.5+170');
+      expect(result, isNotNull);
+      expect(result!, contains('- 功能：实现自适应内容面板'));
+      expect(result, isNot(contains('- 旧版本内容')));
+    });
   });
 
   group('parseChangelogSections', () {


### PR DESCRIPTION
## Summary

Replace the fragile regex→AST two-step matching in `_tryBetaHeading` with a single-pass AST prefix match. The old approach used `RegExp` to find a candidate version, then re-parsed markdown to do exact AST match — when the two differed (e.g. due to invisible characters in the Chinese CHANGELOG), the fallback silently returned `null`.

This caused:
- Changelog banner not showing at all on Chinese-locale devices
- About page changelog dialog showing the full changelog instead of the current version section
- The develop button "Show Changelog Banner" having no effect

## Type of Change

- [x] fix

## Related Issue

<!-- No open issue — reported directly by user -->

## Checklist

- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change
