### PR TITLE
Drop jni override and build Linux for both archs

### DIFF
--- a/.github/workflows/_build_test.yml
+++ b/.github/workflows/_build_test.yml
@@ -33,8 +33,35 @@ on:
         required: true
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        env:
+          PLATFORM: ${{ inputs.platform }}
+        run: |
+          case "$PLATFORM" in
+            linux)
+              MATRIX='[
+                {"platform":"linux","arch":"x64","runner":"ubuntu-22.04"},
+                {"platform":"linux","arch":"arm64","runner":"ubuntu-22.04-arm"}
+              ]' ;;
+            ios|macos)
+              MATRIX="[{\"platform\":\"$PLATFORM\",\"arch\":\"\",\"runner\":\"macos-latest\"}]" ;;
+            *)
+              MATRIX="[{\"platform\":\"$PLATFORM\",\"arch\":\"\",\"runner\":\"ubuntu-latest\"}]" ;;
+          esac
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   build:
-    runs-on: ${{ (inputs.platform == 'ios' || inputs.platform == 'macos') && 'macos-latest' || 'ubuntu-latest' }}
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
     environment: ${{ inputs.environment }}
     steps:
       - id: meta
@@ -42,7 +69,7 @@ jobs:
           case "${{ inputs.platform }}" in
             android) echo "label=Android" >> "$GITHUB_OUTPUT" ;;
             ios) echo "label=iOS" >> "$GITHUB_OUTPUT" ;;
-            linux) echo "label=Linux" >> "$GITHUB_OUTPUT" ;;
+            linux) echo "label=Linux (${{ matrix.arch }})" >> "$GITHUB_OUTPUT" ;;
             macos) echo "label=macOS" >> "$GITHUB_OUTPUT" ;;
           esac
 
@@ -77,6 +104,8 @@ jobs:
       - if: inputs.platform == 'linux'
         id: build-linux
         uses: ./.github/actions/build_linux
+        with:
+          arch: ${{ matrix.arch }}
 
       - if: inputs.platform == 'macos'
         id: build-macos
@@ -99,7 +128,7 @@ jobs:
                      echo "path=${{ steps.build-android.outputs.path }}" >> "$GITHUB_OUTPUT" ;;
             ios)     echo "name=app-release.ipa" >> "$GITHUB_OUTPUT"
                      echo "path=${{ steps.build-ios.outputs.ipa-path }}" >> "$GITHUB_OUTPUT" ;;
-            linux)   echo "name=linux-bundle-x64" >> "$GITHUB_OUTPUT"
+            linux)   echo "name=linux-bundle-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
                      echo "path=${{ steps.build-linux.outputs.path }}" >> "$GITHUB_OUTPUT" ;;
             macos)   echo "name=app-release.app" >> "$GITHUB_OUTPUT"
                      echo "path=${{ steps.build-macos.outputs.path }}" >> "$GITHUB_OUTPUT" ;;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -862,13 +862,13 @@ packages:
     source: hosted
     version: "1.0.5"
   jni:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   jni_flutter:
     dependency: transitive
     description:
@@ -877,6 +877,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  jni_util:
+    dependency: transitive
+    description:
+      name: jni_util
+      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   json_annotation:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -224,13 +224,6 @@ dev_dependencies:
   melos: ^7.8.0
   msix: ^3.16.8
 
-# FIXME: jni >= 1.0.1 added global_jni_env.c which casts va_list ↔ void*, valid
-# on x86_64 (va_list is char*) but a hard error on ARM64 where va_list is a
-# struct.  Tracked at https://github.com/dart-lang/native/issues/3498.
-# Drop this once a fixed jni ships.
-dependency_overrides:
-  jni: 1.0.0
-
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
## Summary
Drops the `jni: 1.0.0` dependency override from `pubspec.yaml` — the ARM64 `va_list` build issue that forced the pin was fixed upstream in `jni 1.0.3`, so the override is no longer needed. `pubspec.lock` is bumped to `jni 1.0.3` (now transitive, with `jni_util` added).

Also makes the `/build` PR test build compile Linux for both host architectures via an arch matrix in `_build_test.yml` (x64 on `ubuntu-22.04`, arm64 on `ubuntu-22.04-arm`), mirroring `release-app.yml`'s `build-linux-flatpak`. Artifacts are now named `linux-bundle-<arch>`.

## Type of Change
- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] style
- [ ] test
- [x] chore

## Related Issue
Related to https://github.com/dart-lang/native/issues/3498 (fixed upstream in jni 1.0.3)

## Checklist
- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change