### PR TITLE
refactor: replace manual sync triggers with AppEventBus subscription

### DIFF
--- a/lib/entries/app/providers.dart
+++ b/lib/entries/app/providers.dart
@@ -131,6 +131,9 @@ class AppProviders extends SingleChildStatelessWidget {
         ..updateDBHelper(helper)
         ..setNotificationChannelData(channel),
     ),
+    ViewModelProxyProvider<AppEventBus, AppSyncOwner>(
+      update: (context, bus, previous) => previous..attachEventBus(bus),
+    ),
     ListenableProxyProvider<AppSyncOwner, AppSyncSettingsAccess>(
       create: (context) => context.read<AppSyncOwner>(),
       update: (context, value, previous) => value,

--- a/lib/models/app_event.dart
+++ b/lib/models/app_event.dart
@@ -187,6 +187,46 @@ final class HabitRecordsChangedEvent extends AppEvent {
   }
 }
 
+final class HabitDataChangedEvent extends AppEvent {
+  final String? msg;
+  final List<HabitUUID> uuidList;
+  final HabitDataChangeType changeType;
+
+  const HabitDataChangedEvent({
+    this.msg,
+    required this.uuidList,
+    required this.changeType,
+    super.trace,
+  });
+
+  @override
+  HabitDataChangedEvent extendSource(
+    AppEventPageSource page,
+    AppEventFunctionSource function,
+  ) => HabitDataChangedEvent(
+    msg: msg,
+    uuidList: uuidList,
+    changeType: changeType,
+    trace: buildNewTrace(page, function),
+  );
+
+  @override
+  String toString() {
+    final bf = StringBuffer("HabitDataChangedEvent(");
+    final data = <String>[
+      if (msg != null) "msg=$msg",
+      "uuidList=$uuidList",
+      "changeType=$changeType",
+      "trace=$trace",
+    ];
+    bf.writeAll(data, ",");
+    bf.write(")");
+    return bf.toString();
+  }
+}
+
+enum HabitDataChangeType { created, updated }
+
 final class GroupChangedEvent extends AppEvent {
   final String? msg;
   final List<GroupUUID> uuidList;

--- a/lib/pages/group_manage/_providers/group_manage.dart
+++ b/lib/pages/group_manage/_providers/group_manage.dart
@@ -158,6 +158,7 @@ class GroupManageViewModel extends ChangeNotifier
   void handleEvent(AppEvent event) => switch (event) {
     GroupChangedEvent() => _handleGroupChanged(event),
     ReloadDataEvent() => _handleReloadData(event),
+    HabitDataChangedEvent() => _handleHabitDataChanged(event),
     HabitStatusChangedEvent() || HabitRecordsChangedEvent() => null,
   };
 
@@ -168,6 +169,14 @@ class GroupManageViewModel extends ChangeNotifier
 
   void _handleReloadData(ReloadDataEvent event) {
     appLog.habit.debug("GroupManage.reload", ex: ["ReloadDataEvent", event]);
+    requestReload();
+  }
+
+  void _handleHabitDataChanged(HabitDataChangedEvent event) {
+    appLog.habit.debug(
+      "GroupManage.reload",
+      ex: ["HabitDataChangedEvent", event],
+    );
     requestReload();
   }
 

--- a/lib/pages/habit_detail/_providers/habit_detail.dart
+++ b/lib/pages/habit_detail/_providers/habit_detail.dart
@@ -136,6 +136,7 @@ class HabitDetailViewModel extends ChangeNotifier
   @override
   void handleEvent(AppEvent event) => switch (event) {
     ReloadDataEvent() ||
+    HabitDataChangedEvent() ||
     HabitStatusChangedEvent() ||
     HabitRecordsChangedEvent() ||
     GroupChangedEvent() => null,

--- a/lib/pages/habit_detail/_providers/habit_detail.dart
+++ b/lib/pages/habit_detail/_providers/habit_detail.dart
@@ -54,16 +54,20 @@ extension on AppEventSubscriptions {
     AppEventPageSource.habitDetail: {AppEventFunctionSource.recordChanged},
   };
 
-  void pushEditCompleted() => push(
-    const ReloadDataEvent(
+  void pushHabitEdited(HabitUUID uuid) => push(
+    HabitDataChangedEvent(
       msg: "habit_detail.edit.completed",
+      uuidList: [uuid],
+      changeType: HabitDataChangeType.updated,
       trace: _kHabitChangedTrace,
     ),
   );
 
-  void pushRecordEdited() => push(
-    const ReloadDataEvent(
+  void pushRecordEdited(HabitUUID uuid) => push(
+    HabitDataChangedEvent(
       msg: "habit_detail.record.edited",
+      uuidList: [uuid],
+      changeType: HabitDataChangeType.updated,
       trace: _kRecordChangedTrace,
     ),
   );
@@ -544,7 +548,8 @@ class HabitDetailViewModel extends ChangeNotifier
   void onEditCompleted({habit_summary.HabitDetailAdapter? summary}) {
     requestReload();
     if (summary?.mounted != true) {
-      _eventSubs?.pushEditCompleted();
+      final uuid = habitUUID;
+      if (uuid != null) _eventSubs?.pushHabitEdited(uuid);
     } else {
       summary!.onHabitDataChanged();
     }
@@ -557,7 +562,8 @@ class HabitDetailViewModel extends ChangeNotifier
   void onEditRecordCompleted({habit_summary.HabitDetailAdapter? summary}) {
     requestReload();
     if (summary?.mounted != true) {
-      _eventSubs?.pushRecordEdited();
+      final uuid = habitUUID;
+      if (uuid != null) _eventSubs?.pushRecordEdited(uuid);
     } else {
       summary!.onHabitDataChanged();
     }

--- a/lib/pages/habit_detail/_widgets/habit_edit_repl_rcd_cal.dart
+++ b/lib/pages/habit_detail/_widgets/habit_edit_repl_rcd_cal.dart
@@ -19,7 +19,6 @@ import 'package:simple_heatmap_calendar/simple_heatmap_calendar.dart';
 
 import '../../../common/consts.dart';
 import '../../../common/types.dart';
-import '../../../extensions/context_extensions.dart';
 import '../../../extensions/custom_color_extensions.dart';
 import '../../../models/habit_color.dart';
 import '../../../models/habit_daily_record_form.dart';
@@ -28,7 +27,6 @@ import '../../../models/habit_detail_chart.dart';
 import '../../../models/habit_form.dart';
 import '../../../models/habit_summary.dart';
 import '../../../providers/app_ui/app_custom_date_format.dart';
-import '../../../providers/workflow/app_sync.dart';
 import '../../../theme/color.dart';
 import '../../../widgets/widgets.dart';
 import '../../common/widgets.dart';
@@ -95,16 +93,8 @@ class _HabitEditReplacementRecordCalendarDialog
     }
   }
 
-  void _onRecordChangeConfirmed(
-    HabitSummaryRecord record, {
-    String? reason,
-    bool shouldSyncOnce = true,
-  }) {
+  void _onRecordChangeConfirmed(HabitSummaryRecord record, {String? reason}) {
     if (!mounted) return;
-    // try sync once
-    if (shouldSyncOnce) {
-      context.maybeRead<AppSyncTriggerAccess>()?.delayedStartTaskOnce();
-    }
     final habitUUID = _vm.habitUUID;
     if (habitUUID != null) {
       _vm.onCalendarRecordChanged(

--- a/lib/pages/habit_detail/page.dart
+++ b/lib/pages/habit_detail/page.dart
@@ -40,7 +40,6 @@ import '../../providers/app_ui/app_custom_date_format.dart';
 import '../../providers/app_ui/app_developer.dart';
 import '../../providers/app_ui/app_first_day.dart';
 import '../../providers/support/utils.dart';
-import '../../providers/workflow/app_sync.dart';
 import '../../providers/workflow/habits_file_exporter.dart';
 import '../../storage/db/handlers/habit.dart';
 import '../../theme/color.dart';
@@ -244,14 +243,8 @@ class _PageState extends State<_Page>
     );
   }
 
-  void _onHabitStatusChangeConfirmed({bool shouldSyncOnce = true}) {
+  void _onHabitStatusChangeConfirmed() {
     if (!mounted) return;
-    // try sync once
-    if (shouldSyncOnce) {
-      context.maybeRead<AppSyncTriggerAccess>()?.delayedStartTaskOnce(
-        delay: kAppUndoDialogShowDuration * 2,
-      );
-    }
   }
 
   void _openHabitArchiveConfirmDialog() async {

--- a/lib/pages/habit_edit/_providers/habit_form.dart
+++ b/lib/pages/habit_edit/_providers/habit_form.dart
@@ -48,16 +48,21 @@ extension on AppEventSubscriptions {
     AppEventPageSource.habitEdit: {AppEventFunctionSource.groupChanged},
   };
 
-  void pushReloadData(HabitDisplayEditMode editMode) => push(switch (editMode) {
-    HabitDisplayEditMode.create => const ReloadDataEvent(
-      msg: "habit_edit.saveHabit.create",
-      trace: _kHabitCreatedTrace,
-    ),
-    HabitDisplayEditMode.edit => const ReloadDataEvent(
-      msg: "habit_edit.saveHabit.edit",
-      trace: _kHabitChangedTrace,
-    ),
-  });
+  void pushHabitSaved(HabitUUID uuid, HabitDisplayEditMode editMode) =>
+      push(switch (editMode) {
+        HabitDisplayEditMode.create => HabitDataChangedEvent(
+          msg: "habit_edit.saveHabit.create",
+          uuidList: [uuid],
+          changeType: HabitDataChangeType.created,
+          trace: _kHabitCreatedTrace,
+        ),
+        HabitDisplayEditMode.edit => HabitDataChangedEvent(
+          msg: "habit_edit.saveHabit.edit",
+          uuidList: [uuid],
+          changeType: HabitDataChangeType.updated,
+          trace: _kHabitChangedTrace,
+        ),
+      });
 
   void pushGroupCreated(GroupUUID uuid) => push(
     GroupChangedEvent(
@@ -177,6 +182,7 @@ class HabitFormViewModel extends ChangeNotifier
     GroupChangedEvent() => _handleGroupChanged(),
     ReloadDataEvent() ||
     HabitStatusChangedEvent() ||
+    HabitDataChangedEvent() ||
     HabitRecordsChangedEvent() => null,
   };
 
@@ -381,7 +387,7 @@ class HabitFormViewModel extends ChangeNotifier
       HabitDisplayEditMode.create => _saveNewHabit(),
       HabitDisplayEditMode.edit => _saveExistHabit(),
     };
-    if (result != null) _subs?.pushReloadData(_form.editMode);
+    if (result != null) _subs?.pushHabitSaved(result.uuid!, _form.editMode);
     return result;
   }
 

--- a/lib/pages/habit_edit/page.dart
+++ b/lib/pages/habit_edit/page.dart
@@ -32,7 +32,6 @@ import '../../models/habit_reminder.dart';
 import '../../providers/app_ui/app_caches.dart';
 import '../../providers/app_ui/app_developer.dart';
 import '../../providers/app_ui/app_first_day.dart';
-import '../../providers/workflow/app_sync.dart';
 import '../../reminders/notification_channel.dart';
 import '../../storage/db/handlers/habit.dart';
 import '../../widgets/widgets.dart';
@@ -263,10 +262,6 @@ class _PageState extends State<_Page> {
     if (!formvm.canSaveHabit()) return;
     final result = await formvm.saveHabit();
     if (!mounted) return;
-    if (mounted && result != null) {
-      // try sync once
-      context.maybeRead<AppSyncTriggerAccess>()?.delayedStartTaskOnce();
-    }
     // pop result
     Navigator.of(context).maybePop(result);
   }

--- a/lib/pages/habits_display/_providers/habit_group_modify.dart
+++ b/lib/pages/habits_display/_providers/habit_group_modify.dart
@@ -165,7 +165,7 @@ class HabitGroupModifyViewModel extends ChangeNotifier
   void handleEvent(AppEvent event) => switch (event) {
     GroupChangedEvent() => _handleGroupChanged(),
     ReloadDataEvent() => _handleReloadData(),
-    final HabitDataChangedEvent e => _handleHabitDataChanged(e),
+    HabitDataChangedEvent() => _handleHabitDataChanged(event),
     HabitStatusChangedEvent() || HabitRecordsChangedEvent() => null,
   };
 

--- a/lib/pages/habits_display/_providers/habit_group_modify.dart
+++ b/lib/pages/habits_display/_providers/habit_group_modify.dart
@@ -165,7 +165,7 @@ class HabitGroupModifyViewModel extends ChangeNotifier
   void handleEvent(AppEvent event) => switch (event) {
     GroupChangedEvent() => _handleGroupChanged(),
     ReloadDataEvent() => _handleReloadData(),
-    HabitDataChangedEvent() => _handleHabitDataChanged(),
+    final HabitDataChangedEvent e => _handleHabitDataChanged(e),
     HabitStatusChangedEvent() || HabitRecordsChangedEvent() => null,
   };
 
@@ -179,10 +179,10 @@ class HabitGroupModifyViewModel extends ChangeNotifier
     requestReload();
   }
 
-  void _handleHabitDataChanged() {
+  void _handleHabitDataChanged(HabitDataChangedEvent event) {
     appLog.habit.debug(
       "HabitGroupModify.reload",
-      ex: ["HabitDataChangedEvent"],
+      ex: ["HabitDataChangedEvent", event],
     );
     requestReload();
   }

--- a/lib/pages/habits_display/_providers/habit_group_modify.dart
+++ b/lib/pages/habits_display/_providers/habit_group_modify.dart
@@ -165,6 +165,7 @@ class HabitGroupModifyViewModel extends ChangeNotifier
   void handleEvent(AppEvent event) => switch (event) {
     GroupChangedEvent() => _handleGroupChanged(),
     ReloadDataEvent() => _handleReloadData(),
+    HabitDataChangedEvent() => _handleHabitDataChanged(),
     HabitStatusChangedEvent() || HabitRecordsChangedEvent() => null,
   };
 
@@ -175,6 +176,14 @@ class HabitGroupModifyViewModel extends ChangeNotifier
 
   void _handleReloadData() {
     appLog.habit.debug("HabitGroupModify.reload", ex: ["ReloadDataEvent"]);
+    requestReload();
+  }
+
+  void _handleHabitDataChanged() {
+    appLog.habit.debug(
+      "HabitGroupModify.reload",
+      ex: ["HabitDataChangedEvent"],
+    );
     requestReload();
   }
 

--- a/lib/pages/habits_display/_providers/habit_summary.dart
+++ b/lib/pages/habits_display/_providers/habit_summary.dart
@@ -59,14 +59,6 @@ extension on AppEventSubscriptions {
     AppEventPageSource.habitDisplay: {AppEventFunctionSource.recordChanged},
   };
 
-  void pushReloadDisplay({bool? clearSnackBar}) => push(
-    ReloadDataEvent(
-      msg: "habit_display.reload.data",
-      clearSnackBar: clearSnackBar ?? false,
-      trace: _kHabitChangedTrace,
-    ),
-  );
-
   void pushHabitStatusChanged(List<HabitStatusChangedRecord> records) {
     final grouped = records.groupListsBy((r) => r.newStatus);
     for (final entry in grouped.entries) {
@@ -99,14 +91,27 @@ extension on AppEventSubscriptions {
   /// Pushes a [HabitStatusChangedEvent] for batch-group-modify operations.
   ///
   /// The affected habits remain [HabitStatus.activated]; only their group
-  /// association changes.  This replaces the previous [pushReloadDisplay]
-  /// in [executeBatchGroupModify] so that both UI refresh and sync trigger
-  /// flow through a single semantically-correct event.
+  /// association changes.  This replaces the previous pattern of pushing
+  /// a [ReloadDataEvent] in [executeBatchGroupModify] so that both UI
+  /// refresh and sync trigger flow through a single semantically-correct
+  /// event.
   void pushBatchGroupChanged(List<HabitUUID> uuids) => push(
     HabitStatusChangedEvent(
       msg: "habit_display.batchGroupModify",
       uuidList: uuids,
       status: HabitStatus.activated,
+      trace: _kHabitChangedTrace,
+    ),
+  );
+
+  /// Pushes a [HabitDataChangedEvent] for drag-reorder / cross-group-move
+  /// operations so that both UI refresh and sync trigger flow through a
+  /// single semantically-correct event.
+  void pushHabitReordered(HabitUUID uuid) => push(
+    HabitDataChangedEvent(
+      msg: "habit_display.reorder",
+      uuidList: [uuid],
+      changeType: HabitDataChangeType.updated,
       trace: _kHabitChangedTrace,
     ),
   );
@@ -961,10 +966,11 @@ class HabitSummaryViewModel extends ChangeNotifier
   }
 
   Future<void> onHabitReorderComplate(int index, int dropIndex) async {
+    final movedCache = currentHabitList[index] as HabitSummaryDataSortCache;
     _applyHabitReorder(index, dropIndex);
     await _writeChangedSortPositionToDB(fromIndex: index, toIndex: dropIndex);
     exitEditMode(listen: false);
-    _reloadBridge.eventSubs?.pushReloadDisplay();
+    _reloadBridge.eventSubs?.pushHabitReordered(movedCache.uuid);
   }
 
   Future<void> onCrossGroupHabitMove(
@@ -1010,7 +1016,7 @@ class HabitSummaryViewModel extends ChangeNotifier
     }
     resortData();
     exitEditMode(listen: false);
-    _reloadBridge.eventSubs?.pushReloadDisplay();
+    _reloadBridge.eventSubs?.pushHabitReordered(movedUUID);
   }
 
   Future<List<HabitStatusChangedRecord>> _changeHabitsStatus(
@@ -1215,7 +1221,9 @@ class HabitSummaryViewModel extends ChangeNotifier
       }
     }
     resortData(listen: listen);
-    if (revertUUIDs.isNotEmpty) _reloadBridge.eventSubs?.pushReloadDisplay();
+    if (revertUUIDs.isNotEmpty) {
+      _reloadBridge.eventSubs?.pushBatchGroupChanged(revertUUIDs);
+    }
     return true;
   }
   //#endregion

--- a/lib/pages/habits_display/_providers/habit_summary.dart
+++ b/lib/pages/habits_display/_providers/habit_summary.dart
@@ -965,8 +965,23 @@ class HabitSummaryViewModel extends ChangeNotifier
     );
   }
 
+  HabitSummaryDataSortCache? _requireSortCache(int index) {
+    final cache = currentHabitList[index];
+    if (cache is! HabitSummaryDataSortCache) {
+      if (kDebugMode) {
+        throw StateError(
+          'Expected HabitSummaryDataSortCache at index=$index, '
+          'got ${cache.runtimeType}',
+        );
+      }
+      return null;
+    }
+    return cache;
+  }
+
   Future<void> onHabitReorderComplate(int index, int dropIndex) async {
-    final movedCache = currentHabitList[index] as HabitSummaryDataSortCache;
+    final movedCache = _requireSortCache(index);
+    if (movedCache == null) return;
     _applyHabitReorder(index, dropIndex);
     await _writeChangedSortPositionToDB(fromIndex: index, toIndex: dropIndex);
     exitEditMode(listen: false);
@@ -978,19 +993,11 @@ class HabitSummaryViewModel extends ChangeNotifier
     int targetIndex,
     String? targetGroupUUID,
   ) async {
-    final movedCache = currentHabitList[sourceIndex];
-    if (movedCache is! HabitSummaryDataSortCache) {
-      if (kDebugMode) {
-        throw StateError(
-          'Expected HabitSummaryDataSortCache at sourceIndex=$sourceIndex, '
-          'got ${movedCache.runtimeType}',
-        );
-      }
-      return;
-    }
+    final movedCache = _requireSortCache(sourceIndex);
+    if (movedCache == null) return;
     final movedData = movedCache.data;
     if (movedData == null) return;
-    final movedUUID = movedData.uuid;
+    final movedUUID = movedCache.uuid;
     final oldGroupId = movedData.groupId;
 
     _applyHabitReorder(sourceIndex, targetIndex);

--- a/lib/pages/habits_display/_providers/habit_summary.dart
+++ b/lib/pages/habits_display/_providers/habit_summary.dart
@@ -95,6 +95,21 @@ extension on AppEventSubscriptions {
       trace: _kRecordChangedTrace,
     ),
   );
+
+  /// Pushes a [HabitStatusChangedEvent] for batch-group-modify operations.
+  ///
+  /// The affected habits remain [HabitStatus.activated]; only their group
+  /// association changes.  This replaces the previous [pushReloadDisplay]
+  /// in [executeBatchGroupModify] so that both UI refresh and sync trigger
+  /// flow through a single semantically-correct event.
+  void pushBatchGroupChanged(List<HabitUUID> uuids) => push(
+    HabitStatusChangedEvent(
+      msg: "habit_display.batchGroupModify",
+      uuidList: uuids,
+      status: HabitStatus.activated,
+      trace: _kHabitChangedTrace,
+    ),
+  );
 }
 
 extension HabitSummaryDataExntesion on HabitSummaryData {
@@ -776,6 +791,7 @@ class HabitSummaryViewModel extends ChangeNotifier
     HabitStatusChangedEvent() ||
     HabitRecordsChangedEvent() ||
     GroupChangedEvent() => requestReload(clearSnackBar: false),
+    HabitDataChangedEvent() => null,
   };
 
   void _handleReloadData(ReloadDataEvent event) {
@@ -1162,7 +1178,7 @@ class HabitSummaryViewModel extends ChangeNotifier
     _groupCollection = await _groupManager.tryLoadGroupCollection();
     resortData(listen: listen);
     exitEditMode(listen: false);
-    _reloadBridge.eventSubs?.pushReloadDisplay();
+    _reloadBridge.eventSubs?.pushBatchGroupChanged(changedUUIDs);
 
     return changedUUIDs.length;
   }

--- a/lib/pages/habits_display/_providers/habits_today.dart
+++ b/lib/pages/habits_display/_providers/habits_today.dart
@@ -310,6 +310,7 @@ class HabitsTodayViewModel extends ChangeNotifier
   void handleEvent(AppEvent event) => switch (event) {
     ReloadDataEvent() => _handleReloadData(event),
     HabitStatusChangedEvent() => _handleHabitStatusChanged(event),
+    HabitDataChangedEvent() => _handleHabitDataChanged(event),
     HabitRecordsChangedEvent() => _handleRecordsChanged(event),
     GroupChangedEvent() => null,
   };
@@ -326,6 +327,14 @@ class HabitsTodayViewModel extends ChangeNotifier
     appLog.habit.debug(
       "HabitsTody",
       ex: ["habit status changed event triggered", event],
+    );
+    requestReload();
+  }
+
+  void _handleHabitDataChanged(HabitDataChangedEvent event) {
+    appLog.habit.debug(
+      "HabitsTody",
+      ex: ["habit data changed event triggered", event],
     );
     requestReload();
   }

--- a/lib/pages/habits_display/page_habits.dart
+++ b/lib/pages/habits_display/page_habits.dart
@@ -29,7 +29,6 @@ import '../../common/consts.dart';
 import '../../common/enums.dart';
 import '../../common/types.dart';
 import '../../extensions/color_extensions.dart';
-import '../../extensions/context_extensions.dart';
 import '../../l10n/localizations.dart';
 import '../../logging/helper.dart';
 import '../../models/app_event.dart';
@@ -197,29 +196,17 @@ class HabitsTabPageState extends State<HabitsTabPage>
   }
 
   void _onHabitStatusChangeConfirmed(
-    List<HabitStatusChangedRecord> recordList, {
-    bool shouldSyncOnce = true,
-  }) {
+    List<HabitStatusChangedRecord> recordList,
+  ) {
     if (!mounted) return;
-    // try sync once
-    if (shouldSyncOnce) {
-      context.maybeRead<AppSyncWorkflowAccess>()?.delayedStartTaskOnce(
-        delay: kAppUndoDialogShowDuration * 2,
-      );
-    }
   }
 
   void _onRecordChangeConfirmed(
     HabitUUID uuid,
     HabitSummaryRecord record, {
     String? reason,
-    bool shouldSyncOnce = true,
   }) {
     if (!mounted) return;
-    // try sync once
-    if (shouldSyncOnce) {
-      context.maybeRead<AppSyncWorkflowAccess>()?.delayedStartTaskOnce();
-    }
   }
 
   void _revertHabitsStatus(List<HabitStatusChangedRecord> recordList) async {
@@ -754,9 +741,6 @@ class HabitsTabPageState extends State<HabitsTabPage>
     );
 
     if (!mounted || count == 0) return;
-    context.maybeRead<AppSyncWorkflowAccess>()?.delayedStartTaskOnce(
-      delay: kAppUndoDialogShowDuration * 2,
-    );
 
     final l10n = L10n.of(context);
     final snackBar = buildSnackBarWithUndo(
@@ -921,7 +905,6 @@ class HabitsTabPageState extends State<HabitsTabPage>
     void finishReorder(Future<void> task) => task
         .then((_) {
           if (!mounted) return;
-          context.maybeRead<AppSyncWorkflowAccess>()?.delayedStartTaskOnce();
         })
         .catchError((Object e, StackTrace s) {
           if (!mounted) return;

--- a/lib/pages/habits_display/page_today.dart
+++ b/lib/pages/habits_display/page_today.dart
@@ -22,7 +22,6 @@ import 'package:provider/provider.dart';
 import '../../common/consts.dart';
 import '../../common/types.dart';
 import '../../common/utils.dart';
-import '../../extensions/context_extensions.dart';
 import '../../l10n/localizations.dart';
 import '../../logging/helper.dart';
 import '../../models/habit_daily_record_form.dart';
@@ -295,10 +294,7 @@ class _HabitsTodayController {
     HabitUUID uuid,
     HabitSummaryRecord record, {
     String? reason,
-  }) {
-    // try sync once
-    context.maybeRead<AppSyncWorkflowAccess>()?.delayedStartTaskOnce();
-  }
+  }) {}
 
   void onMain(HabitUUID uuid) {
     final habit = _vm.getHabit(uuid);

--- a/lib/pages/habits_status_changer/_providers/habit_status_changer.dart
+++ b/lib/pages/habits_status_changer/_providers/habit_status_changer.dart
@@ -109,6 +109,7 @@ class HabitStatusChangerViewModel
   @override
   void handleEvent(AppEvent event) => switch (event) {
     ReloadDataEvent() ||
+    HabitDataChangedEvent() ||
     HabitStatusChangedEvent() ||
     HabitRecordsChangedEvent() ||
     GroupChangedEvent() => null,

--- a/lib/pages/habits_status_changer/_providers/habit_status_changer.dart
+++ b/lib/pages/habits_status_changer/_providers/habit_status_changer.dart
@@ -40,6 +40,32 @@ import '../../../providers/workflow/habits_manager.dart';
 
 part 'habit_status_changer.g.dart';
 
+extension on AppEventSubscriptions {
+  static const _kStatusChangerSavedTrace = {
+    AppEventPageSource.habitStatusChanger: {
+      AppEventFunctionSource.recordChanged,
+    },
+  };
+
+  /// Pushes a [HabitRecordsChangedEvent] for the status-changer save
+  /// operation, triggering cross-view refresh and sync.
+  void pushRecordsSaved({
+    required List<HabitUUID> uuidList,
+    required List<HabitRecordDate> dateList,
+    required HabitRecordStatus status,
+    String? reason,
+  }) => push(
+    HabitRecordsChangedEvent(
+      msg: "habit_status_changer.confirm.pressed",
+      uuidList: uuidList,
+      dateList: dateList,
+      status: status,
+      reason: reason,
+      trace: _kStatusChangerSavedTrace,
+    ),
+  );
+}
+
 enum RecordStatusChangerStatus {
   skip,
   ok,
@@ -357,16 +383,13 @@ class HabitStatusChangerViewModel
     if (!mounted) return 0;
 
     requestReloadData();
-    _eventSubs?.push(
-      const ReloadDataEvent(
-        msg: "habit_status_changer.confirm.pressed",
-        exiEditMode: true,
-        trace: {
-          AppEventPageSource.habitStatusChanger: {
-            AppEventFunctionSource.recordChanged,
-          },
-        },
-      ),
+    _eventSubs?.pushRecordsSaved(
+      uuidList: records.map((r) => r.habit.uuid).toList(),
+      dateList: records.map((r) => r.data.date).toList(),
+      status: records.first.data.status,
+      reason: selectStatus == RecordStatusChangerStatus.skip
+          ? skipReason
+          : null,
     );
     if (listen) notifyListeners();
     return records.length;

--- a/lib/pages/habits_status_changer/_providers/habit_status_changer.dart
+++ b/lib/pages/habits_status_changer/_providers/habit_status_changer.dart
@@ -380,7 +380,7 @@ class HabitStatusChangerViewModel
         habit.reCalculateAutoComplateRecords(firstDay: firstday);
       },
     );
-    if (!mounted) return 0;
+    if (!mounted || records.isEmpty) return 0;
 
     requestReloadData();
     _eventSubs?.pushRecordsSaved(

--- a/lib/pages/habits_status_changer/page.dart
+++ b/lib/pages/habits_status_changer/page.dart
@@ -19,7 +19,6 @@ import 'package:sliver_tools/sliver_tools.dart';
 
 import '../../common/types.dart';
 import '../../common/utils.dart';
-import '../../extensions/context_extensions.dart';
 import '../../extensions/navigator_extensions.dart';
 import '../../logging/helper.dart';
 import '../../models/custom_date_format.dart';
@@ -28,7 +27,6 @@ import '../../models/habit_summary.dart';
 import '../../providers/app_ui/app_compact_ui_switcher.dart';
 import '../../providers/app_ui/app_custom_date_format.dart';
 import '../../providers/app_ui/app_developer.dart';
-import '../../providers/workflow/app_sync.dart';
 import '../../utils/safe_sliver_tools.dart';
 import '../../widgets/helpers.dart';
 import '../../widgets/widgets.dart';
@@ -154,8 +152,6 @@ class _PageState extends State<_Page> {
 
     final changedCount = await _vm.saveSelectStatus();
     if (!mounted || changedCount <= 0) return;
-
-    context.maybeRead<AppSyncTriggerAccess>()?.delayedStartTaskOnce();
 
     final snackBar = buildSnackBarWithDismiss(
       context,

--- a/lib/providers/workflow/app_sync.dart
+++ b/lib/providers/workflow/app_sync.dart
@@ -31,6 +31,7 @@ import '../../l10n/localizations.dart';
 import '../../logging/helper.dart';
 import '../../logging/logger_message.dart' show AppLoggerMessage;
 import '../../logging/logger_utils.dart';
+import '../../models/app_event.dart';
 import '../../models/app_sync_options.dart';
 import '../../models/app_sync_server.dart';
 import '../../models/app_sync_server_form.dart';
@@ -44,6 +45,7 @@ import '../../utils/app_clock.dart';
 import '../../utils/app_path_provider.dart';
 import '../../utils/async_debouncer.dart';
 import '../support/commons.dart';
+import 'app_event.dart';
 
 part 'app_sync.g.dart';
 
@@ -51,6 +53,7 @@ const kAppSyncDelayDuration1 = Duration(seconds: 1);
 const kAppSyncDelayDuration2 = Duration(milliseconds: 1500);
 const kAppSyncDelayDuration3 = Duration(milliseconds: 2500);
 const kAppSyncOnceDelay = Duration(seconds: 5);
+const _kAppSyncUndoDelay = Duration(seconds: 8);
 
 abstract interface class AppSyncSettingsAccess implements Listenable {
   bool get enabled;
@@ -130,7 +133,8 @@ class AppSyncOwner
         AppSyncSettingsAccess,
         AppSyncStatusSource,
         AppSyncTriggerAccess,
-        AppSyncWorkflowAccess {
+        AppSyncWorkflowAccess,
+        AppEventSubscriber {
   late final AppSyncTaskDispatcher _appSyncTask;
 
   late final CascadingAsyncDebouncer _delayedSyncTrigger;
@@ -145,6 +149,8 @@ class AppSyncOwner
 
   AppSyncPeriodicTimer? _autoSyncTimer;
   bool _clearLogsOnStartup = false;
+
+  AppEventSubscriptions? _eventSubs;
 
   AppSyncOwner() : _passwordStore = const _AppSyncPasswordStore() {
     _appSyncTask = AppSyncTaskDispatcher(this);
@@ -166,6 +172,7 @@ class AppSyncOwner
   void dispose() {
     if (!mounted) return;
     _mounted = false;
+    _eventSubs?.cancelAll();
     _delayedSyncTrigger.cancel();
     _autoSyncTimer?.cancel();
     _appSyncTask.dispose();
@@ -500,6 +507,33 @@ class AppSyncOwner
     );
     _delayedSyncTrigger.exec(delay: delay);
   }
+
+  //#region AppEventSubscriber
+
+  void attachEventBus(AppEventBus bus) {
+    _eventSubs?.cancelAll();
+    _eventSubs = AppEventSubscriptions(this, bus)
+      ..subscribe<HabitDataChangedEvent>()
+      ..subscribe<HabitStatusChangedEvent>()
+      ..subscribe<HabitRecordsChangedEvent>()
+      ..subscribe<GroupChangedEvent>();
+  }
+
+  @override
+  bool shouldReceive(AppEvent event) => true;
+
+  @override
+  void handleEvent(AppEvent event) => switch (event) {
+    HabitDataChangedEvent() ||
+    HabitRecordsChangedEvent() ||
+    GroupChangedEvent() => delayedStartTaskOnce(),
+    HabitStatusChangedEvent() => delayedStartTaskOnce(
+      delay: _kAppSyncUndoDelay,
+    ),
+    ReloadDataEvent() => null,
+  };
+
+  //#endregion
 }
 
 @immutable

--- a/test/unit/pages/habit_detail/habit_detail_viewmodel_test.dart
+++ b/test/unit/pages/habit_detail/habit_detail_viewmodel_test.dart
@@ -247,7 +247,7 @@ void main() {
 
   group('HabitDetailViewModel event push', () {
     test(
-      'onEditCompleted pushes ReloadDataEvent via AppEventSubscriptions',
+      'onEditCompleted pushes HabitDataChangedEvent via AppEventSubscriptions',
       () async {
         final detailData = _buildHabitDetailData();
         final access = _FakeHabitDetailAccess(seedData: detailData);
@@ -255,8 +255,8 @@ void main() {
         final vm = HabitDetailViewModel()
           ..attachAccess(access)
           ..updateAppEvent(bus);
-        final events = <ReloadDataEvent>[];
-        bus.on<ReloadDataEvent>().listen(events.add);
+        final events = <HabitDataChangedEvent>[];
+        bus.on<HabitDataChangedEvent>().listen(events.add);
 
         await vm.loadData(detailData.data.uuid, listen: false);
         vm.onEditCompleted();
@@ -265,7 +265,7 @@ void main() {
         expect(
           events.length,
           1,
-          reason: 'onEditCompleted should push one ReloadDataEvent',
+          reason: 'onEditCompleted should push one HabitDataChangedEvent',
         );
         final event = events.single;
         expect(
@@ -276,13 +276,15 @@ void main() {
           isTrue,
           reason: 'trace must include habitDetail.habitChanged',
         );
+        expect(event.uuidList, [detailData.data.uuid]);
+        expect(event.changeType, HabitDataChangeType.updated);
         vm.dispose();
         bus.dispose();
       },
     );
 
     test(
-      'onEditRecordCompleted pushes ReloadDataEvent via AppEventSubscriptions',
+      'onEditRecordCompleted pushes HabitDataChangedEvent via AppEventSubscriptions',
       () async {
         final detailData = _buildHabitDetailData();
         final access = _FakeHabitDetailAccess(seedData: detailData);
@@ -290,8 +292,8 @@ void main() {
         final vm = HabitDetailViewModel()
           ..attachAccess(access)
           ..updateAppEvent(bus);
-        final events = <ReloadDataEvent>[];
-        bus.on<ReloadDataEvent>().listen(events.add);
+        final events = <HabitDataChangedEvent>[];
+        bus.on<HabitDataChangedEvent>().listen(events.add);
 
         await vm.loadData(detailData.data.uuid, listen: false);
         vm.onEditRecordCompleted();
@@ -300,7 +302,7 @@ void main() {
         expect(
           events.length,
           1,
-          reason: 'onEditRecordCompleted should push one ReloadDataEvent',
+          reason: 'onEditRecordCompleted should push one HabitDataChangedEvent',
         );
         final event = events.single;
         expect(
@@ -311,6 +313,8 @@ void main() {
           isTrue,
           reason: 'trace must include habitDetail.recordChanged',
         );
+        expect(event.uuidList, [detailData.data.uuid]);
+        expect(event.changeType, HabitDataChangeType.updated);
         vm.dispose();
         bus.dispose();
       },


### PR DESCRIPTION
## Summary

Replaces UI-level manual `delayedStartTaskOnce()` calls with a centralized `AppSyncOwner` subscription to `AppEventBus`. After a habit/record/group mutation, the page VM pushes the appropriate event, and `AppSyncOwner` triggers sync automatically with debounce. UI pages no longer need to remember to call sync after every mutation.

Key changes:
- **New event type**: `HabitDataChangedEvent` + `HabitDataChangeType` (created/updated) — replaces `ReloadDataEvent` for habit create/edit
- **AppSyncOwner** subscribes to `HabitDataChangedEvent`, `HabitStatusChangedEvent`, `HabitRecordsChangedEvent`, `GroupChangedEvent` via `AppEventBus`
- **Delay strategy**: 5s default; 8s for `HabitStatusChangedEvent` (archive/delete/revert/batch-group-modify)
- **Removed**: 9 manual `delayedStartTaskOnce()` calls across 6 UI pages
- **Added**: `HabitDataChangedEvent` handlers in all 8 `AppEventSubscriber` implementations
- **New extension**: `pushBatchGroupChanged` in `habit_summary.dart` replaces `pushReloadDisplay` for batch group modify

## Type of Change
- [x] refactor

## Checklist
- [x] Ran `make aio && make test` locally — 1009 tests pass