### PR TITLE
refactor: extract PopScopeGate widget with PopScopeHandler interface

### DIFF
--- a/lib/pages/app_sync_server_editor/_providers/app_sync_server_form.dart
+++ b/lib/pages/app_sync_server_editor/_providers/app_sync_server_form.dart
@@ -19,11 +19,12 @@ import 'package:flutter/foundation.dart';
 import '../../../logging/helper.dart';
 import '../../../models/app_sync_server.dart';
 import '../../../models/app_sync_server_form.dart';
+import '../../../pages/common/widgets.dart';
 import '../../../providers/support/commons.dart';
 import '../../../providers/workflow/app_sync.dart';
 
 class AppSyncServerFormViewModel extends ChangeNotifier
-    implements ProviderMounted {
+    implements ProviderMounted, PopScopeHandler {
   final AppSyncServer? initServerConfig;
 
   bool _mounted = true;
@@ -57,6 +58,9 @@ class AppSyncServerFormViewModel extends ChangeNotifier
   bool get pwdLoaded => _pwdLoaded;
 
   bool get edited => _edited;
+
+  @override
+  bool get canPop => !edited;
 
   bool get canSave => _form.canSave();
 

--- a/lib/pages/app_sync_server_editor/page.dart
+++ b/lib/pages/app_sync_server_editor/page.dart
@@ -216,7 +216,7 @@ class _PageState extends State<_Page> {
 
   @override
   Widget build(BuildContext context) =>
-      PopScopeGate<AppSyncServerFormViewModel>(
+      PopScopeConsumer<AppSyncServerFormViewModel>(
         onCannotPop: (ctx, vm, result) => cancelConfirmProcess(result),
         child: AnimatedSwitcher(
           transitionBuilder: (child, animation) =>

--- a/lib/pages/app_sync_server_editor/page.dart
+++ b/lib/pages/app_sync_server_editor/page.dart
@@ -24,6 +24,7 @@ import '../../models/app_sync_server_form.dart';
 import '../../providers/app_ui/app_developer.dart';
 import '../../providers/workflow/app_sync.dart';
 import '../../widgets/widgets.dart';
+import '../common/widgets.dart';
 import '_providers/app_sync_server_form.dart';
 import 'widgets.dart';
 
@@ -215,16 +216,8 @@ class _PageState extends State<_Page> {
 
   @override
   Widget build(BuildContext context) =>
-      Selector<AppSyncServerFormViewModel, bool>(
-        selector: (context, vm) => shouldShowCancelConfirmDialog(vm),
-        builder: (context, value, child) => PopScope<AppSyncServerEditorResult>(
-          canPop: !value,
-          child: child!,
-          onPopInvokedWithResult: (didPop, result) async {
-            if (didPop) return;
-            await cancelConfirmProcess(result);
-          },
-        ),
+      PopScopeGate<AppSyncServerFormViewModel>(
+        onCannotPop: (ctx, vm, result) => cancelConfirmProcess(result),
         child: AnimatedSwitcher(
           transitionBuilder: (child, animation) =>
               FadeTransition(opacity: animation, child: child),

--- a/lib/pages/common/_widgets/pop_scope_consumer.dart
+++ b/lib/pages/common/_widgets/pop_scope_consumer.dart
@@ -19,32 +19,33 @@ import 'package:provider/provider.dart';
 
 /// Interface for ViewModels whose pop-ability depends on internal state.
 ///
-/// Implement this on a [ChangeNotifier]-based ViewModel so [PopScopeGate]
-/// can read [canPop] reactively via [context.select].
+/// Implement this on a [ChangeNotifier]-based ViewModel so
+/// [PopScopeConsumer] can read [canPop] reactively via [context.select].
 ///
 /// When [canPop] is `true`, the system back gesture triggers a normal
 /// pop — this satisfies Android's predictive back gesture requirements.
-/// When `false`, the pop is intercepted and [PopScopeGate.onCannotPop]
+/// When `false`, the pop is intercepted and [PopScopeConsumer.onCannotPop]
 /// is called instead.
 abstract interface class PopScopeHandler {
   /// Whether the enclosing route can currently be popped by the system.
   bool get canPop;
 }
 
-/// A [PopScope] wrapper driven by a [PopScopeHandler] ViewModel from the
-/// [Provider] tree.
+/// A [PopScope] wrapper that reads a [PopScopeHandler] ViewModel from the
+/// [Provider] tree — analogous to [Consumer] but specialized for pop-scope
+/// interception.
 ///
-/// Uses [context.select] to read [PopScopeHandler.canPop] reactively
-/// (rebuilding only [PopScope], not [child]).  When a pop is blocked
-/// because [PopScopeHandler.canPop] is `false`, the [onCannotPop]
-/// callback is invoked with the current [BuildContext] and the resolved
-/// ViewModel instance.
+/// Uses [context.select] under the hood to read [PopScopeHandler.canPop]
+/// reactively (rebuilding only [PopScope], not [child]).  When a pop is
+/// blocked because [PopScopeHandler.canPop] is `false`, the [onCannotPop]
+/// callback is invoked with the current [BuildContext], the resolved
+/// ViewModel instance, and the pop result.
 ///
 /// When [PopScopeHandler.canPop] is `true`, the system back gesture
 /// triggers a normal pop — this satisfies Android's predictive back
 /// gesture requirements.  When `false`, the pop is intercepted and
 /// [onCannotPop] is called instead.
-class PopScopeGate<T extends PopScopeHandler> extends StatelessWidget {
+class PopScopeConsumer<T extends PopScopeHandler> extends StatelessWidget {
   /// The subtree wrapped by the [PopScope].
   ///
   /// This widget is held as a field so Flutter can skip rebuilding it
@@ -62,7 +63,7 @@ class PopScopeGate<T extends PopScopeHandler> extends StatelessWidget {
   final FutureOr<void> Function(BuildContext context, T vm, dynamic result)?
   onCannotPop;
 
-  const PopScopeGate({super.key, required this.child, this.onCannotPop});
+  const PopScopeConsumer({super.key, required this.child, this.onCannotPop});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/common/_widgets/pop_scope_gate.dart
+++ b/lib/pages/common/_widgets/pop_scope_gate.dart
@@ -54,12 +54,13 @@ class PopScopeGate<T extends PopScopeHandler> extends StatelessWidget {
   /// Called when a system back gesture was attempted while
   /// [PopScopeHandler.canPop] is `false`.
   ///
-  /// Receives both the current [BuildContext] and the resolved ViewModel
-  /// instance of type [T].  Typical usage: exit a selection sub-mode,
-  /// show a confirmation dialog, navigate, etc.  The system will retry
-  /// the pop on the next back gesture once [PopScopeHandler.canPop]
-  /// becomes `true`.
-  final FutureOr<void> Function(BuildContext context, T vm)? onCannotPop;
+  /// Receives the current [BuildContext], the resolved ViewModel instance
+  /// of type [T], and the `result` from [PopScope.onPopInvokedWithResult].
+  /// Typical usage: exit a selection sub-mode, show a confirmation
+  /// dialog, navigate, etc.  The system will retry the pop on the next
+  /// back gesture once [PopScopeHandler.canPop] becomes `true`.
+  final FutureOr<void> Function(BuildContext context, T vm, dynamic result)?
+  onCannotPop;
 
   const PopScopeGate({super.key, required this.child, this.onCannotPop});
 
@@ -71,7 +72,7 @@ class PopScopeGate<T extends PopScopeHandler> extends StatelessWidget {
       onPopInvokedWithResult: (didPop, result) {
         if (didPop) return;
         final vm = context.read<T>();
-        onCannotPop?.call(context, vm);
+        onCannotPop?.call(context, vm, result);
       },
       child: child,
     );

--- a/lib/pages/common/_widgets/pop_scope_gate.dart
+++ b/lib/pages/common/_widgets/pop_scope_gate.dart
@@ -1,0 +1,79 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+/// Interface for ViewModels whose pop-ability depends on internal state.
+///
+/// Implement this on a [ChangeNotifier]-based ViewModel so [PopScopeGate]
+/// can read [canPop] reactively via [context.select].
+///
+/// When [canPop] is `true`, the system back gesture triggers a normal
+/// pop — this satisfies Android's predictive back gesture requirements.
+/// When `false`, the pop is intercepted and [PopScopeGate.onCannotPop]
+/// is called instead.
+abstract interface class PopScopeHandler {
+  /// Whether the enclosing route can currently be popped by the system.
+  bool get canPop;
+}
+
+/// A [PopScope] wrapper driven by a [PopScopeHandler] ViewModel from the
+/// [Provider] tree.
+///
+/// Uses [context.select] to read [PopScopeHandler.canPop] reactively
+/// (rebuilding only [PopScope], not [child]).  When a pop is blocked
+/// because [PopScopeHandler.canPop] is `false`, the [onCannotPop]
+/// callback is invoked with the current [BuildContext] and the resolved
+/// ViewModel instance.
+///
+/// When [PopScopeHandler.canPop] is `true`, the system back gesture
+/// triggers a normal pop — this satisfies Android's predictive back
+/// gesture requirements.  When `false`, the pop is intercepted and
+/// [onCannotPop] is called instead.
+class PopScopeGate<T extends PopScopeHandler> extends StatelessWidget {
+  /// The subtree wrapped by the [PopScope].
+  ///
+  /// This widget is held as a field so Flutter can skip rebuilding it
+  /// when only [canPop] changes.
+  final Widget child;
+
+  /// Called when a system back gesture was attempted while
+  /// [PopScopeHandler.canPop] is `false`.
+  ///
+  /// Receives both the current [BuildContext] and the resolved ViewModel
+  /// instance of type [T].  Typical usage: exit a selection sub-mode,
+  /// show a confirmation dialog, navigate, etc.  The system will retry
+  /// the pop on the next back gesture once [PopScopeHandler.canPop]
+  /// becomes `true`.
+  final FutureOr<void> Function(BuildContext context, T vm)? onCannotPop;
+
+  const PopScopeGate({super.key, required this.child, this.onCannotPop});
+
+  @override
+  Widget build(BuildContext context) {
+    final canPop = context.select<T, bool>((vm) => vm.canPop);
+    return PopScope(
+      canPop: canPop,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
+        final vm = context.read<T>();
+        onCannotPop?.call(context, vm);
+      },
+      child: child,
+    );
+  }
+}

--- a/lib/pages/common/widgets.dart
+++ b/lib/pages/common/widgets.dart
@@ -30,7 +30,7 @@ export '_widgets/loglevel_changer_tile.dart';
 export '_widgets/not_found_image.dart';
 export '_widgets/notification_activated.dart';
 export '_widgets/notification_pending_requests.dart';
-export '_widgets/pop_scope_gate.dart';
+export '_widgets/pop_scope_consumer.dart';
 export '_widgets/sync_loading_indicator.dart';
 export '_widgets/sync_now_tile.dart';
 export '_widgets/today_done_image.dart';

--- a/lib/pages/common/widgets.dart
+++ b/lib/pages/common/widgets.dart
@@ -30,6 +30,7 @@ export '_widgets/loglevel_changer_tile.dart';
 export '_widgets/not_found_image.dart';
 export '_widgets/notification_activated.dart';
 export '_widgets/notification_pending_requests.dart';
+export '_widgets/pop_scope_gate.dart';
 export '_widgets/sync_loading_indicator.dart';
 export '_widgets/sync_now_tile.dart';
 export '_widgets/today_done_image.dart';

--- a/lib/pages/group_manage/_providers/group_manage.dart
+++ b/lib/pages/group_manage/_providers/group_manage.dart
@@ -26,6 +26,7 @@ import '../../../models/habit_color.dart';
 import '../../../models/habit_display.dart';
 import '../../../models/habit_group.dart';
 import '../../../models/habit_group_display.dart';
+import '../../../pages/common/widgets.dart';
 import '../../../providers/support/commons.dart';
 import '../../../providers/support/page_load_runtime.dart';
 import '../../../providers/workflow/app_event.dart';
@@ -39,7 +40,7 @@ import '../../../storage/profile_provider.dart';
 /// value falls back to the global [DisplayGroupModeProfileHandler] config.
 class GroupManageViewModel extends ChangeNotifier
     with ProfileHandlerLoadedMixin
-    implements ProviderMounted, AppEventLoaded {
+    implements ProviderMounted, AppEventLoaded, PopScopeHandler {
   GroupManageViewModel({String? initialGroupUUID})
     : _initialGroupUUID = initialGroupUUID;
 
@@ -271,6 +272,9 @@ class GroupManageViewModel extends ChangeNotifier
     _selectedGroupUUIDs.clear();
     notifyListeners();
   }
+
+  @override
+  bool get canPop => !_selectionMode;
 
   void toggleSelection(String uuid) {
     if (!_selectionMode) return;

--- a/lib/pages/group_manage/page.dart
+++ b/lib/pages/group_manage/page.dart
@@ -294,17 +294,8 @@ class _PageState extends State<_Page> {
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (didPop, result) {
-        if (didPop) return;
-        final vm = context.read<GroupManageViewModel>();
-        if (vm.selectionMode) {
-          vm.exitSelectionMode();
-        } else {
-          Navigator.of(context).pop();
-        }
-      },
+    return PopScopeGate<GroupManageViewModel>(
+      onCannotPop: (_, vm) => vm.exitSelectionMode(),
       child: ColorfulNavibar(
         child: Scaffold(
           body: Selector<GroupManageViewModel, (bool, bool)>(

--- a/lib/pages/group_manage/page.dart
+++ b/lib/pages/group_manage/page.dart
@@ -294,7 +294,7 @@ class _PageState extends State<_Page> {
 
   @override
   Widget build(BuildContext context) {
-    return PopScopeGate<GroupManageViewModel>(
+    return PopScopeConsumer<GroupManageViewModel>(
       onCannotPop: (_, vm, _) => vm.exitSelectionMode(),
       child: ColorfulNavibar(
         child: Scaffold(

--- a/lib/pages/group_manage/page.dart
+++ b/lib/pages/group_manage/page.dart
@@ -295,7 +295,7 @@ class _PageState extends State<_Page> {
   @override
   Widget build(BuildContext context) {
     return PopScopeGate<GroupManageViewModel>(
-      onCannotPop: (_, vm) => vm.exitSelectionMode(),
+      onCannotPop: (_, vm, _) => vm.exitSelectionMode(),
       child: ColorfulNavibar(
         child: Scaffold(
           body: Selector<GroupManageViewModel, (bool, bool)>(

--- a/lib/pages/habits_display/_providers/habit_group_modify.dart
+++ b/lib/pages/habits_display/_providers/habit_group_modify.dart
@@ -22,7 +22,7 @@ import '../../../logging/helper.dart';
 import '../../../models/app_event.dart';
 import '../../../models/habit_group.dart';
 import '../../../models/habit_summary.dart';
-import '../../../pages/common/_widgets/group_edit_form.dart';
+import '../../../pages/common/widgets.dart';
 import '../../../providers/app_ui/app_caches.dart';
 import '../../../providers/support/commons.dart';
 import '../../../providers/support/page_load_runtime.dart';
@@ -41,7 +41,7 @@ import '../helpers.dart';
 /// when groups are created / updated / deleted elsewhere while the dialog
 /// is open (same pattern as [GroupManageViewModel]).
 class HabitGroupModifyViewModel extends ChangeNotifier
-    implements ProviderMounted {
+    implements ProviderMounted, PopScopeHandler {
   final List<HabitSummaryData> _selectedData;
 
   GroupManager? _groupManager;
@@ -96,6 +96,9 @@ class HabitGroupModifyViewModel extends ChangeNotifier
   FormMode get mode => _mode;
   bool get isCreateMode => _mode == FormMode.create;
   bool get isSelectMode => _mode == FormMode.select;
+
+  @override
+  bool get canPop => isSelectMode;
 
   List<HabitGroupData> get groups => _groups;
   GroupUUID? get selectedGroupId => _selectedGroupId;

--- a/lib/pages/habits_display/_providers/habit_summary.dart
+++ b/lib/pages/habits_display/_providers/habit_summary.dart
@@ -37,6 +37,7 @@ import '../../../models/habit_score.dart';
 import '../../../models/habit_stat.dart';
 import '../../../models/habit_status.dart';
 import '../../../models/habit_summary.dart';
+import '../../../pages/common/widgets.dart';
 import '../../../providers/support/commons.dart';
 import '../../../providers/support/page_load_runtime.dart';
 import '../../../providers/workflow/app_event.dart';
@@ -62,7 +63,7 @@ extension HabitSummaryDataExntesion on HabitSummaryData {
 
 class HabitSummaryViewModel extends ChangeNotifier
     with PinnedAppbarMixin
-    implements ProviderMounted, AppEventLoaded {
+    implements ProviderMounted, AppEventLoaded, PopScopeHandler {
   // data
   final _data = HabitSummaryDataCollection();
   var _sortableCache = const _HabitsSortableCache(
@@ -127,6 +128,7 @@ class HabitSummaryViewModel extends ChangeNotifier
 
   bool get isCalendarExpanded => _isCalandarExpanded;
 
+  @override
   bool get canPop => !isInEditMode && !isInSearchMode && !isCalendarExpanded;
 
   void toggleCalendarStatus({bool listen = true}) => isCalendarExpanded

--- a/lib/pages/habits_display/_widgets/habit_display_group_modify_dialog.dart
+++ b/lib/pages/habits_display/_widgets/habit_display_group_modify_dialog.dart
@@ -255,10 +255,11 @@ Future<GroupModifySelectorResult?> showHabitGroupModifySelector({
     builder: (context, buildBody) => _GroupModifySelectorScope(
       selectedData: selectedHabitsData,
       bodyBuilder: (ctx) => Consumer<HabitGroupModifyViewModel>(
-        builder: (context, vm, _) => PopScopeGate<HabitGroupModifyViewModel>(
-          onCannotPop: (_, vm, _) => vm.switchToSelectMode(),
-          child: buildBody(ctx),
-        ),
+        builder: (context, vm, _) =>
+            PopScopeConsumer<HabitGroupModifyViewModel>(
+              onCannotPop: (_, vm, _) => vm.switchToSelectMode(),
+              child: buildBody(ctx),
+            ),
       ),
     ),
     contentBuilder: (_) => const _GroupModifySelectorContent(),

--- a/lib/pages/habits_display/_widgets/habit_display_group_modify_dialog.dart
+++ b/lib/pages/habits_display/_widgets/habit_display_group_modify_dialog.dart
@@ -25,7 +25,7 @@ import '../../../models/app_event.dart';
 import '../../../models/habit_color.dart';
 import '../../../models/habit_group.dart';
 import '../../../models/habit_summary.dart';
-import '../../../pages/common/_widgets/group_edit_form.dart';
+import '../../../pages/common/widgets.dart';
 import '../../../providers/app_ui/app_caches.dart';
 import '../../../providers/app_ui/custom_color_history.dart';
 import '../../../providers/workflow/app_event.dart';
@@ -255,11 +255,8 @@ Future<GroupModifySelectorResult?> showHabitGroupModifySelector({
     builder: (context, buildBody) => _GroupModifySelectorScope(
       selectedData: selectedHabitsData,
       bodyBuilder: (ctx) => Consumer<HabitGroupModifyViewModel>(
-        builder: (context, vm, _) => PopScope(
-          canPop: vm.isSelectMode,
-          onPopInvokedWithResult: (didPop, _) {
-            if (!didPop) vm.switchToSelectMode();
-          },
+        builder: (context, vm, _) => PopScopeGate<HabitGroupModifyViewModel>(
+          onCannotPop: (_, vm, _) => vm.switchToSelectMode(),
           child: buildBody(ctx),
         ),
       ),

--- a/lib/pages/habits_display/page.dart
+++ b/lib/pages/habits_display/page.dart
@@ -242,7 +242,7 @@ class _PageState extends State<_Page> {
     );
 
     return ColorfulNavibar(
-      child: PopScopeGate<HabitSummaryViewModel>(
+      child: PopScopeConsumer<HabitSummaryViewModel>(
         onCannotPop: (ctx, vm, result) async {
           if (await _handleWillPop() && ctx.mounted) {
             Navigator.of(ctx).popOrExit(result);

--- a/lib/pages/habits_display/page.dart
+++ b/lib/pages/habits_display/page.dart
@@ -21,6 +21,7 @@ import '../../extensions/navigator_extensions.dart';
 import '../../models/app_entry.dart';
 import '../../providers/app_ui/app_launch_entry.dart';
 import '../../widgets/widgets.dart';
+import '../common/widgets.dart';
 import '_providers/habit_summary.dart';
 import 'page_habits.dart';
 import 'page_today.dart';
@@ -109,14 +110,6 @@ class _PageState extends State<_Page> {
       if (state != null) {
         return await state.onWillPop();
       }
-    }
-    return true;
-  }
-
-  bool _canPop(bool canPop) {
-    if (_currentTabIndex == _PageTabs.display.index) {
-      final state = _habitsTabKey.currentState;
-      if (state != null) return canPop;
     }
     return true;
   }
@@ -249,19 +242,12 @@ class _PageState extends State<_Page> {
     );
 
     return ColorfulNavibar(
-      child: Selector<HabitSummaryViewModel, bool>(
-        selector: (context, vm) => vm.canPop,
-        shouldRebuild: (previous, next) => previous != next,
-        builder: (context, canPop, child) => PopScope(
-          canPop: _canPop(canPop),
-          onPopInvokedWithResult: (didPop, result) async {
-            if (didPop) return;
-            if (await _handleWillPop() && context.mounted) {
-              Navigator.of(context).popOrExit(result);
-            }
-          },
-          child: child!,
-        ),
+      child: PopScopeGate<HabitSummaryViewModel>(
+        onCannotPop: (ctx, vm, result) async {
+          if (await _handleWillPop() && ctx.mounted) {
+            Navigator.of(ctx).popOrExit(result);
+          }
+        },
         child: scaffold,
       ),
     );

--- a/lib/pages/habits_status_changer/_providers/habit_status_changer.dart
+++ b/lib/pages/habits_status_changer/_providers/habit_status_changer.dart
@@ -31,6 +31,7 @@ import '../../../models/habit_date.dart';
 import '../../../models/habit_form.dart';
 import '../../../models/habit_repo_actions.dart';
 import '../../../models/habit_summary.dart';
+import '../../../pages/common/widgets.dart';
 import '../../../providers/support/commons.dart';
 import '../../../providers/support/page_load_runtime.dart';
 import '../../../providers/workflow/habits_manager.dart';
@@ -59,7 +60,7 @@ enum RecordStatusChangerStatus {
 
 class HabitStatusChangerViewModel
     with ChangeNotifier
-    implements ProviderMounted {
+    implements ProviderMounted, PopScopeHandler {
   // data
   final List<HabitUUID> _selectedUUIDList;
   late HabitStatusChangerForm _form;
@@ -196,6 +197,9 @@ class HabitStatusChangerViewModel
     return _form.selectStatus != null &&
         _form.selectStatus != getDefaultChangerStatus(_form);
   }
+
+  @override
+  bool get canPop => !canSave;
 
   Iterable<HabitSummaryRecord> get selectDateRecords => _habitDataController
       .habits

--- a/lib/pages/habits_status_changer/page.dart
+++ b/lib/pages/habits_status_changer/page.dart
@@ -329,15 +329,9 @@ class _PageState extends State<_Page> {
     );
 
     final div = buildDivider(context);
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (didPop, result) async {
-        if (didPop) return;
-        await _onClosePageButtonPressed(
-          defaultConfirmResult: true,
-          result: result,
-        );
-      },
+    return PopScopeGate<HabitStatusChangerViewModel>(
+      onCannotPop: (ctx, vm, result) =>
+          _onClosePageButtonPressed(defaultConfirmResult: true, result: result),
       child: PageScaffold(
         appbar: HabitStatusChangerAppbar(
           title: L10nBuilder(

--- a/lib/pages/habits_status_changer/page.dart
+++ b/lib/pages/habits_status_changer/page.dart
@@ -329,7 +329,7 @@ class _PageState extends State<_Page> {
     );
 
     final div = buildDivider(context);
-    return PopScopeGate<HabitStatusChangerViewModel>(
+    return PopScopeConsumer<HabitStatusChangerViewModel>(
       onCannotPop: (ctx, vm, result) =>
           _onClosePageButtonPressed(defaultConfirmResult: true, result: result),
       child: PageScaffold(


### PR DESCRIPTION
## Summary
Extract a reusable `PopScopeGate<T>` widget and `PopScopeHandler` interface to replace manual `PopScope` + `Selector` patterns across the app. When `canPop` is `true`, the system back gesture triggers a normal pop — this enables **Android's predictive back gesture** animation. When `false`, the pop is intercepted and the `onCannotPop` callback handles it (e.g. exit selection mode, show unsaved-changes dialog).

## Type of Change
- [ ] feat
- [ ] fix
- [x] refactor
- [ ] docs
- [ ] style
- [ ] test
- [ ] chore

## Checklist
- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change