### PR TITLE
refactor: migrate page routing to go_router

### DIFF
--- a/.github/workflows/_build_test.yml
+++ b/.github/workflows/_build_test.yml
@@ -44,10 +44,7 @@ jobs:
         run: |
           case "$PLATFORM" in
             linux)
-              MATRIX='[
-                {"platform":"linux","arch":"x64","runner":"ubuntu-22.04"},
-                {"platform":"linux","arch":"arm64","runner":"ubuntu-22.04-arm"}
-              ]' ;;
+              MATRIX='[{"platform":"linux","arch":"x64","runner":"ubuntu-22.04"},{"platform":"linux","arch":"arm64","runner":"ubuntu-22.04-arm"}]' ;;
             ios|macos)
               MATRIX="[{\"platform\":\"$PLATFORM\",\"arch\":\"\",\"runner\":\"macos-latest\"}]" ;;
             *)

--- a/lib/entries/app/entry.dart
+++ b/lib/entries/app/entry.dart
@@ -31,11 +31,21 @@ import '../../logging/helper.dart';
 import '../../models/app_sync_tasks.dart';
 import '../../models/app_theme_color.dart';
 import '../../models/habit_date.dart';
+import '../../pages/app_about/page.dart' show AppAboutPage;
+import '../../pages/app_debugger/page.dart' show AppDebuggerPage;
+import '../../pages/app_notify_config/page.dart' show AppNotifyConfigPage;
+import '../../pages/app_settings/page.dart' show AppSettingPage;
+import '../../pages/app_sync/page.dart' show AppSyncPage;
 import '../../pages/common/widgets.dart';
+import '../../pages/expermental_features/page.dart'
+    show ExpermentalFeaturesPage;
+import '../../pages/group_manage/page.dart' show GroupManagePage;
 import '../../pages/habit_detail/page.dart' show HabitDetailPage;
 import '../../pages/habit_edit/page.dart' show HabitEditPage;
 import '../../pages/habits_display/page.dart' show HabitsDisplayPage;
 import '../../pages/habits_display/providers.dart' show PageProviders;
+import '../../pages/habits_status_changer/page.dart'
+    show HabitsStatusChangerPage;
 import '../../providers/app_ui/app_debugger.dart';
 import '../../providers/app_ui/app_language.dart';
 import '../../providers/app_ui/app_theme.dart';
@@ -45,9 +55,11 @@ import '../../providers/workflow/app_sync.dart';
 import '../../providers/workflow/habits_manager.dart';
 import '../../reminders/notification_channel.dart';
 import '../../routes/app_router.dart';
+import '../../routes/helpers/group_manage_helper.dart';
 import '../../routes/helpers/habit_create_helper.dart';
 import '../../routes/helpers/habit_detail_helper.dart';
 import '../../routes/helpers/habit_edit_helper.dart';
+import '../../routes/helpers/habits_status_changer_helper.dart';
 import '../../storage/db_helper_builder.dart';
 import '../../storage/profile/handlers.dart';
 import '../../storage/profile_builder.dart';
@@ -118,42 +130,64 @@ class AppEntry extends StatelessWidget {
 class _AppEntry extends StatelessWidget {
   const _AppEntry();
 
-  static final _router = AppRouterBuilder()
-      .addHabits(builder: (_, _) => const _DisplayEntry())
-      .addHabitDetail(
-        builder: (_, state) {
-          final (:habitUUID, :color, :adapter) = state.unpackHabitDetail();
-          return Provider.value(
-            value: adapter,
-            child: HabitDetailPage(habitUUID: habitUUID, color: color),
-          );
-        },
-      )
-      .addHabitCreate(
-        pageBuilder: (_, state) {
-          final (:initForm) = state.unpackHabitCreate();
-          return MaterialPage<void>(
-            fullscreenDialog: true,
-            child: HabitEditPage(
-              initForm: initForm,
-              showInFullscreenDialog: false,
-            ),
-          );
-        },
-      )
-      .addHabitEdit(
-        pageBuilder: (_, state) {
-          final (:habitId, :initForm) = state.unpackHabitEdit();
-          return MaterialPage<void>(
-            fullscreenDialog: true,
-            child: HabitEditPage(
-              initForm: initForm,
-              showInFullscreenDialog: false,
-            ),
-          );
-        },
-      )
-      .build(home: AppRoute.habits);
+  static final _router =
+      (AppRouterBuilder()
+            ..addHabits(builder: (_, _) => const _DisplayEntry())
+            ..addHabitDetail(
+              builder: (_, state) {
+                final (:habitUUID, :color, :adapter) = state
+                    .unpackHabitDetail();
+                return Provider.value(
+                  value: adapter,
+                  child: HabitDetailPage(habitUUID: habitUUID, color: color),
+                );
+              },
+            )
+            ..addHabitCreate(
+              pageBuilder: (_, state) {
+                final (:initForm) = state.unpackHabitCreate();
+                return MaterialPage<void>(
+                  fullscreenDialog: true,
+                  child: HabitEditPage(
+                    initForm: initForm,
+                    showInFullscreenDialog: false,
+                  ),
+                );
+              },
+            )
+            ..addHabitEdit(
+              pageBuilder: (_, state) {
+                final (:habitId, :initForm) = state.unpackHabitEdit();
+                return MaterialPage<void>(
+                  fullscreenDialog: true,
+                  child: HabitEditPage(
+                    initForm: initForm,
+                    showInFullscreenDialog: false,
+                  ),
+                );
+              },
+            )
+            ..addSettings(builder: (_, _) => const AppSettingPage())
+            ..addSettingsAbout(builder: (_, _) => const AppAboutPage())
+            ..addSettingsSync(builder: (_, _) => const AppSyncPage())
+            ..addSettingsNotify(builder: (_, _) => const AppNotifyConfigPage())
+            ..addExperimental(
+              builder: (_, _) => const ExpermentalFeaturesPage(),
+            )
+            ..addDebugger(builder: (_, _) => const AppDebuggerPage())
+            ..addGroupManage(
+              builder: (_, state) {
+                final (:selectedGroupId) = state.unpackGroupManage();
+                return GroupManagePage(initialGroupUUID: selectedGroupId);
+              },
+            )
+            ..addHabitsStatus(
+              builder: (_, state) {
+                final (:uuidList) = state.unpackHabitsStatusChanger();
+                return HabitsStatusChangerPage(uuidList: uuidList);
+              },
+            ))
+          .build(home: AppRoute.habits);
 
   String? getFontFamily() {
     switch (defaultTargetPlatform) {

--- a/lib/entries/app/entry.dart
+++ b/lib/entries/app/entry.dart
@@ -32,7 +32,6 @@ import '../../models/app_sync_tasks.dart';
 import '../../models/app_theme_color.dart';
 import '../../models/habit_date.dart';
 import '../../pages/common/widgets.dart';
-import '../../pages/habits_display/_widgets/changelog_banner_sliver.dart';
 import '../../pages/habits_display/page.dart' show HabitsDisplayPage;
 import '../../providers/app_ui/app_debugger.dart';
 import '../../providers/app_ui/app_language.dart';

--- a/lib/entries/app/entry.dart
+++ b/lib/entries/app/entry.dart
@@ -135,10 +135,10 @@ class _AppEntry extends StatelessWidget {
             ..addHabits(builder: (_, _) => const _DisplayEntry())
             ..addHabitDetail(
               builder: (_, state) {
-                final (:habitUUID, :color, :adapter) = state
+                final (:habitUUID, :color, :summaryAdapter) = state
                     .unpackHabitDetail();
                 return Provider.value(
-                  value: adapter,
+                  value: summaryAdapter,
                   child: HabitDetailPage(habitUUID: habitUUID, color: color),
                 );
               },

--- a/lib/entries/app/entry.dart
+++ b/lib/entries/app/entry.dart
@@ -33,6 +33,7 @@ import '../../models/app_theme_color.dart';
 import '../../models/habit_date.dart';
 import '../../pages/common/widgets.dart';
 import '../../pages/habits_display/page.dart' show HabitsDisplayPage;
+import '../../pages/habits_display/providers.dart' show PageProviders;
 import '../../providers/app_ui/app_debugger.dart';
 import '../../providers/app_ui/app_language.dart';
 import '../../providers/app_ui/app_theme.dart';
@@ -41,6 +42,7 @@ import '../../providers/workflow/app_reminder.dart';
 import '../../providers/workflow/app_sync.dart';
 import '../../providers/workflow/habits_manager.dart';
 import '../../reminders/notification_channel.dart';
+import '../../routes/app_router.dart';
 import '../../storage/db_helper_builder.dart';
 import '../../storage/profile/handlers.dart';
 import '../../storage/profile_builder.dart';
@@ -101,9 +103,7 @@ class AppEntry extends StatelessWidget {
         errorBuilder: (details) => AppErrorEntry(errorDetails: details),
         builder: (context, child) => DateChanger(
           interval: const Duration(seconds: 10),
-          builder: (context) => const AppProviders(
-            child: _AppEntry(homePage: AppPostInit(child: HabitsDisplayPage())),
-          ),
+          builder: (context) => const AppProviders(child: _AppEntry()),
         ),
       ),
     );
@@ -111,9 +111,11 @@ class AppEntry extends StatelessWidget {
 }
 
 class _AppEntry extends StatelessWidget {
-  final Widget homePage;
+  const _AppEntry();
 
-  const _AppEntry({required this.homePage});
+  static final _router = AppRouterBuilder()
+      .addHabits(builder: (_, _) => const _DisplayEntry())
+      .build(home: AppRoute.habits);
 
   String? getFontFamily() {
     switch (defaultTargetPlatform) {
@@ -242,7 +244,7 @@ class _AppEntry extends StatelessWidget {
           final disableAnimations = context.select<AnimationScaleSync, bool>(
             (vm) => vm.disableAnimations,
           );
-          return AppRootView(
+          return AppRootView.router(
             themeMode: transToMaterialThemeType(themeMode),
             language: language,
             disableAnimations: disableAnimations,
@@ -296,11 +298,105 @@ class _AppEntry extends StatelessWidget {
                 extensions: [customColor],
               );
             },
-            child: ChangelogBanner(child: homePage),
+            config: _router,
           );
         },
       ),
     );
+  }
+}
+
+class _DisplayEntry extends StatelessWidget {
+  const _DisplayEntry();
+
+  @override
+  Widget build(BuildContext context) => const ChangelogBanner(
+    child: AppPostInit(child: PageProviders(child: HabitsDisplayPage())),
+  );
+}
+
+class AppPostInit extends SingleChildStatefulWidget {
+  const AppPostInit({required Widget child, super.key}) : super(child: child);
+
+  @override
+  State<StatefulWidget> createState() => _AppPostInitState();
+}
+
+class _AppPostInitState extends SingleChildState<AppPostInit> {
+  final _appSyncBridge = _AppSyncPostInitBridge();
+  final _habitReminderBridge = _HabitReminderPostInitBridge();
+  bool _didHandlePostInit = false;
+
+  void _syncL10n([L10n? l10n]) {
+    context.maybeRead<NotificationChannelData>()?.onL10nUpdate(l10n);
+    _habitReminderBridge.sync(context);
+    _appSyncBridge.sync(
+      context,
+      l10n: l10n,
+      onNeedCheck: _onWebDavAppSyncUserConfirmNeedCheck,
+    );
+  }
+
+  Future<bool> _onWebDavAppSyncUserConfirmNeedCheck(
+    WebDavConfigTaskChecklist checklist,
+  ) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => checklist.isEmptyDir
+          ? const AppSyncWebDavNewServerConfirmDialog()
+          : const AppSyncWebDavOldServerConfirmDialog(),
+    ).then((value) => value ?? false);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _syncL10n(L10n.of(context));
+  }
+
+  @override
+  void dispose() {
+    _habitReminderBridge.dispose();
+    _appSyncBridge.dispose();
+    super.dispose();
+  }
+
+  void _handlePostInit(BuildContext context) {
+    final l10n = L10n.of(context);
+    final reminderContent = AppReminderContent.maybeFromL10n(l10n);
+    appLog.build.info(context, ex: ["onPostInitHandled", l10n]);
+    context.maybeRead<AppDebuggerViewModel>()?.processDebuggingNotification(
+      l10n,
+    );
+    context.maybeRead<AppReminderAccess>()?.processTrigger(
+      const AppReminderTrigger.startup(),
+      content: reminderContent,
+    );
+    context.maybeRead<HabitsDisplayAccess>()?.refreshHabitReminders(
+      params: const HabitReminderRefreshParams.startup(),
+    );
+    _syncL10n(l10n);
+    _didHandlePostInit = true;
+
+    final handler = context
+        .read<ProfileViewModel>()
+        .getHandler<AppLastChangelogVersionProfileHandler>();
+    final currentVersion = AppInfo().changelogVersion;
+    final lastVersion = handler?.get();
+
+    if (lastVersion != currentVersion) {
+      handler?.set(currentVersion);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        showChangelogBanner(context, version: currentVersion);
+      });
+    }
+  }
+
+  @override
+  Widget buildWithChild(BuildContext context, Widget? child) {
+    if (!_didHandlePostInit) _handlePostInit(context);
+    return child!;
   }
 }
 
@@ -465,90 +561,5 @@ final class _HabitReminderPostInitBridge {
     access.refreshHabitReminders(
       params: const HabitReminderRefreshParams.dateChange(),
     );
-  }
-}
-
-class AppPostInit extends SingleChildStatefulWidget {
-  const AppPostInit({required Widget child, super.key}) : super(child: child);
-
-  @override
-  State<StatefulWidget> createState() => _AppPostInitState();
-}
-
-class _AppPostInitState extends SingleChildState<AppPostInit> {
-  final _appSyncBridge = _AppSyncPostInitBridge();
-  final _habitReminderBridge = _HabitReminderPostInitBridge();
-  bool _didHandlePostInit = false;
-
-  void _syncL10n([L10n? l10n]) {
-    context.maybeRead<NotificationChannelData>()?.onL10nUpdate(l10n);
-    _habitReminderBridge.sync(context);
-    _appSyncBridge.sync(
-      context,
-      l10n: l10n,
-      onNeedCheck: _onWebDavAppSyncUserConfirmNeedCheck,
-    );
-  }
-
-  Future<bool> _onWebDavAppSyncUserConfirmNeedCheck(
-    WebDavConfigTaskChecklist checklist,
-  ) {
-    return showDialog<bool>(
-      context: context,
-      builder: (context) => checklist.isEmptyDir
-          ? const AppSyncWebDavNewServerConfirmDialog()
-          : const AppSyncWebDavOldServerConfirmDialog(),
-    ).then((value) => value ?? false);
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _syncL10n(L10n.of(context));
-  }
-
-  @override
-  void dispose() {
-    _habitReminderBridge.dispose();
-    _appSyncBridge.dispose();
-    super.dispose();
-  }
-
-  void _handlePostInit(BuildContext context) {
-    final l10n = L10n.of(context);
-    final reminderContent = AppReminderContent.maybeFromL10n(l10n);
-    appLog.build.info(context, ex: ["onPostInitHandled", l10n]);
-    context.maybeRead<AppDebuggerViewModel>()?.processDebuggingNotification(
-      l10n,
-    );
-    context.maybeRead<AppReminderAccess>()?.processTrigger(
-      const AppReminderTrigger.startup(),
-      content: reminderContent,
-    );
-    context.maybeRead<HabitsDisplayAccess>()?.refreshHabitReminders(
-      params: const HabitReminderRefreshParams.startup(),
-    );
-    _syncL10n(l10n);
-    _didHandlePostInit = true;
-
-    final handler = context
-        .read<ProfileViewModel>()
-        .getHandler<AppLastChangelogVersionProfileHandler>();
-    final currentVersion = AppInfo().changelogVersion;
-    final lastVersion = handler?.get();
-
-    if (lastVersion != currentVersion) {
-      handler?.set(currentVersion);
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        showChangelogBanner(context, version: currentVersion);
-      });
-    }
-  }
-
-  @override
-  Widget buildWithChild(BuildContext context, Widget? child) {
-    if (!_didHandlePostInit) _handlePostInit(context);
-    return child!;
   }
 }

--- a/lib/entries/app/entry.dart
+++ b/lib/entries/app/entry.dart
@@ -33,6 +33,7 @@ import '../../models/app_theme_color.dart';
 import '../../models/habit_date.dart';
 import '../../pages/common/widgets.dart';
 import '../../pages/habit_detail/page.dart' show HabitDetailPage;
+import '../../pages/habit_edit/page.dart' show HabitEditPage;
 import '../../pages/habits_display/page.dart' show HabitsDisplayPage;
 import '../../pages/habits_display/providers.dart' show PageProviders;
 import '../../providers/app_ui/app_debugger.dart';
@@ -44,7 +45,9 @@ import '../../providers/workflow/app_sync.dart';
 import '../../providers/workflow/habits_manager.dart';
 import '../../reminders/notification_channel.dart';
 import '../../routes/app_router.dart';
+import '../../routes/helpers/habit_create_helper.dart';
 import '../../routes/helpers/habit_detail_helper.dart';
+import '../../routes/helpers/habit_edit_helper.dart';
 import '../../storage/db_helper_builder.dart';
 import '../../storage/profile/handlers.dart';
 import '../../storage/profile_builder.dart';
@@ -123,6 +126,30 @@ class _AppEntry extends StatelessWidget {
           return Provider.value(
             value: adapter,
             child: HabitDetailPage(habitUUID: habitUUID, color: color),
+          );
+        },
+      )
+      .addHabitCreate(
+        pageBuilder: (_, state) {
+          final (:initForm) = state.unpackHabitCreate();
+          return MaterialPage<void>(
+            fullscreenDialog: true,
+            child: HabitEditPage(
+              initForm: initForm,
+              showInFullscreenDialog: false,
+            ),
+          );
+        },
+      )
+      .addHabitEdit(
+        pageBuilder: (_, state) {
+          final (:habitId, :initForm) = state.unpackHabitEdit();
+          return MaterialPage<void>(
+            fullscreenDialog: true,
+            child: HabitEditPage(
+              initForm: initForm,
+              showInFullscreenDialog: false,
+            ),
           );
         },
       )

--- a/lib/entries/app/entry.dart
+++ b/lib/entries/app/entry.dart
@@ -32,6 +32,7 @@ import '../../models/app_sync_tasks.dart';
 import '../../models/app_theme_color.dart';
 import '../../models/habit_date.dart';
 import '../../pages/common/widgets.dart';
+import '../../pages/habit_detail/page.dart' show HabitDetailPage;
 import '../../pages/habits_display/page.dart' show HabitsDisplayPage;
 import '../../pages/habits_display/providers.dart' show PageProviders;
 import '../../providers/app_ui/app_debugger.dart';
@@ -43,6 +44,7 @@ import '../../providers/workflow/app_sync.dart';
 import '../../providers/workflow/habits_manager.dart';
 import '../../reminders/notification_channel.dart';
 import '../../routes/app_router.dart';
+import '../../routes/helpers/habit_detail_helper.dart';
 import '../../storage/db_helper_builder.dart';
 import '../../storage/profile/handlers.dart';
 import '../../storage/profile_builder.dart';
@@ -115,6 +117,15 @@ class _AppEntry extends StatelessWidget {
 
   static final _router = AppRouterBuilder()
       .addHabits(builder: (_, _) => const _DisplayEntry())
+      .addHabitDetail(
+        builder: (_, state) {
+          final (:habitUUID, :color, :adapter) = state.unpackHabitDetail();
+          return Provider.value(
+            value: adapter,
+            child: HabitDetailPage(habitUUID: habitUUID, color: color),
+          );
+        },
+      )
       .build(home: AppRoute.habits);
 
   String? getFontFamily() {

--- a/lib/entries/common/app_root_view.dart
+++ b/lib/entries/common/app_root_view.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/consts.dart';
 import '../../common/global.dart';
@@ -23,6 +24,7 @@ class AppRootView extends StatelessWidget {
   final ThemeMode themeMode;
   final Locale? language;
   final Widget? child;
+  final GoRouter? routerConfig;
   final ThemeData Function()? lightThemeBuilder;
   final ThemeData Function()? darkThemeBuilder;
   final bool disableAnimations;
@@ -35,7 +37,18 @@ class AppRootView extends StatelessWidget {
     this.darkThemeBuilder,
     this.child,
     this.disableAnimations = false,
-  });
+  }) : routerConfig = null;
+
+  const AppRootView.router({
+    super.key,
+    required this.themeMode,
+    this.language,
+    this.lightThemeBuilder,
+    this.darkThemeBuilder,
+    required GoRouter config,
+    this.disableAnimations = false,
+  }) : child = null,
+       routerConfig = config;
 
   const AppRootView.withDefault({
     super.key,
@@ -45,11 +58,34 @@ class AppRootView extends StatelessWidget {
     this.darkThemeBuilder,
     this.child,
     this.disableAnimations = false,
-  });
+  }) : routerConfig = null;
+
+  bool get _useRouter => routerConfig != null;
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    Widget routerApp() => MaterialApp.router(
+      routerConfig: routerConfig!,
+      onGenerateTitle: (context) => L10n.of(context)?.appName ?? appName,
+      scaffoldMessengerKey: snackbarKey,
+      theme: lightThemeBuilder?.call(),
+      darkTheme: darkThemeBuilder?.call(),
+      themeMode: themeMode,
+      locale: language,
+      shortcuts: WidgetsApp.defaultShortcuts,
+      actions: WidgetsApp.defaultActions,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          disableAnimations:
+              disableAnimations || MediaQuery.disableAnimationsOf(context),
+        ),
+        child: UnfocusOnTap(child: child),
+      ),
+      localizationsDelegates: appLocalizationsDelegates,
+      supportedLocales: appSupportedLocales,
+      debugShowCheckedModeBanner: false,
+    );
+    Widget homeApp() => MaterialApp(
       onGenerateTitle: (context) => L10n.of(context)?.appName ?? appName,
       navigatorKey: navigatorKey,
       navigatorObservers: [currentRouteObserver],
@@ -72,5 +108,6 @@ class AppRootView extends StatelessWidget {
       supportedLocales: appSupportedLocales,
       debugShowCheckedModeBanner: false,
     );
+    return _useRouter ? routerApp() : homeApp();
   }
 }

--- a/lib/entries/common/app_root_view.dart
+++ b/lib/entries/common/app_root_view.dart
@@ -62,47 +62,49 @@ class AppRootView extends StatelessWidget {
 
   bool get _useRouter => routerConfig != null;
 
+  Widget _builder(BuildContext context, Widget? child) => MediaQuery(
+    data: MediaQuery.of(context).copyWith(
+      disableAnimations:
+          disableAnimations || MediaQuery.disableAnimationsOf(context),
+    ),
+    child: UnfocusOnTap(child: child),
+  );
+
+  String _onGenerateTitle(BuildContext context) =>
+      L10n.of(context)?.appName ?? appName;
+
   @override
   Widget build(BuildContext context) {
+    final lightTheme = lightThemeBuilder?.call();
+    final darkTheme = darkThemeBuilder?.call();
+
     Widget routerApp() => MaterialApp.router(
       routerConfig: routerConfig!,
-      onGenerateTitle: (context) => L10n.of(context)?.appName ?? appName,
+      onGenerateTitle: _onGenerateTitle,
       scaffoldMessengerKey: snackbarKey,
-      theme: lightThemeBuilder?.call(),
-      darkTheme: darkThemeBuilder?.call(),
+      theme: lightTheme,
+      darkTheme: darkTheme,
       themeMode: themeMode,
       locale: language,
       shortcuts: WidgetsApp.defaultShortcuts,
       actions: WidgetsApp.defaultActions,
-      builder: (context, child) => MediaQuery(
-        data: MediaQuery.of(context).copyWith(
-          disableAnimations:
-              disableAnimations || MediaQuery.disableAnimationsOf(context),
-        ),
-        child: UnfocusOnTap(child: child),
-      ),
+      builder: _builder,
       localizationsDelegates: appLocalizationsDelegates,
       supportedLocales: appSupportedLocales,
       debugShowCheckedModeBanner: false,
     );
     Widget homeApp() => MaterialApp(
-      onGenerateTitle: (context) => L10n.of(context)?.appName ?? appName,
+      onGenerateTitle: _onGenerateTitle,
       navigatorKey: navigatorKey,
       navigatorObservers: [currentRouteObserver],
       scaffoldMessengerKey: snackbarKey,
-      theme: lightThemeBuilder?.call(),
-      darkTheme: darkThemeBuilder?.call(),
+      theme: lightTheme,
+      darkTheme: darkTheme,
       themeMode: themeMode,
       locale: language,
       shortcuts: WidgetsApp.defaultShortcuts,
       actions: WidgetsApp.defaultActions,
-      builder: (context, child) => MediaQuery(
-        data: MediaQuery.of(context).copyWith(
-          disableAnimations:
-              disableAnimations || MediaQuery.disableAnimationsOf(context),
-        ),
-        child: UnfocusOnTap(child: child),
-      ),
+      builder: _builder,
       home: child,
       localizationsDelegates: appLocalizationsDelegates,
       supportedLocales: appSupportedLocales,

--- a/lib/pages/app_about/page.dart
+++ b/lib/pages/app_about/page.dart
@@ -27,12 +27,6 @@ import '../../widgets/widgets.dart';
 import '../common/widgets.dart';
 import 'widgets.dart';
 
-Future<void> naviToAppAboutPage({required BuildContext context}) async {
-  return Navigator.of(
-    context,
-  ).push<void>(MaterialPageRoute(builder: (context) => const AppAboutPage()));
-}
-
 class AppAboutPage extends StatelessWidget {
   const AppAboutPage({super.key});
 

--- a/lib/pages/app_debugger/page.dart
+++ b/lib/pages/app_debugger/page.dart
@@ -28,6 +28,7 @@ import '../../logging/helper.dart';
 import '../../logging/level.dart';
 import '../../logging/logger_manager.dart';
 import '../../providers/app_ui/app_debugger.dart';
+import '../../routes/app_router.dart';
 import '../../routes/navigator_helpers.dart';
 import '../../utils/app_path_provider.dart';
 import '../../utils/debug_info.dart';
@@ -43,9 +44,9 @@ Future<void> onDebuggerNotificationTapped() async {
   final currentRouteName = currentRouteObserver.routeName;
   appLog.debugger.info(
     "onDebuggerNotificationTapped: navi",
-    ex: [AppDebuggerPage.routerName, currentRouteName],
+    ex: [AppRoute.debugger.name, currentRouteName],
   );
-  if (currentRouteName != AppDebuggerPage.routerName) {
+  if (currentRouteName != AppRoute.debugger.name) {
     naviToAppDebuggerPage(context: context);
   }
 }

--- a/lib/pages/app_debugger/page.dart
+++ b/lib/pages/app_debugger/page.dart
@@ -28,6 +28,7 @@ import '../../logging/helper.dart';
 import '../../logging/level.dart';
 import '../../logging/logger_manager.dart';
 import '../../providers/app_ui/app_debugger.dart';
+import '../../routes/navigator_helpers.dart';
 import '../../utils/app_path_provider.dart';
 import '../../utils/debug_info.dart';
 import '../../utils/xshare.dart';
@@ -47,15 +48,6 @@ Future<void> onDebuggerNotificationTapped() async {
   if (currentRouteName != AppDebuggerPage.routerName) {
     naviToAppDebuggerPage(context: context);
   }
-}
-
-Future<void> naviToAppDebuggerPage({required BuildContext context}) async {
-  return Navigator.of(context).push<void>(
-    MaterialPageRoute(
-      builder: (context) => const AppDebuggerPage(),
-      settings: const RouteSettings(name: AppDebuggerPage.routerName),
-    ),
-  );
 }
 
 /// Depend Providers

--- a/lib/pages/app_notify_config/page.dart
+++ b/lib/pages/app_notify_config/page.dart
@@ -20,12 +20,6 @@ import '../../providers/workflow/app_notify_config.dart';
 import '../../reminders/notification_channel.dart';
 import '../../widgets/widgets.dart';
 
-Future<void> naviToNotifyConfigPage({required BuildContext context}) {
-  return Navigator.of(context).push<void>(
-    MaterialPageRoute(builder: (context) => const AppNotifyConfigPage()),
-  );
-}
-
 class AppNotifyConfigPage extends StatelessWidget {
   const AppNotifyConfigPage({super.key});
 

--- a/lib/pages/app_settings/_widgets/app_setting_notify_tile.dart
+++ b/lib/pages/app_settings/_widgets/app_setting_notify_tile.dart
@@ -18,7 +18,7 @@ import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
 
 import '../../../l10n/localizations.dart';
-import '../../app_notify_config/page.dart' as app_notify_config;
+import '../../../routes/navigator_helpers.dart';
 
 class AppSettingNotifyTile extends StatelessWidget {
   const AppSettingNotifyTile({super.key});
@@ -57,7 +57,7 @@ class _AppSettingNotifyTile extends StatelessWidget {
     return ListTile(
       title: Text(l10n?.appSetting_notify_titleTile ?? "Notifications"),
       subtitle: l10n != null ? Text(l10n.appSetting_notify_subtitleTile) : null,
-      onTap: () => app_notify_config.naviToNotifyConfigPage(context: context),
+      onTap: () => naviToNotifyConfigPage(context: context),
     );
   }
 }

--- a/lib/pages/app_settings/page.dart
+++ b/lib/pages/app_settings/page.dart
@@ -51,26 +51,16 @@ import '../../providers/workflow/habits_file_exporter.dart';
 import '../../providers/workflow/habits_file_importer.dart';
 import '../../providers/workflow/habits_manager.dart';
 import '../../providers/workflow/thirdparty_file_importer.dart';
+import '../../routes/navigator_helpers.dart';
 import '../../storage/db_helper_provider.dart';
 import '../../storage/profile_provider.dart';
 import '../../utils/app_path_provider.dart';
 import '../../utils/xshare.dart';
 import '../../widgets/helpers.dart';
 import '../../widgets/widgets.dart';
-import '../app_about/page.dart' as app_about;
-import '../app_debugger/page.dart' as app_debugger;
-import '../app_sync/page.dart' as app_sync;
 import '../common/widgets.dart';
-import '../expermental_features/page.dart' as exp_feature;
-import '../group_manage/page.dart' as group_manage;
 import 'providers.dart';
 import 'widgets.dart';
-
-Future<void> naviToAppSettingPage({required BuildContext context}) async {
-  return Navigator.of(
-    context,
-  ).push<void>(MaterialPageRoute(builder: (context) => const AppSettingPage()));
-}
 
 /// Depend Providers
 /// - Required for page providers:
@@ -825,8 +815,7 @@ class _PageState extends State<_Page> with XShare {
                 "Experimental Features",
           ),
         ),
-        onTap: () =>
-            exp_feature.naviToExperimentalFeaturesPage(context: context),
+        onTap: () => naviToExperimentalFeaturesPage(context: context),
       ),
       Selector<AppDeveloperViewModel, bool>(
         selector: (context, vm) => vm.isInDevelopMode,
@@ -855,7 +844,7 @@ class _PageState extends State<_Page> with XShare {
               ? Text(l10n.appSetting_debugger_titleText)
               : const Text("Debugger"),
         ),
-        onTap: () => app_debugger.naviToAppDebuggerPage(context: context),
+        onTap: () => naviToAppDebuggerPage(context: context),
       ),
       ListTile(
         title: L10nBuilder(
@@ -863,7 +852,7 @@ class _PageState extends State<_Page> with XShare {
               ? Text(l10n.appSetting_about_titleText)
               : const Text("About"),
         ),
-        onTap: () => app_about.naviToAppAboutPage(context: context),
+        onTap: () => naviToAppAboutPage(context: context),
       ),
     ];
 
@@ -884,7 +873,7 @@ class _PageState extends State<_Page> with XShare {
               ? Text(l10n.appSetting_manageGroups_subtitleText)
               : const Text("Create, edit, and delete habit groups"),
           trailing: const Icon(Icons.chevron_right),
-          onTap: () => group_manage.naviToGroupManagePage(context: context),
+          onTap: () => naviToGroupManagePage(context: context),
         ),
       ),
     ];
@@ -903,7 +892,7 @@ class _PageState extends State<_Page> with XShare {
           builder: (context, l10n) =>
               Text(l10n?.appSetting_syncOption_titleText ?? "Sync Option"),
         ),
-        onTap: () => app_sync.naviToAppSyncPage(context: context),
+        onTap: () => naviToAppSyncPage(context: context),
       ),
     ];
 

--- a/lib/pages/app_sync/page.dart
+++ b/lib/pages/app_sync/page.dart
@@ -26,12 +26,6 @@ import '../app_sync_server_editor/page.dart' as app_sync_server_editor;
 import 'providers.dart';
 import 'widgets.dart';
 
-Future<void> naviToAppSyncPage({required BuildContext context}) async {
-  return Navigator.of(
-    context,
-  ).push<void>(MaterialPageRoute(builder: (context) => const AppSyncPage()));
-}
-
 final class AppSyncPage extends StatelessWidget {
   const AppSyncPage({super.key});
 

--- a/lib/pages/expermental_features/page.dart
+++ b/lib/pages/expermental_features/page.dart
@@ -21,12 +21,6 @@ import '../../logging/helper.dart';
 import '../../providers/app_ui/app_experimental_feature.dart';
 import '../../widgets/widgets.dart';
 
-Future<void> naviToExperimentalFeaturesPage({required BuildContext context}) {
-  return Navigator.of(context).push<void>(
-    MaterialPageRoute(builder: (context) => const ExpermentalFeaturesPage()),
-  );
-}
-
 class ExpermentalFeaturesPage extends StatelessWidget {
   const ExpermentalFeaturesPage({super.key});
 

--- a/lib/pages/group_manage/page.dart
+++ b/lib/pages/group_manage/page.dart
@@ -30,17 +30,6 @@ import '_providers/group_manage.dart';
 import 'providers.dart';
 import 'widgets.dart';
 
-Future<void> naviToGroupManagePage({
-  required BuildContext context,
-  String? initialGroupUUID,
-}) async {
-  return Navigator.of(context).push<void>(
-    MaterialPageRoute(
-      builder: (context) => GroupManagePage(initialGroupUUID: initialGroupUUID),
-    ),
-  );
-}
-
 class GroupManagePage extends StatelessWidget {
   final String? initialGroupUUID;
 

--- a/lib/pages/habit_detail/page.dart
+++ b/lib/pages/habit_detail/page.dart
@@ -41,6 +41,7 @@ import '../../providers/app_ui/app_developer.dart';
 import '../../providers/app_ui/app_first_day.dart';
 import '../../providers/support/utils.dart';
 import '../../providers/workflow/habits_file_exporter.dart';
+import '../../routes/navigator_helpers.dart';
 import '../../storage/db/handlers/habit.dart';
 import '../../theme/color.dart';
 import '../../theme/icon.dart';
@@ -50,7 +51,6 @@ import '../../widgets/helpers.dart';
 import '../../widgets/widgets.dart';
 import '../common/debug.dart';
 import '../common/widgets.dart';
-import '../habit_edit/page.dart' as habit_edit;
 import '../habits_display/_providers/habit_summary.dart' as habit_summary;
 import '_providers/habit_detail.dart';
 import '_providers/habit_detail_freqchart.dart';
@@ -71,22 +71,6 @@ class DetailPageReturn {
     this.habitName,
     this.recordList,
   });
-}
-
-Future<DetailPageReturn?> naviToHabitDetailPage({
-  required BuildContext context,
-  required HabitUUID habitUUID,
-  HabitColor? color,
-  habit_summary.HabitSummaryViewModel? summary,
-}) async {
-  return Navigator.of(context).push<DetailPageReturn>(
-    MaterialPageRoute(
-      builder: (context) => Provider.value(
-        value: summary?.buildHabitDetailAdapter(),
-        child: HabitDetailPage(habitUUID: habitUUID, color: color),
-      ),
-    ),
-  );
 }
 
 // _AppEventBusExtension removed — VM now handles all event emission.
@@ -163,10 +147,7 @@ class _PageState extends State<_Page>
     final dbcell = await _vm.loadCurrentHabitDetail();
     if (dbcell == null || !mounted) return false;
     final form = formBuilder(dbcell);
-    final result = await habit_edit.naviToHabitEidtPage(
-      context: context,
-      initForm: form,
-    );
+    final result = await naviToHabitEidtPage(context: context, initForm: form);
     if (result == null) return false;
     if (!(mounted && _vm.mounted)) return false;
     _vm.onEditCompleted(summary: _summary);

--- a/lib/pages/habit_detail/page.dart
+++ b/lib/pages/habit_detail/page.dart
@@ -147,7 +147,9 @@ class _PageState extends State<_Page>
     final dbcell = await _vm.loadCurrentHabitDetail();
     if (dbcell == null || !mounted) return false;
     final form = formBuilder(dbcell);
-    final result = await naviToHabitEidtPage(context: context, initForm: form);
+    final result = await (form.editMode == HabitDisplayEditMode.create
+        ? naviToHabitCreatePage(context: context, initForm: form)
+        : naviToHabitEditPage(context: context, initForm: form));
     if (result == null) return false;
     if (!(mounted && _vm.mounted)) return false;
     _vm.onEditCompleted(summary: _summary);

--- a/lib/pages/habit_edit/page.dart
+++ b/lib/pages/habit_edit/page.dart
@@ -33,26 +33,11 @@ import '../../providers/app_ui/app_caches.dart';
 import '../../providers/app_ui/app_developer.dart';
 import '../../providers/app_ui/app_first_day.dart';
 import '../../reminders/notification_channel.dart';
-import '../../storage/db/handlers/habit.dart';
 import '../../widgets/widgets.dart';
 import '../common/debug.dart';
 import '../common/widgets.dart';
 import '_providers/habit_form.dart';
 import 'widgets.dart';
-
-Future<HabitDBCell?> naviToHabitEidtPage({
-  required BuildContext context,
-  required HabitForm initForm,
-  bool? naviWithFullscreenDialog,
-}) async {
-  return Navigator.of(context).push<HabitDBCell>(
-    MaterialPageRoute(
-      fullscreenDialog: naviWithFullscreenDialog ?? true,
-      builder: (context) =>
-          HabitEditPage(initForm: initForm, showInFullscreenDialog: false),
-    ),
-  );
-}
 
 /// Depend Providers
 /// - Required for builder:

--- a/lib/pages/habits_display/_providers/habit_summary.dart
+++ b/lib/pages/habits_display/_providers/habit_summary.dart
@@ -176,8 +176,7 @@ class HabitSummaryViewModel extends ChangeNotifier
 
   HabitSummaryViewModel();
 
-  HabitDetailAdapter buildHabitDetailAdapter() =>
-      HabitDetailAdapter(root: this);
+  HabitDetailAdapter get summaryAdapter => HabitDetailAdapter(root: this);
 
   @override
   bool get mounted => _mounted;

--- a/lib/pages/habits_display/_widgets/habit_display_develop_list.dart
+++ b/lib/pages/habits_display/_widgets/habit_display_develop_list.dart
@@ -20,8 +20,8 @@ import '../../../l10n/localizations.dart';
 import '../../../providers/app_ui/app_debugger.dart';
 import '../../../storage/profile/handlers.dart';
 import '../../../storage/profile_provider.dart';
+import '../../../widgets/widgets.dart';
 import '../../common/widgets.dart';
-import 'changelog_banner_sliver.dart';
 
 class HabitDisplayDevelopSliverList extends StatefulWidget {
   final void Function(int count, bool withGroups)? onAddCountHabitsPressed;

--- a/lib/pages/habits_display/page_habits.dart
+++ b/lib/pages/habits_display/page_habits.dart
@@ -651,7 +651,9 @@ class HabitsTabPageState extends State<HabitsTabPage>
       if (!mounted) return false;
     }
 
-    final result = await naviToHabitEidtPage(context: context, initForm: form);
+    final result = await (form.editMode == HabitDisplayEditMode.create
+        ? naviToHabitCreatePage(context: context, initForm: form)
+        : naviToHabitEditPage(context: context, initForm: form));
 
     if (result == null) return false;
     if (!(mounted && _vm.mounted)) return false;

--- a/lib/pages/habits_display/page_habits.dart
+++ b/lib/pages/habits_display/page_habits.dart
@@ -974,7 +974,7 @@ class HabitsTabPageState extends State<HabitsTabPage>
         context: context,
         habitUUID: uuid,
         color: _vm.getHabit(uuid)?.color,
-        adapter: _vm.buildHabitDetailAdapter(),
+        summaryAdapter: _vm.summaryAdapter,
       );
 
       if (result == null || !mounted) return;

--- a/lib/pages/habits_display/page_habits.dart
+++ b/lib/pages/habits_display/page_habits.dart
@@ -1465,7 +1465,7 @@ class _GroupHeaderTileState extends State<_GroupHeaderTile> {
               if (!mounted) return;
               naviToGroupManagePage(
                 context: context,
-                initialGroupUUID: widget.header.groupUUID,
+                selectedGroupId: widget.header.groupUUID,
               );
             },
             child: Text(l10n?.groupHeader_menu_manage ?? 'Manage'),

--- a/lib/pages/habits_display/page_habits.dart
+++ b/lib/pages/habits_display/page_habits.dart
@@ -50,14 +50,13 @@ import '../../providers/app_ui/habits_sort.dart';
 import '../../providers/workflow/app_event.dart';
 import '../../providers/workflow/app_sync.dart';
 import '../../providers/workflow/habits_file_exporter.dart';
+import '../../routes/navigator_helpers.dart';
 import '../../storage/db/handlers/habit.dart';
 import '../../utils/xshare.dart';
 import '../../widgets/helpers.dart';
 import '../../widgets/widgets.dart';
-import '../app_settings/page.dart' as app_settings;
 import '../common/debug.dart';
 import '../common/widgets.dart';
-import '../group_manage/page.dart' as group_manage;
 import '../habit_detail/page.dart' as habit_detail;
 import '../habit_edit/page.dart' as habit_edit;
 import '../habits_status_changer/page.dart' as habits_status_changer;
@@ -601,7 +600,7 @@ class HabitsTabPageState extends State<HabitsTabPage>
       _vm.exitSearchMode();
       _vm.exitEditMode();
     }
-    app_settings.naviToAppSettingPage(context: context);
+    naviToAppSettingPage(context: context);
   }
 
   Future<void> _onRefreshIndicatorTriggered() async {
@@ -652,10 +651,7 @@ class HabitsTabPageState extends State<HabitsTabPage>
       if (!mounted) return false;
     }
 
-    final result = await habit_edit.naviToHabitEidtPage(
-      context: context,
-      initForm: form,
-    );
+    final result = await naviToHabitEidtPage(context: context, initForm: form);
 
     if (result == null) return false;
     if (!(mounted && _vm.mounted)) return false;
@@ -972,11 +968,11 @@ class HabitsTabPageState extends State<HabitsTabPage>
       if (!mounted) return;
 
       Navigator.of(context).popUntil((route) => route.isFirst);
-      final result = await habit_detail.naviToHabitDetailPage(
+      final result = await naviToHabitDetailPage(
         context: context,
         habitUUID: uuid,
         color: _vm.getHabit(uuid)?.color,
-        summary: _vm,
+        adapter: _vm.buildHabitDetailAdapter(),
       );
 
       if (result == null || !mounted) return;
@@ -1465,7 +1461,7 @@ class _GroupHeaderTileState extends State<_GroupHeaderTile> {
             leadingIcon: const Icon(Icons.drag_handle),
             onPressed: () {
               if (!mounted) return;
-              group_manage.naviToGroupManagePage(
+              naviToGroupManagePage(
                 context: context,
                 initialGroupUUID: widget.header.groupUUID,
               );

--- a/lib/pages/habits_display/providers.dart
+++ b/lib/pages/habits_display/providers.dart
@@ -31,6 +31,8 @@ import '_providers/habit_summary.dart';
 import '_providers/habits_grouping.dart';
 import '_providers/habits_today.dart';
 
+export '_providers/habit_summary.dart' show HabitDetailAdapter;
+
 class PageProviders extends SingleChildStatelessWidget {
   const PageProviders({super.key, super.child});
 

--- a/lib/pages/habits_display/widgets.dart
+++ b/lib/pages/habits_display/widgets.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export '_widgets/changelog_banner_sliver.dart';
 export '_widgets/habit_display_develop_list.dart';
 export '_widgets/habit_display_edit_mode_action.dart';
 export '_widgets/habit_display_empty_image.dart';

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -18,7 +18,9 @@ import '../../common/global.dart';
 
 enum AppRoute {
   habits('habits'),
-  habitDetail('habits/:habitId');
+  habitDetail('habits/:habitId'),
+  habitCreate('habit/create'),
+  habitEdit('habit/edit');
 
   const AppRoute(this.name);
   final String name;
@@ -30,6 +32,8 @@ class AppRouterBuilder {
   static String _pathFor(AppRoute route) => switch (route) {
     AppRoute.habits => '/habits',
     AppRoute.habitDetail => '/habits/:habitId',
+    AppRoute.habitCreate => '/habit/create',
+    AppRoute.habitEdit => '/habit/edit',
   };
 
   AppRouterBuilder addHabits({required GoRouterWidgetBuilder builder}) {
@@ -44,6 +48,30 @@ class AppRouterBuilder {
     const route = AppRoute.habitDetail;
     _routes.add(
       GoRoute(path: _pathFor(route), name: route.name, builder: builder),
+    );
+    return this;
+  }
+
+  AppRouterBuilder addHabitCreate({required GoRouterPageBuilder pageBuilder}) {
+    const route = AppRoute.habitCreate;
+    _routes.add(
+      GoRoute(
+        path: _pathFor(route),
+        name: route.name,
+        pageBuilder: pageBuilder,
+      ),
+    );
+    return this;
+  }
+
+  AppRouterBuilder addHabitEdit({required GoRouterPageBuilder pageBuilder}) {
+    const route = AppRoute.habitEdit;
+    _routes.add(
+      GoRoute(
+        path: _pathFor(route),
+        name: route.name,
+        pageBuilder: pageBuilder,
+      ),
     );
     return this;
   }

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -1,0 +1,49 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:go_router/go_router.dart';
+
+import '../../common/global.dart';
+
+enum AppRoute {
+  habits('habits');
+
+  const AppRoute(this.name);
+  final String name;
+}
+
+class AppRouterBuilder {
+  final List<RouteBase> _routes = [];
+
+  static String _pathFor(AppRoute route) => switch (route) {
+    AppRoute.habits => '/habits',
+  };
+
+  AppRouterBuilder addHabits({required GoRouterWidgetBuilder builder}) {
+    const route = AppRoute.habits;
+    _routes.add(
+      GoRoute(path: _pathFor(route), name: route.name, builder: builder),
+    );
+    return this;
+  }
+
+  GoRouter build({AppRoute? home}) {
+    return GoRouter(
+      initialLocation: home != null ? _pathFor(home) : null,
+      navigatorKey: navigatorKey,
+      observers: [currentRouteObserver],
+      routes: _routes,
+    );
+  }
+}

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -20,7 +20,15 @@ enum AppRoute {
   habits('habits'),
   habitDetail('habits/:habitId'),
   habitCreate('habit/create'),
-  habitEdit('habit/edit');
+  habitEdit('habit/edit'),
+  settings('settings'),
+  settingsAbout('settings/about'),
+  settingsSync('settings/sync'),
+  settingsNotify('settings/notify'),
+  experimental('experimental'),
+  debugger('debugger'),
+  groupManage('group/manage'),
+  habitsStatus('habits/status');
 
   const AppRoute(this.name);
   final String name;
@@ -34,46 +42,134 @@ class AppRouterBuilder {
     AppRoute.habitDetail => '/habits/:habitId',
     AppRoute.habitCreate => '/habit/create',
     AppRoute.habitEdit => '/habit/edit',
+    AppRoute.settings => '/settings',
+    AppRoute.settingsAbout => '/settings/about',
+    AppRoute.settingsSync => '/settings/sync',
+    AppRoute.settingsNotify => '/settings/notify',
+    AppRoute.experimental => '/experimental',
+    AppRoute.debugger => '/debugger',
+    AppRoute.groupManage => '/group/manage',
+    AppRoute.habitsStatus => '/habits/status',
   };
 
-  AppRouterBuilder addHabits({required GoRouterWidgetBuilder builder}) {
-    const route = AppRoute.habits;
-    _routes.add(
-      GoRoute(path: _pathFor(route), name: route.name, builder: builder),
-    );
-    return this;
-  }
-
-  AppRouterBuilder addHabitDetail({required GoRouterWidgetBuilder builder}) {
-    const route = AppRoute.habitDetail;
-    _routes.add(
-      GoRoute(path: _pathFor(route), name: route.name, builder: builder),
-    );
-    return this;
-  }
-
-  AppRouterBuilder addHabitCreate({required GoRouterPageBuilder pageBuilder}) {
-    const route = AppRoute.habitCreate;
+  void addHabits({required GoRouterWidgetBuilder builder}) {
     _routes.add(
       GoRoute(
-        path: _pathFor(route),
-        name: route.name,
+        path: _pathFor(AppRoute.habits),
+        name: AppRoute.habits.name,
+        builder: builder,
+      ),
+    );
+  }
+
+  void addHabitDetail({required GoRouterWidgetBuilder builder}) {
+    _routes.add(
+      GoRoute(
+        path: _pathFor(AppRoute.habitDetail),
+        name: AppRoute.habitDetail.name,
+        builder: builder,
+      ),
+    );
+  }
+
+  void addHabitCreate({required GoRouterPageBuilder pageBuilder}) {
+    _routes.add(
+      GoRoute(
+        path: _pathFor(AppRoute.habitCreate),
+        name: AppRoute.habitCreate.name,
         pageBuilder: pageBuilder,
       ),
     );
-    return this;
   }
 
-  AppRouterBuilder addHabitEdit({required GoRouterPageBuilder pageBuilder}) {
-    const route = AppRoute.habitEdit;
+  void addHabitEdit({required GoRouterPageBuilder pageBuilder}) {
     _routes.add(
       GoRoute(
-        path: _pathFor(route),
-        name: route.name,
+        path: _pathFor(AppRoute.habitEdit),
+        name: AppRoute.habitEdit.name,
         pageBuilder: pageBuilder,
       ),
     );
-    return this;
+  }
+
+  void addSettings({required GoRouterWidgetBuilder builder}) {
+    _routes.add(
+      GoRoute(
+        path: _pathFor(AppRoute.settings),
+        name: AppRoute.settings.name,
+        builder: builder,
+      ),
+    );
+  }
+
+  void addSettingsAbout({required GoRouterWidgetBuilder builder}) {
+    _routes.add(
+      GoRoute(
+        path: _pathFor(AppRoute.settingsAbout),
+        name: AppRoute.settingsAbout.name,
+        builder: builder,
+      ),
+    );
+  }
+
+  void addSettingsSync({required GoRouterWidgetBuilder builder}) {
+    _routes.add(
+      GoRoute(
+        path: _pathFor(AppRoute.settingsSync),
+        name: AppRoute.settingsSync.name,
+        builder: builder,
+      ),
+    );
+  }
+
+  void addSettingsNotify({required GoRouterWidgetBuilder builder}) {
+    _routes.add(
+      GoRoute(
+        path: _pathFor(AppRoute.settingsNotify),
+        name: AppRoute.settingsNotify.name,
+        builder: builder,
+      ),
+    );
+  }
+
+  void addExperimental({required GoRouterWidgetBuilder builder}) {
+    _routes.add(
+      GoRoute(
+        path: _pathFor(AppRoute.experimental),
+        name: AppRoute.experimental.name,
+        builder: builder,
+      ),
+    );
+  }
+
+  void addDebugger({required GoRouterWidgetBuilder builder}) {
+    _routes.add(
+      GoRoute(
+        path: _pathFor(AppRoute.debugger),
+        name: AppRoute.debugger.name,
+        builder: builder,
+      ),
+    );
+  }
+
+  void addGroupManage({required GoRouterWidgetBuilder builder}) {
+    _routes.add(
+      GoRoute(
+        path: _pathFor(AppRoute.groupManage),
+        name: AppRoute.groupManage.name,
+        builder: builder,
+      ),
+    );
+  }
+
+  void addHabitsStatus({required GoRouterWidgetBuilder builder}) {
+    _routes.add(
+      GoRoute(
+        path: _pathFor(AppRoute.habitsStatus),
+        name: AppRoute.habitsStatus.name,
+        builder: builder,
+      ),
+    );
   }
 
   GoRouter build({AppRoute? home}) {

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -17,7 +17,8 @@ import 'package:go_router/go_router.dart';
 import '../../common/global.dart';
 
 enum AppRoute {
-  habits('habits');
+  habits('habits'),
+  habitDetail('habits/:habitId');
 
   const AppRoute(this.name);
   final String name;
@@ -28,10 +29,19 @@ class AppRouterBuilder {
 
   static String _pathFor(AppRoute route) => switch (route) {
     AppRoute.habits => '/habits',
+    AppRoute.habitDetail => '/habits/:habitId',
   };
 
   AppRouterBuilder addHabits({required GoRouterWidgetBuilder builder}) {
     const route = AppRoute.habits;
+    _routes.add(
+      GoRoute(path: _pathFor(route), name: route.name, builder: builder),
+    );
+    return this;
+  }
+
+  AppRouterBuilder addHabitDetail({required GoRouterWidgetBuilder builder}) {
+    const route = AppRoute.habitDetail;
     _routes.add(
       GoRoute(path: _pathFor(route), name: route.name, builder: builder),
     );

--- a/lib/routes/helpers/group_manage_helper.dart
+++ b/lib/routes/helpers/group_manage_helper.dart
@@ -1,0 +1,45 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../app_router.dart';
+
+const _kRouteQuerySelectedGroupId = 'selectedGroupId';
+
+/// Unpacked parameters for the group manage route builder.
+typedef GroupManageParams = ({String? selectedGroupId});
+
+/// Unpacks [GoRouterState] into [GroupManageParams] for the
+/// [AppRoute.groupManage] route builder.
+///
+/// Reads the pre-selected group from the [_kRouteQuerySelectedGroupId]
+/// query parameter.
+extension GroupManageRoute on GoRouterState {
+  GroupManageParams unpackGroupManage() {
+    final selectedGroupId = uri.queryParameters[_kRouteQuerySelectedGroupId];
+    return (selectedGroupId: selectedGroupId);
+  }
+}
+
+/// Pushes the [AppRoute.groupManage] route onto the navigator.
+extension GroupManagePush on BuildContext {
+  Future<void> pushGroupManage({String? selectedGroupId}) => pushNamed(
+    AppRoute.groupManage.name,
+    queryParameters: selectedGroupId != null
+        ? {_kRouteQuerySelectedGroupId: selectedGroupId}
+        : const <String, dynamic>{},
+  );
+}

--- a/lib/routes/helpers/habit_create_helper.dart
+++ b/lib/routes/helpers/habit_create_helper.dart
@@ -1,0 +1,56 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../models/habit_form.dart';
+import '../../storage/db/handlers/habit.dart';
+import '../app_router.dart';
+
+/// Strongly-typed container for [AppRoute.habitCreate] extra data.
+///
+/// Wraps the underlying go_router record with an [extension type] so the
+/// extra payload carries a nominal (non-structural) type.  Callers construct
+/// via [HabitCreateExtra.new] and consumers unwrap via the [initForm]
+/// accessor — the raw record is never exposed.
+///
+/// [initForm] is optional: when provided it acts as a template
+/// (e.g. pre-filling fields from a selected habit).
+extension type const HabitCreateExtra._(({HabitForm? initForm}) _value) {
+  const HabitCreateExtra({HabitForm? initForm}) : this._((initForm: initForm));
+
+  HabitForm? get initForm => _value.initForm;
+}
+
+/// Unpacked parameters for the habit create route builder.
+typedef HabitCreateParams = ({HabitForm? initForm});
+
+/// Unpacks [GoRouterState] into [HabitCreateParams] for the
+/// [AppRoute.habitCreate] route builder.
+extension HabitCreateRoute on GoRouterState {
+  HabitCreateParams unpackHabitCreate() {
+    final extra = this.extra! as HabitCreateExtra;
+    return (initForm: extra.initForm);
+  }
+}
+
+/// Pushes the [AppRoute.habitCreate] route onto the navigator.
+extension HabitCreatePush on BuildContext {
+  Future<HabitDBCell?> pushHabitCreate({HabitForm? initForm}) =>
+      pushNamed<HabitDBCell>(
+        AppRoute.habitCreate.name,
+        extra: HabitCreateExtra(initForm: initForm),
+      );
+}

--- a/lib/routes/helpers/habit_create_helper.dart
+++ b/lib/routes/helpers/habit_create_helper.dart
@@ -39,10 +39,15 @@ typedef HabitCreateParams = ({HabitForm? initForm});
 
 /// Unpacks [GoRouterState] into [HabitCreateParams] for the
 /// [AppRoute.habitCreate] route builder.
+///
+/// When [extra] is null or not a [HabitCreateExtra] (e.g. deep-link
+/// navigation where [HabitForm] cannot be passed via extra),
+/// [initForm] defaults to null.
 extension HabitCreateRoute on GoRouterState {
   HabitCreateParams unpackHabitCreate() {
-    final extra = this.extra! as HabitCreateExtra;
-    return (initForm: extra.initForm);
+    final extra = this.extra;
+    final createExtra = extra is HabitCreateExtra ? extra : null;
+    return (initForm: createExtra?.initForm);
   }
 }
 

--- a/lib/routes/helpers/habit_detail_helper.dart
+++ b/lib/routes/helpers/habit_detail_helper.dart
@@ -46,13 +46,18 @@ typedef HabitDetailParams = ({
 
 /// Unpacks [GoRouterState] into [HabitDetailParams] for the
 /// [AppRoute.habitDetail] route builder.
+///
+/// When [extra] is null or not a [HabitDetailExtra] (e.g. deep-link
+/// navigation where [HabitDetailAdapter] cannot be passed via extra),
+/// [color] and [adapter] default to null.
 extension HabitDetailRoute on GoRouterState {
   HabitDetailParams unpackHabitDetail() {
-    final extra = this.extra! as HabitDetailExtra;
+    final extra = this.extra;
+    final detailExtra = extra is HabitDetailExtra ? extra : null;
     return (
       habitUUID: pathParameters['habitId']!,
-      color: extra.color,
-      adapter: extra.adapter,
+      color: detailExtra?.color,
+      adapter: detailExtra?.adapter,
     );
   }
 }

--- a/lib/routes/helpers/habit_detail_helper.dart
+++ b/lib/routes/helpers/habit_detail_helper.dart
@@ -1,0 +1,71 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../common/types.dart';
+import '../../models/habit_color.dart';
+import '../../pages/habit_detail/page.dart' as habit_detail;
+import '../../pages/habits_display/providers.dart' show HabitDetailAdapter;
+import '../app_router.dart';
+
+/// Strongly-typed container for [AppRoute.habitDetail] extra data.
+///
+/// Wraps the underlying go_router record with an [extension type] so the
+/// extra payload carries a nominal (non-structural) type.  Callers construct
+/// via [HabitDetailExtra.new] and consumers unwrap via the [color]/[adapter]
+/// accessors — the raw record is never exposed.
+extension type const HabitDetailExtra._(
+  ({HabitColor? color, HabitDetailAdapter? adapter}) _value
+) {
+  const HabitDetailExtra({HabitColor? color, HabitDetailAdapter? adapter})
+    : this._((color: color, adapter: adapter));
+
+  HabitColor? get color => _value.color;
+  HabitDetailAdapter? get adapter => _value.adapter;
+}
+
+/// Unpacked parameters for the habit detail route builder.
+typedef HabitDetailParams = ({
+  HabitUUID habitUUID,
+  HabitColor? color,
+  HabitDetailAdapter? adapter,
+});
+
+/// Unpacks [GoRouterState] into [HabitDetailParams] for the
+/// [AppRoute.habitDetail] route builder.
+extension HabitDetailRoute on GoRouterState {
+  HabitDetailParams unpackHabitDetail() {
+    final extra = this.extra! as HabitDetailExtra;
+    return (
+      habitUUID: pathParameters['habitId']!,
+      color: extra.color,
+      adapter: extra.adapter,
+    );
+  }
+}
+
+/// Pushes the [AppRoute.habitDetail] route onto the navigator.
+extension HabitDetailPush on BuildContext {
+  Future<habit_detail.DetailPageReturn?> pushHabitDetail({
+    required HabitUUID habitUUID,
+    HabitColor? color,
+    HabitDetailAdapter? adapter,
+  }) => pushNamed<habit_detail.DetailPageReturn>(
+    AppRoute.habitDetail.name,
+    pathParameters: {'habitId': habitUUID},
+    extra: HabitDetailExtra(color: color, adapter: adapter),
+  );
+}

--- a/lib/routes/helpers/habit_detail_helper.dart
+++ b/lib/routes/helpers/habit_detail_helper.dart
@@ -18,38 +18,40 @@ import 'package:go_router/go_router.dart';
 import '../../common/types.dart';
 import '../../models/habit_color.dart';
 import '../../pages/habit_detail/page.dart' as habit_detail;
-import '../../pages/habits_display/providers.dart' show HabitDetailAdapter;
+import '../../pages/habits_display/_providers/habit_summary.dart' as summary;
 import '../app_router.dart';
 
 /// Strongly-typed container for [AppRoute.habitDetail] extra data.
 ///
 /// Wraps the underlying go_router record with an [extension type] so the
 /// extra payload carries a nominal (non-structural) type.  Callers construct
-/// via [HabitDetailExtra.new] and consumers unwrap via the [color]/[adapter]
+/// via [HabitDetailExtra.new] and consumers unwrap via the [color]/[summaryAdapter]
 /// accessors — the raw record is never exposed.
 extension type const HabitDetailExtra._(
-  ({HabitColor? color, HabitDetailAdapter? adapter}) _value
+  ({HabitColor? color, summary.HabitDetailAdapter? summaryAdapter}) _value
 ) {
-  const HabitDetailExtra({HabitColor? color, HabitDetailAdapter? adapter})
-    : this._((color: color, adapter: adapter));
+  const HabitDetailExtra({
+    HabitColor? color,
+    summary.HabitDetailAdapter? summaryAdapter,
+  }) : this._((color: color, summaryAdapter: summaryAdapter));
 
   HabitColor? get color => _value.color;
-  HabitDetailAdapter? get adapter => _value.adapter;
+  summary.HabitDetailAdapter? get summaryAdapter => _value.summaryAdapter;
 }
 
 /// Unpacked parameters for the habit detail route builder.
 typedef HabitDetailParams = ({
   HabitUUID habitUUID,
   HabitColor? color,
-  HabitDetailAdapter? adapter,
+  summary.HabitDetailAdapter? summaryAdapter,
 });
 
 /// Unpacks [GoRouterState] into [HabitDetailParams] for the
 /// [AppRoute.habitDetail] route builder.
 ///
 /// When [extra] is null or not a [HabitDetailExtra] (e.g. deep-link
-/// navigation where [HabitDetailAdapter] cannot be passed via extra),
-/// [color] and [adapter] default to null.
+/// navigation where [summary.HabitDetailAdapter] cannot be passed via extra),
+/// [color] and [summaryAdapter] default to null.
 extension HabitDetailRoute on GoRouterState {
   HabitDetailParams unpackHabitDetail() {
     final extra = this.extra;
@@ -57,7 +59,7 @@ extension HabitDetailRoute on GoRouterState {
     return (
       habitUUID: pathParameters['habitId']!,
       color: detailExtra?.color,
-      adapter: detailExtra?.adapter,
+      summaryAdapter: detailExtra?.summaryAdapter,
     );
   }
 }
@@ -67,10 +69,10 @@ extension HabitDetailPush on BuildContext {
   Future<habit_detail.DetailPageReturn?> pushHabitDetail({
     required HabitUUID habitUUID,
     HabitColor? color,
-    HabitDetailAdapter? adapter,
+    summary.HabitDetailAdapter? summaryAdapter,
   }) => pushNamed<habit_detail.DetailPageReturn>(
     AppRoute.habitDetail.name,
     pathParameters: {'habitId': habitUUID},
-    extra: HabitDetailExtra(color: color, adapter: adapter),
+    extra: HabitDetailExtra(color: color, summaryAdapter: summaryAdapter),
   );
 }

--- a/lib/routes/helpers/habit_edit_helper.dart
+++ b/lib/routes/helpers/habit_edit_helper.dart
@@ -20,6 +20,8 @@ import '../../models/habit_form.dart';
 import '../../storage/db/handlers/habit.dart';
 import '../app_router.dart';
 
+const _kRouteQueryHabitId = 'habitId';
+
 /// Strongly-typed container for [AppRoute.habitEdit] extra data.
 ///
 /// Wraps the underlying go_router record with an [extension type] so the
@@ -54,8 +56,8 @@ extension HabitEditRoute on GoRouterState {
   HabitEditParams unpackHabitEdit() {
     final extra = this.extra! as HabitEditExtra;
     assert(
-      uri.queryParameters['habitId'] == extra.habitId,
-      'Query habitId (${uri.queryParameters['habitId']}) '
+      uri.queryParameters[_kRouteQueryHabitId] == extra.habitId,
+      'Query habitId (${uri.queryParameters[_kRouteQueryHabitId]}) '
       '!= extra habitId (${extra.habitId})',
     );
     return (habitId: extra.habitId, initForm: extra.initForm);
@@ -78,7 +80,7 @@ extension HabitEditPush on BuildContext {
     );
     return pushNamed<HabitDBCell>(
       AppRoute.habitEdit.name,
-      queryParameters: {'habitId': habitId},
+      queryParameters: {_kRouteQueryHabitId: habitId},
       extra: HabitEditExtra(habitId: habitId, initForm: initForm),
     );
   }

--- a/lib/routes/helpers/habit_edit_helper.dart
+++ b/lib/routes/helpers/habit_edit_helper.dart
@@ -50,11 +50,19 @@ typedef HabitEditParams = ({HabitUUID habitId, HabitForm initForm});
 /// Unpacks [GoRouterState] into [HabitEditParams] for the
 /// [AppRoute.habitEdit] route builder.
 ///
-/// Asserts that the query parameter [habitId] matches the [extra.habitId]
-/// for bidirectional integrity.
+/// Throws [StateError] when [extra] is null or not a [HabitEditExtra],
+/// since both [habitId] and [initForm] are required for this route.
+/// Also asserts that the query parameter [habitId] matches the
+/// [HabitEditExtra.habitId] for bidirectional integrity.
 extension HabitEditRoute on GoRouterState {
   HabitEditParams unpackHabitEdit() {
-    final extra = this.extra! as HabitEditExtra;
+    final extra = this.extra;
+    if (extra is! HabitEditExtra) {
+      throw StateError(
+        'GoRouterState.extra must be a HabitEditExtra, '
+        'got ${extra.runtimeType}',
+      );
+    }
     assert(
       uri.queryParameters[_kRouteQueryHabitId] == extra.habitId,
       'Query habitId (${uri.queryParameters[_kRouteQueryHabitId]}) '

--- a/lib/routes/helpers/habit_edit_helper.dart
+++ b/lib/routes/helpers/habit_edit_helper.dart
@@ -1,0 +1,85 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../common/types.dart';
+import '../../models/habit_form.dart';
+import '../../storage/db/handlers/habit.dart';
+import '../app_router.dart';
+
+/// Strongly-typed container for [AppRoute.habitEdit] extra data.
+///
+/// Wraps the underlying go_router record with an [extension type] so the
+/// extra payload carries a nominal (non-structural) type.  Callers construct
+/// via [HabitEditExtra.new] and consumers unwrap via the [habitId]/[initForm]
+/// accessors — the raw record is never exposed.
+///
+/// Both [habitId] and [initForm] are required. The [habitId] is also carried
+/// as a query parameter in the URL for observability and future deep-link
+/// support.
+extension type const HabitEditExtra._(
+  ({HabitUUID habitId, HabitForm initForm}) _value
+) {
+  const HabitEditExtra({
+    required HabitUUID habitId,
+    required HabitForm initForm,
+  }) : this._((habitId: habitId, initForm: initForm));
+
+  HabitUUID get habitId => _value.habitId;
+  HabitForm get initForm => _value.initForm;
+}
+
+/// Unpacked parameters for the habit edit route builder.
+typedef HabitEditParams = ({HabitUUID habitId, HabitForm initForm});
+
+/// Unpacks [GoRouterState] into [HabitEditParams] for the
+/// [AppRoute.habitEdit] route builder.
+///
+/// Asserts that the query parameter [habitId] matches the [extra.habitId]
+/// for bidirectional integrity.
+extension HabitEditRoute on GoRouterState {
+  HabitEditParams unpackHabitEdit() {
+    final extra = this.extra! as HabitEditExtra;
+    assert(
+      uri.queryParameters['habitId'] == extra.habitId,
+      'Query habitId (${uri.queryParameters['habitId']}) '
+      '!= extra habitId (${extra.habitId})',
+    );
+    return (habitId: extra.habitId, initForm: extra.initForm);
+  }
+}
+
+/// Pushes the [AppRoute.habitEdit] route onto the navigator.
+///
+/// Asserts that [initForm.editParams.uuid] matches [habitId] for
+/// caller-side integrity.
+extension HabitEditPush on BuildContext {
+  Future<HabitDBCell?> pushHabitEdit({
+    required HabitUUID habitId,
+    required HabitForm initForm,
+  }) {
+    assert(
+      initForm.editParams?.uuid == habitId,
+      'initForm.editParams.uuid (${initForm.editParams?.uuid}) '
+      '!= habitId ($habitId)',
+    );
+    return pushNamed<HabitDBCell>(
+      AppRoute.habitEdit.name,
+      queryParameters: {'habitId': habitId},
+      extra: HabitEditExtra(habitId: habitId, initForm: initForm),
+    );
+  }
+}

--- a/lib/routes/helpers/habits_status_changer_helper.dart
+++ b/lib/routes/helpers/habits_status_changer_helper.dart
@@ -1,0 +1,70 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../common/types.dart';
+import '../app_router.dart';
+
+const _kRouteQueryHabitId = 'habitId';
+
+/// Strongly-typed container for [AppRoute.habitsStatus] extra data.
+///
+/// Wraps the [uuidList] with an [extension type] so the extra payload
+/// carries a nominal (non-structural) type.
+///
+/// [uuidList] is nullable: when set, it is the primary source of habit
+/// IDs (programmatic navigation). When null, the unpacker falls back to
+/// the [_kRouteQueryHabitId] query parameters (deeplink navigation).
+extension type const HabitsStatusChangerExtra._(
+  ({List<HabitUUID>? uuidList}) _value
+) {
+  const HabitsStatusChangerExtra({List<HabitUUID>? uuidList})
+    : this._((uuidList: uuidList));
+
+  List<HabitUUID>? get uuidList => _value.uuidList;
+}
+
+/// Unpacked parameters for the habits status changer route builder.
+typedef HabitsStatusChangerParams = ({List<HabitUUID> uuidList});
+
+/// Unpacks [GoRouterState] into [HabitsStatusChangerParams] for the
+/// [AppRoute.habitsStatus] route builder.
+///
+/// Priority: [HabitsStatusChangerExtra.uuidList] (programmatic) →
+/// [_kRouteQueryHabitId] query parameters (deeplink).
+extension HabitsStatusChangerRoute on GoRouterState {
+  HabitsStatusChangerParams unpackHabitsStatusChanger() {
+    final extra = this.extra as HabitsStatusChangerExtra?;
+    final uuidList =
+        extra?.uuidList ??
+        uri.queryParametersAll[_kRouteQueryHabitId] ??
+        const <String>[];
+    return (uuidList: uuidList);
+  }
+}
+
+/// Pushes the [AppRoute.habitsStatus] route onto the navigator.
+///
+/// Passes [uuidList] via [extra] (in-memory, primary source).
+/// The unpacker also supports deeplink via [_kRouteQueryHabitId] query
+/// parameters as a future extension.
+extension HabitsStatusChangerPush on BuildContext {
+  Future<void> pushHabitsStatusChanger({required List<HabitUUID> uuidList}) =>
+      pushNamed(
+        AppRoute.habitsStatus.name,
+        extra: HabitsStatusChangerExtra(uuidList: uuidList),
+      );
+}

--- a/lib/routes/navigator_helpers.dart
+++ b/lib/routes/navigator_helpers.dart
@@ -13,25 +13,21 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../common/types.dart';
 import '../models/habit_color.dart';
 import '../models/habit_display.dart';
 import '../models/habit_form.dart';
-import '../pages/app_about/page.dart' as app_about;
-import '../pages/app_debugger/page.dart' as app_debugger;
-import '../pages/app_notify_config/page.dart' as app_notify_config;
-import '../pages/app_settings/page.dart' as app_settings;
-import '../pages/app_sync/page.dart' as app_sync;
-import '../pages/expermental_features/page.dart' as exp_feature;
-import '../pages/group_manage/page.dart' as group_manage;
 import '../pages/habit_detail/page.dart' as habit_detail;
 import '../pages/habits_display/providers.dart' show HabitDetailAdapter;
-import '../pages/habits_status_changer/page.dart' as habits_status_changer;
 import '../storage/db/handlers/habit.dart';
+import 'app_router.dart';
+import 'helpers/group_manage_helper.dart';
 import 'helpers/habit_create_helper.dart';
 import 'helpers/habit_detail_helper.dart';
 import 'helpers/habit_edit_helper.dart';
+import 'helpers/habits_status_changer_helper.dart';
 
 Future<HabitDBCell?> naviToHabitCreatePage({
   required BuildContext context,
@@ -64,61 +60,29 @@ Future<habit_detail.DetailPageReturn?> naviToHabitDetailPage({
 );
 
 Future<void> naviToAppSettingPage({required BuildContext context}) =>
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => const app_settings.AppSettingPage(),
-      ),
-    );
+    context.pushNamed(AppRoute.settings.name);
 
 Future<void> naviToAppAboutPage({required BuildContext context}) =>
-    Navigator.of(context).push(
-      MaterialPageRoute(builder: (context) => const app_about.AppAboutPage()),
-    );
+    context.pushNamed(AppRoute.settingsAbout.name);
 
 Future<void> naviToGroupManagePage({
   required BuildContext context,
-  String? initialGroupUUID,
-}) => Navigator.of(context).push(
-  MaterialPageRoute(
-    builder: (context) =>
-        group_manage.GroupManagePage(initialGroupUUID: initialGroupUUID),
-  ),
-);
+  String? selectedGroupId,
+}) => context.pushGroupManage(selectedGroupId: selectedGroupId);
 
-Future<void> naviToAppSyncPage({required BuildContext context}) => Navigator.of(
-  context,
-).push(MaterialPageRoute(builder: (context) => const app_sync.AppSyncPage()));
+Future<void> naviToAppSyncPage({required BuildContext context}) =>
+    context.pushNamed(AppRoute.settingsSync.name);
 
 Future<void> naviToNotifyConfigPage({required BuildContext context}) =>
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => const app_notify_config.AppNotifyConfigPage(),
-      ),
-    );
+    context.pushNamed(AppRoute.settingsNotify.name);
 
 Future<void> naviToAppDebuggerPage({required BuildContext context}) =>
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => const app_debugger.AppDebuggerPage(),
-        settings: const RouteSettings(
-          name: app_debugger.AppDebuggerPage.routerName,
-        ),
-      ),
-    );
+    context.pushNamed(AppRoute.debugger.name);
 
 Future<void> naviToExperimentalFeaturesPage({required BuildContext context}) =>
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => const exp_feature.ExpermentalFeaturesPage(),
-      ),
-    );
+    context.pushNamed(AppRoute.experimental.name);
 
 Future<void> naviToHabitsStatusChangerPage({
   required BuildContext context,
   required List<HabitUUID> uuidList,
-}) => Navigator.of(context).push(
-  MaterialPageRoute(
-    builder: (context) =>
-        habits_status_changer.HabitsStatusChangerPage(uuidList: uuidList),
-  ),
-);
+}) => context.pushHabitsStatusChanger(uuidList: uuidList);

--- a/lib/routes/navigator_helpers.dart
+++ b/lib/routes/navigator_helpers.dart
@@ -1,0 +1,120 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../common/types.dart';
+import '../models/habit_color.dart';
+import '../models/habit_form.dart';
+import '../pages/app_about/page.dart' as app_about;
+import '../pages/app_debugger/page.dart' as app_debugger;
+import '../pages/app_notify_config/page.dart' as app_notify_config;
+import '../pages/app_settings/page.dart' as app_settings;
+import '../pages/app_sync/page.dart' as app_sync;
+import '../pages/expermental_features/page.dart' as exp_feature;
+import '../pages/group_manage/page.dart' as group_manage;
+import '../pages/habit_detail/page.dart' as habit_detail;
+import '../pages/habit_edit/page.dart' as habit_edit;
+import '../pages/habits_display/providers.dart' show HabitDetailAdapter;
+import '../pages/habits_status_changer/page.dart' as habits_status_changer;
+import '../storage/db/handlers/habit.dart';
+
+Future<HabitDBCell?> naviToHabitEidtPage({
+  required BuildContext context,
+  required HabitForm initForm,
+  bool? naviWithFullscreenDialog,
+}) => Navigator.of(context).push(
+  MaterialPageRoute(
+    fullscreenDialog: naviWithFullscreenDialog ?? true,
+    builder: (context) => habit_edit.HabitEditPage(
+      initForm: initForm,
+      showInFullscreenDialog: false,
+    ),
+  ),
+);
+
+Future<habit_detail.DetailPageReturn?> naviToHabitDetailPage({
+  required BuildContext context,
+  required HabitUUID habitUUID,
+  HabitColor? color,
+  HabitDetailAdapter? adapter,
+}) => Navigator.of(context).push(
+  MaterialPageRoute(
+    builder: (context) => Provider.value(
+      value: adapter,
+      child: habit_detail.HabitDetailPage(habitUUID: habitUUID, color: color),
+    ),
+  ),
+);
+
+Future<void> naviToAppSettingPage({required BuildContext context}) =>
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => const app_settings.AppSettingPage(),
+      ),
+    );
+
+Future<void> naviToAppAboutPage({required BuildContext context}) =>
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (context) => const app_about.AppAboutPage()),
+    );
+
+Future<void> naviToGroupManagePage({
+  required BuildContext context,
+  String? initialGroupUUID,
+}) => Navigator.of(context).push(
+  MaterialPageRoute(
+    builder: (context) =>
+        group_manage.GroupManagePage(initialGroupUUID: initialGroupUUID),
+  ),
+);
+
+Future<void> naviToAppSyncPage({required BuildContext context}) => Navigator.of(
+  context,
+).push(MaterialPageRoute(builder: (context) => const app_sync.AppSyncPage()));
+
+Future<void> naviToNotifyConfigPage({required BuildContext context}) =>
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => const app_notify_config.AppNotifyConfigPage(),
+      ),
+    );
+
+Future<void> naviToAppDebuggerPage({required BuildContext context}) =>
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => const app_debugger.AppDebuggerPage(),
+        settings: const RouteSettings(
+          name: app_debugger.AppDebuggerPage.routerName,
+        ),
+      ),
+    );
+
+Future<void> naviToExperimentalFeaturesPage({required BuildContext context}) =>
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => const exp_feature.ExpermentalFeaturesPage(),
+      ),
+    );
+
+Future<void> naviToHabitsStatusChangerPage({
+  required BuildContext context,
+  required List<HabitUUID> uuidList,
+}) => Navigator.of(context).push(
+  MaterialPageRoute(
+    builder: (context) =>
+        habits_status_changer.HabitsStatusChangerPage(uuidList: uuidList),
+  ),
+);

--- a/lib/routes/navigator_helpers.dart
+++ b/lib/routes/navigator_helpers.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../common/types.dart';
 import '../models/habit_color.dart';
@@ -30,6 +29,7 @@ import '../pages/habit_edit/page.dart' as habit_edit;
 import '../pages/habits_display/providers.dart' show HabitDetailAdapter;
 import '../pages/habits_status_changer/page.dart' as habits_status_changer;
 import '../storage/db/handlers/habit.dart';
+import 'helpers/habit_detail_helper.dart';
 
 Future<HabitDBCell?> naviToHabitEidtPage({
   required BuildContext context,
@@ -50,13 +50,10 @@ Future<habit_detail.DetailPageReturn?> naviToHabitDetailPage({
   required HabitUUID habitUUID,
   HabitColor? color,
   HabitDetailAdapter? adapter,
-}) => Navigator.of(context).push(
-  MaterialPageRoute(
-    builder: (context) => Provider.value(
-      value: adapter,
-      child: habit_detail.HabitDetailPage(habitUUID: habitUUID, color: color),
-    ),
-  ),
+}) => context.pushHabitDetail(
+  habitUUID: habitUUID,
+  color: color,
+  adapter: adapter,
 );
 
 Future<void> naviToAppSettingPage({required BuildContext context}) =>

--- a/lib/routes/navigator_helpers.dart
+++ b/lib/routes/navigator_helpers.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 
 import '../common/types.dart';
 import '../models/habit_color.dart';
+import '../models/habit_display.dart';
 import '../models/habit_form.dart';
 import '../pages/app_about/page.dart' as app_about;
 import '../pages/app_debugger/page.dart' as app_debugger;
@@ -25,25 +26,31 @@ import '../pages/app_sync/page.dart' as app_sync;
 import '../pages/expermental_features/page.dart' as exp_feature;
 import '../pages/group_manage/page.dart' as group_manage;
 import '../pages/habit_detail/page.dart' as habit_detail;
-import '../pages/habit_edit/page.dart' as habit_edit;
 import '../pages/habits_display/providers.dart' show HabitDetailAdapter;
 import '../pages/habits_status_changer/page.dart' as habits_status_changer;
 import '../storage/db/handlers/habit.dart';
+import 'helpers/habit_create_helper.dart';
 import 'helpers/habit_detail_helper.dart';
+import 'helpers/habit_edit_helper.dart';
 
-Future<HabitDBCell?> naviToHabitEidtPage({
+Future<HabitDBCell?> naviToHabitCreatePage({
+  required BuildContext context,
+  HabitForm? initForm,
+}) => context.pushHabitCreate(initForm: initForm);
+
+Future<HabitDBCell?> naviToHabitEditPage({
   required BuildContext context,
   required HabitForm initForm,
-  bool? naviWithFullscreenDialog,
-}) => Navigator.of(context).push(
-  MaterialPageRoute(
-    fullscreenDialog: naviWithFullscreenDialog ?? true,
-    builder: (context) => habit_edit.HabitEditPage(
-      initForm: initForm,
-      showInFullscreenDialog: false,
-    ),
-  ),
-);
+}) {
+  assert(
+    initForm.editMode == HabitDisplayEditMode.edit,
+    'naviToHabitEditPage called with editMode=${initForm.editMode}',
+  );
+  return context.pushHabitEdit(
+    habitId: initForm.editParams!.uuid,
+    initForm: initForm,
+  );
+}
 
 Future<habit_detail.DetailPageReturn?> naviToHabitDetailPage({
   required BuildContext context,

--- a/lib/routes/navigator_helpers.dart
+++ b/lib/routes/navigator_helpers.dart
@@ -52,11 +52,11 @@ Future<habit_detail.DetailPageReturn?> naviToHabitDetailPage({
   required BuildContext context,
   required HabitUUID habitUUID,
   HabitColor? color,
-  HabitDetailAdapter? adapter,
+  HabitDetailAdapter? summaryAdapter,
 }) => context.pushHabitDetail(
   habitUUID: habitUUID,
   color: color,
-  adapter: adapter,
+  summaryAdapter: summaryAdapter,
 );
 
 Future<void> naviToAppSettingPage({required BuildContext context}) =>

--- a/lib/widgets/_widgets/changelog_banner.dart
+++ b/lib/widgets/_widgets/changelog_banner.dart
@@ -15,11 +15,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
-import '../../../common/app_info.dart';
-import '../../../extensions/asset_bundle_extensions.dart';
-import '../../../l10n/localizations.dart';
-import '../../app_changelog/changelog_dialog.dart';
-import '../../app_changelog/changelog_parser.dart';
+import '../../common/app_info.dart';
+import '../../extensions/asset_bundle_extensions.dart';
+import '../../l10n/localizations.dart';
+import '../../pages/app_changelog/changelog_dialog.dart';
+import '../../pages/app_changelog/changelog_parser.dart';
 
 /// App-level manager for the changelog banner.
 ///

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -18,6 +18,7 @@ export '_widgets/animated_reorderable_list.dart';
 export '_widgets/app_ui_layout_builder.dart';
 export '_widgets/appbar_actions.dart';
 export '_widgets/beta_badge.dart';
+export '_widgets/changelog_banner.dart';
 export '_widgets/chip_list.dart';
 export '_widgets/color_display_chip.dart';
 export '_widgets/color_swatch_button.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -749,6 +749,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "55973bf1b27790489f8710ea615fe939f911ddcc5986fe97305e4fc19fa29ee9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "17.4.0"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -165,6 +165,7 @@ dependencies:
   crypto: ^3.0.2
   timezone: ^0.11.0
   nested: ^1.0.0
+  go_router: ^17.0.0
   async: ^2.11.0
   pool: ^1.5.1
   rxdart: ^0.28.0

--- a/test/feature/habits_display/habit_display_page_test.dart
+++ b/test/feature/habits_display/habit_display_page_test.dart
@@ -20,7 +20,6 @@ import 'package:mhabit/models/habit_summary.dart';
 import 'package:mhabit/pages/common/_widgets/not_found_image.dart';
 import 'package:mhabit/pages/habits_display/_providers/habit_summary.dart';
 import 'package:mhabit/pages/habits_display/_providers/habits_today.dart';
-import 'package:mhabit/pages/habits_display/_widgets/changelog_banner_sliver.dart';
 import 'package:mhabit/pages/habits_display/page_habits.dart';
 import 'package:mhabit/pages/habits_display/page_today.dart';
 import 'package:mhabit/providers/app_ui/app_compact_ui_switcher.dart';
@@ -38,6 +37,7 @@ import 'package:mhabit/providers/workflow/app_event.dart';
 import 'package:mhabit/providers/workflow/app_sync.dart';
 import 'package:mhabit/providers/workflow/habits_manager.dart';
 import 'package:mhabit/storage/profile_provider.dart';
+import 'package:mhabit/widgets/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/test/unit/entries/app_root_view_test.dart
+++ b/test/unit/entries/app_root_view_test.dart
@@ -1,0 +1,107 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mhabit/entries/common/app_root_view.dart';
+
+void main() {
+  group('AppRootView', () {
+    testWidgets('default constructor builds MaterialApp with home:', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const AppRootView(
+          themeMode: ThemeMode.system,
+          child: Text('home-child'),
+        ),
+      );
+
+      expect(find.text('home-child'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('.router constructor builds MaterialApp.router with config', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const Text('router-child')),
+        ],
+      );
+
+      await tester.pumpWidget(
+        AppRootView.router(themeMode: ThemeMode.system, config: router),
+      );
+
+      expect(find.text('router-child'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('.withDefault uses ThemeMode.system by default', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const AppRootView.withDefault(child: Text('default-child')),
+      );
+
+      expect(find.text('default-child'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+      'router path: no navigatorKey/navigatorObservers on MaterialApp',
+      (tester) async {
+        // When routerConfig is provided, navigatorKey is managed by GoRouter
+        // and should not appear as direct properties on MaterialApp.
+        final router = GoRouter(
+          initialLocation: '/',
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (_, _) => const Text('router-key-test'),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          AppRootView.router(themeMode: ThemeMode.system, config: router),
+        );
+
+        expect(find.text('router-key-test'), findsOneWidget);
+
+        // Verify a MaterialApp.router descendant exists (no crash = success).
+        final materialAppFinder = find.byType(MaterialApp);
+        expect(materialAppFinder, findsOneWidget);
+      },
+    );
+
+    testWidgets('home path: navigatorKey and observers on MaterialApp', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const AppRootView(
+          themeMode: ThemeMode.system,
+          child: Text('home-key-test'),
+        ),
+      );
+
+      expect(find.text('home-key-test'), findsOneWidget);
+      expect(find.byType(MaterialApp), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/unit/pages/app_changelog/changelog_banner_test.dart
+++ b/test/unit/pages/app_changelog/changelog_banner_test.dart
@@ -15,7 +15,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mhabit/l10n/localizations.dart';
-import 'package:mhabit/pages/habits_display/_widgets/changelog_banner_sliver.dart';
+import 'package:mhabit/widgets/widgets.dart';
 
 const _testVersion = '1.0.0+1';
 const _testContent = '- item a\n- item b';

--- a/test/unit/routes/app_router_test.dart
+++ b/test/unit/routes/app_router_test.dart
@@ -26,9 +26,10 @@ void main() {
     });
 
     test('addHabits sets correct path and name', () {
-      final router = AppRouterBuilder()
-          .addHabits(builder: (_, _) => const SizedBox.shrink())
-          .build();
+      final router =
+          (AppRouterBuilder()
+                ..addHabits(builder: (_, _) => const SizedBox.shrink()))
+              .build();
       final routes = router.configuration.routes;
       expect(routes, hasLength(1));
       final route = routes.first as GoRoute;
@@ -38,9 +39,10 @@ void main() {
     });
 
     test('addHabitDetail sets correct path and name', () {
-      final router = AppRouterBuilder()
-          .addHabitDetail(builder: (_, _) => const SizedBox.shrink())
-          .build();
+      final router =
+          (AppRouterBuilder()
+                ..addHabitDetail(builder: (_, _) => const SizedBox.shrink()))
+              .build();
       final routes = router.configuration.routes;
       expect(routes, hasLength(1));
       final route = routes.first as GoRoute;
@@ -50,12 +52,12 @@ void main() {
     });
 
     test('addHabitCreate sets correct path, name and pageBuilder', () {
-      final router = AppRouterBuilder()
-          .addHabitCreate(
-            pageBuilder: (_, _) =>
-                const MaterialPage<void>(child: SizedBox.shrink()),
-          )
-          .build();
+      final router =
+          (AppRouterBuilder()..addHabitCreate(
+                pageBuilder: (_, _) =>
+                    const MaterialPage<void>(child: SizedBox.shrink()),
+              ))
+              .build();
       final routes = router.configuration.routes;
       expect(routes, hasLength(1));
       final route = routes.first as GoRoute;
@@ -65,12 +67,12 @@ void main() {
     });
 
     test('addHabitEdit sets correct path, name and pageBuilder', () {
-      final router = AppRouterBuilder()
-          .addHabitEdit(
-            pageBuilder: (_, _) =>
-                const MaterialPage<void>(child: SizedBox.shrink()),
-          )
-          .build();
+      final router =
+          (AppRouterBuilder()..addHabitEdit(
+                pageBuilder: (_, _) =>
+                    const MaterialPage<void>(child: SizedBox.shrink()),
+              ))
+              .build();
       final routes = router.configuration.routes;
       expect(routes, hasLength(1));
       final route = routes.first as GoRoute;
@@ -79,31 +81,137 @@ void main() {
       expect(route.pageBuilder, isNotNull);
     });
 
-    test('chains all routes in registration order', () {
-      final router = AppRouterBuilder()
-          .addHabits(builder: (_, _) => const SizedBox.shrink())
-          .addHabitDetail(builder: (_, _) => const SizedBox.shrink())
-          .addHabitCreate(
-            pageBuilder: (_, _) =>
-                const MaterialPage<void>(child: SizedBox.shrink()),
-          )
-          .addHabitEdit(
-            pageBuilder: (_, _) =>
-                const MaterialPage<void>(child: SizedBox.shrink()),
-          )
-          .build();
+    test('addSettings sets correct path and name', () {
+      final router =
+          (AppRouterBuilder()
+                ..addSettings(builder: (_, _) => const SizedBox.shrink()))
+              .build();
+      final route = router.configuration.routes.first as GoRoute;
+      expect(route.path, '/settings');
+      expect(route.name, AppRoute.settings.name);
+      expect(route.builder, isNotNull);
+    });
+
+    test('addSettingsAbout sets correct path and name', () {
+      final router =
+          (AppRouterBuilder()
+                ..addSettingsAbout(builder: (_, _) => const SizedBox.shrink()))
+              .build();
+      final route = router.configuration.routes.first as GoRoute;
+      expect(route.path, '/settings/about');
+      expect(route.name, AppRoute.settingsAbout.name);
+      expect(route.builder, isNotNull);
+    });
+
+    test('addSettingsSync sets correct path and name', () {
+      final router =
+          (AppRouterBuilder()
+                ..addSettingsSync(builder: (_, _) => const SizedBox.shrink()))
+              .build();
+      final route = router.configuration.routes.first as GoRoute;
+      expect(route.path, '/settings/sync');
+      expect(route.name, AppRoute.settingsSync.name);
+      expect(route.builder, isNotNull);
+    });
+
+    test('addSettingsNotify sets correct path and name', () {
+      final router =
+          (AppRouterBuilder()
+                ..addSettingsNotify(builder: (_, _) => const SizedBox.shrink()))
+              .build();
+      final route = router.configuration.routes.first as GoRoute;
+      expect(route.path, '/settings/notify');
+      expect(route.name, AppRoute.settingsNotify.name);
+      expect(route.builder, isNotNull);
+    });
+
+    test('addExperimental sets correct path and name', () {
+      final router =
+          (AppRouterBuilder()
+                ..addExperimental(builder: (_, _) => const SizedBox.shrink()))
+              .build();
+      final route = router.configuration.routes.first as GoRoute;
+      expect(route.path, '/experimental');
+      expect(route.name, AppRoute.experimental.name);
+      expect(route.builder, isNotNull);
+    });
+
+    test('addDebugger sets correct path and name', () {
+      final router =
+          (AppRouterBuilder()
+                ..addDebugger(builder: (_, _) => const SizedBox.shrink()))
+              .build();
+      final route = router.configuration.routes.first as GoRoute;
+      expect(route.path, '/debugger');
+      expect(route.name, AppRoute.debugger.name);
+      expect(route.builder, isNotNull);
+    });
+
+    test('addGroupManage sets correct path and name', () {
+      final router =
+          (AppRouterBuilder()
+                ..addGroupManage(builder: (_, _) => const SizedBox.shrink()))
+              .build();
+      final route = router.configuration.routes.first as GoRoute;
+      expect(route.path, '/group/manage');
+      expect(route.name, AppRoute.groupManage.name);
+      expect(route.builder, isNotNull);
+    });
+
+    test('addHabitsStatus sets correct path and name', () {
+      final router =
+          (AppRouterBuilder()
+                ..addHabitsStatus(builder: (_, _) => const SizedBox.shrink()))
+              .build();
+      final route = router.configuration.routes.first as GoRoute;
+      expect(route.path, '/habits/status');
+      expect(route.name, AppRoute.habitsStatus.name);
+      expect(route.builder, isNotNull);
+    });
+
+    test('chains all 12 routes in registration order', () {
+      final router =
+          (AppRouterBuilder()
+                ..addHabits(builder: (_, _) => const SizedBox.shrink())
+                ..addHabitDetail(builder: (_, _) => const SizedBox.shrink())
+                ..addHabitCreate(
+                  pageBuilder: (_, _) =>
+                      const MaterialPage<void>(child: SizedBox.shrink()),
+                )
+                ..addHabitEdit(
+                  pageBuilder: (_, _) =>
+                      const MaterialPage<void>(child: SizedBox.shrink()),
+                )
+                ..addSettings(builder: (_, _) => const SizedBox.shrink())
+                ..addSettingsAbout(builder: (_, _) => const SizedBox.shrink())
+                ..addSettingsSync(builder: (_, _) => const SizedBox.shrink())
+                ..addSettingsNotify(builder: (_, _) => const SizedBox.shrink())
+                ..addExperimental(builder: (_, _) => const SizedBox.shrink())
+                ..addDebugger(builder: (_, _) => const SizedBox.shrink())
+                ..addGroupManage(builder: (_, _) => const SizedBox.shrink())
+                ..addHabitsStatus(builder: (_, _) => const SizedBox.shrink()))
+              .build();
       final routes = router.configuration.routes;
-      expect(routes, hasLength(4));
+      expect(routes, hasLength(12));
       expect((routes[0] as GoRoute).path, '/habits');
       expect((routes[1] as GoRoute).path, '/habits/:habitId');
       expect((routes[2] as GoRoute).path, '/habit/create');
       expect((routes[3] as GoRoute).path, '/habit/edit');
+      expect((routes[4] as GoRoute).path, '/settings');
+      expect((routes[5] as GoRoute).path, '/settings/about');
+      expect((routes[6] as GoRoute).path, '/settings/sync');
+      expect((routes[7] as GoRoute).path, '/settings/notify');
+      expect((routes[8] as GoRoute).path, '/experimental');
+      expect((routes[9] as GoRoute).path, '/debugger');
+      expect((routes[10] as GoRoute).path, '/group/manage');
+      expect((routes[11] as GoRoute).path, '/habits/status');
     });
 
     test('build without home leaves initialLocation unset', () {
-      final router = AppRouterBuilder()
-          .addHabits(builder: (_, _) => const SizedBox.shrink())
-          .build();
+      final router =
+          (AppRouterBuilder()
+                ..addHabits(builder: (_, _) => const SizedBox.shrink()))
+              .build();
       // When no home is set, routeInformationProvider wraps initialLocation
       // in a RouteInformation. Verify configuration has the routes.
       expect(router.configuration.routes, hasLength(1));
@@ -114,6 +222,14 @@ void main() {
       expect(AppRoute.habitDetail.name, 'habits/:habitId');
       expect(AppRoute.habitCreate.name, 'habit/create');
       expect(AppRoute.habitEdit.name, 'habit/edit');
+      expect(AppRoute.settings.name, 'settings');
+      expect(AppRoute.settingsAbout.name, 'settings/about');
+      expect(AppRoute.settingsSync.name, 'settings/sync');
+      expect(AppRoute.settingsNotify.name, 'settings/notify');
+      expect(AppRoute.experimental.name, 'experimental');
+      expect(AppRoute.debugger.name, 'debugger');
+      expect(AppRoute.groupManage.name, 'group/manage');
+      expect(AppRoute.habitsStatus.name, 'habits/status');
     });
   });
 }

--- a/test/unit/routes/app_router_test.dart
+++ b/test/unit/routes/app_router_test.dart
@@ -1,0 +1,119 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mhabit/routes/app_router.dart';
+
+void main() {
+  group('AppRouterBuilder', () {
+    test('build with no routes produces empty route list', () {
+      final router = AppRouterBuilder().build();
+      final routes = router.configuration.routes;
+      expect(routes, isEmpty);
+    });
+
+    test('addHabits sets correct path and name', () {
+      final router = AppRouterBuilder()
+          .addHabits(builder: (_, _) => const SizedBox.shrink())
+          .build();
+      final routes = router.configuration.routes;
+      expect(routes, hasLength(1));
+      final route = routes.first as GoRoute;
+      expect(route.path, '/habits');
+      expect(route.name, AppRoute.habits.name);
+      expect(route.builder, isNotNull);
+    });
+
+    test('addHabitDetail sets correct path and name', () {
+      final router = AppRouterBuilder()
+          .addHabitDetail(builder: (_, _) => const SizedBox.shrink())
+          .build();
+      final routes = router.configuration.routes;
+      expect(routes, hasLength(1));
+      final route = routes.first as GoRoute;
+      expect(route.path, '/habits/:habitId');
+      expect(route.name, AppRoute.habitDetail.name);
+      expect(route.builder, isNotNull);
+    });
+
+    test('addHabitCreate sets correct path, name and pageBuilder', () {
+      final router = AppRouterBuilder()
+          .addHabitCreate(
+            pageBuilder: (_, _) =>
+                const MaterialPage<void>(child: SizedBox.shrink()),
+          )
+          .build();
+      final routes = router.configuration.routes;
+      expect(routes, hasLength(1));
+      final route = routes.first as GoRoute;
+      expect(route.path, '/habit/create');
+      expect(route.name, AppRoute.habitCreate.name);
+      expect(route.pageBuilder, isNotNull);
+    });
+
+    test('addHabitEdit sets correct path, name and pageBuilder', () {
+      final router = AppRouterBuilder()
+          .addHabitEdit(
+            pageBuilder: (_, _) =>
+                const MaterialPage<void>(child: SizedBox.shrink()),
+          )
+          .build();
+      final routes = router.configuration.routes;
+      expect(routes, hasLength(1));
+      final route = routes.first as GoRoute;
+      expect(route.path, '/habit/edit');
+      expect(route.name, AppRoute.habitEdit.name);
+      expect(route.pageBuilder, isNotNull);
+    });
+
+    test('chains all routes in registration order', () {
+      final router = AppRouterBuilder()
+          .addHabits(builder: (_, _) => const SizedBox.shrink())
+          .addHabitDetail(builder: (_, _) => const SizedBox.shrink())
+          .addHabitCreate(
+            pageBuilder: (_, _) =>
+                const MaterialPage<void>(child: SizedBox.shrink()),
+          )
+          .addHabitEdit(
+            pageBuilder: (_, _) =>
+                const MaterialPage<void>(child: SizedBox.shrink()),
+          )
+          .build();
+      final routes = router.configuration.routes;
+      expect(routes, hasLength(4));
+      expect((routes[0] as GoRoute).path, '/habits');
+      expect((routes[1] as GoRoute).path, '/habits/:habitId');
+      expect((routes[2] as GoRoute).path, '/habit/create');
+      expect((routes[3] as GoRoute).path, '/habit/edit');
+    });
+
+    test('build without home leaves initialLocation unset', () {
+      final router = AppRouterBuilder()
+          .addHabits(builder: (_, _) => const SizedBox.shrink())
+          .build();
+      // When no home is set, routeInformationProvider wraps initialLocation
+      // in a RouteInformation. Verify configuration has the routes.
+      expect(router.configuration.routes, hasLength(1));
+    });
+
+    test('AppRoute enum name matches path convention', () {
+      expect(AppRoute.habits.name, 'habits');
+      expect(AppRoute.habitDetail.name, 'habits/:habitId');
+      expect(AppRoute.habitCreate.name, 'habit/create');
+      expect(AppRoute.habitEdit.name, 'habit/edit');
+    });
+  });
+}

--- a/test/unit/routes/group_manage_helper_test.dart
+++ b/test/unit/routes/group_manage_helper_test.dart
@@ -1,0 +1,68 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mhabit/routes/helpers/group_manage_helper.dart';
+
+void main() {
+  group('unpackGroupManage', () {
+    testWidgets('extracts selectedGroupId from query parameter', (
+      tester,
+    ) async {
+      GoRouterState? capturedState;
+
+      final router = GoRouter(
+        initialLocation: '/group/manage?selectedGroupId=grp-abc',
+        routes: [
+          GoRoute(
+            path: '/group/manage',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final params = capturedState!.unpackGroupManage();
+      expect(params.selectedGroupId, 'grp-abc');
+    });
+
+    testWidgets('selectedGroupId is null when query parameter absent', (
+      tester,
+    ) async {
+      GoRouterState? capturedState;
+
+      final router = GoRouter(
+        initialLocation: '/group/manage',
+        routes: [
+          GoRoute(
+            path: '/group/manage',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final params = capturedState!.unpackGroupManage();
+      expect(params.selectedGroupId, isNull);
+    });
+  });
+}

--- a/test/unit/routes/habit_create_helper_test.dart
+++ b/test/unit/routes/habit_create_helper_test.dart
@@ -86,5 +86,54 @@ void main() {
       final params = capturedState!.unpackHabitCreate();
       expect(params.initForm, isNull);
     });
+
+    testWidgets(
+      'returns default initForm when extra is null (deep-link compat)',
+      (tester) async {
+        GoRouterState? capturedState;
+
+        final router = GoRouter(
+          initialLocation: '/habit/create',
+          routes: [
+            GoRoute(
+              path: '/habit/create',
+              builder: (_, state) {
+                capturedState = state;
+                return const SizedBox.shrink();
+              },
+            ),
+          ],
+        );
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+        final params = capturedState!.unpackHabitCreate();
+        expect(params.initForm, isNull);
+      },
+    );
+
+    testWidgets(
+      'returns default initForm when extra is wrong type (deep-link compat)',
+      (tester) async {
+        GoRouterState? capturedState;
+
+        final router = GoRouter(
+          initialLocation: '/habit/create',
+          initialExtra: 'wrong-type',
+          routes: [
+            GoRoute(
+              path: '/habit/create',
+              builder: (_, state) {
+                capturedState = state;
+                return const SizedBox.shrink();
+              },
+            ),
+          ],
+        );
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+        final params = capturedState!.unpackHabitCreate();
+        expect(params.initForm, isNull);
+      },
+    );
   });
 }

--- a/test/unit/routes/habit_create_helper_test.dart
+++ b/test/unit/routes/habit_create_helper_test.dart
@@ -1,0 +1,90 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mhabit/models/habit_form.dart';
+import 'package:mhabit/routes/helpers/habit_create_helper.dart';
+
+void main() {
+  group('HabitCreateExtra', () {
+    test('construct with initForm — accessor returns it', () {
+      final form = HabitForm.empty();
+      final extra = HabitCreateExtra(initForm: form);
+
+      expect(extra.initForm, same(form));
+    });
+
+    test('construct with no arguments — initForm is null', () {
+      const extra = HabitCreateExtra();
+
+      expect(extra.initForm, isNull);
+    });
+
+    test('construct with null initForm explicitly — initForm is null', () {
+      const extra = HabitCreateExtra(initForm: null);
+
+      expect(extra.initForm, isNull);
+    });
+  });
+
+  group('unpackHabitCreate', () {
+    testWidgets('extracts initForm from extra', (tester) async {
+      GoRouterState? capturedState;
+      final form = HabitForm.empty();
+      final extra = HabitCreateExtra(initForm: form);
+
+      final router = GoRouter(
+        initialLocation: '/habit/create',
+        initialExtra: extra,
+        routes: [
+          GoRoute(
+            path: '/habit/create',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final params = capturedState!.unpackHabitCreate();
+      expect(params.initForm, same(form));
+    });
+
+    testWidgets('initForm is null when extra has no initForm', (tester) async {
+      GoRouterState? capturedState;
+
+      final router = GoRouter(
+        initialLocation: '/habit/create',
+        initialExtra: const HabitCreateExtra(),
+        routes: [
+          GoRoute(
+            path: '/habit/create',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final params = capturedState!.unpackHabitCreate();
+      expect(params.initForm, isNull);
+    });
+  });
+}

--- a/test/unit/routes/habit_detail_helper_test.dart
+++ b/test/unit/routes/habit_detail_helper_test.dart
@@ -22,13 +22,13 @@ import 'package:mhabit/routes/helpers/habit_detail_helper.dart';
 void main() {
   group('HabitDetailExtra', () {
     test(
-      'construct with color only — accessors return color, adapter null',
+      'construct with color only — accessors return color, summaryAdapter null',
       () {
         const color = HabitColor.builtIn(HabitColorType.cc1);
         const extra = HabitDetailExtra(color: color);
 
         expect(extra.color, color);
-        expect(extra.adapter, isNull);
+        expect(extra.summaryAdapter, isNull);
       },
     );
 
@@ -36,7 +36,7 @@ void main() {
       const extra = HabitDetailExtra();
 
       expect(extra.color, isNull);
-      expect(extra.adapter, isNull);
+      expect(extra.summaryAdapter, isNull);
     });
 
     test('construct with same color — accessor returns same value', () {
@@ -78,7 +78,7 @@ void main() {
       final params = capturedState!.unpackHabitDetail();
       expect(params.habitUUID, 'test-habit-id');
       expect(params.color, const HabitColor.builtIn(HabitColorType.cc3));
-      expect(params.adapter, isNull);
+      expect(params.summaryAdapter, isNull);
     });
 
     testWidgets('returns defaults when extra is null (deep-link compat)', (
@@ -103,7 +103,7 @@ void main() {
       final params = capturedState!.unpackHabitDetail();
       expect(params.habitUUID, 'test-id');
       expect(params.color, isNull);
-      expect(params.adapter, isNull);
+      expect(params.summaryAdapter, isNull);
     });
 
     testWidgets(
@@ -129,7 +129,7 @@ void main() {
         final params = capturedState!.unpackHabitDetail();
         expect(params.habitUUID, 'test-id');
         expect(params.color, isNull);
-        expect(params.adapter, isNull);
+        expect(params.summaryAdapter, isNull);
       },
     );
   });

--- a/test/unit/routes/habit_detail_helper_test.dart
+++ b/test/unit/routes/habit_detail_helper_test.dart
@@ -81,7 +81,9 @@ void main() {
       expect(params.adapter, isNull);
     });
 
-    testWidgets('throws when extra is null', (tester) async {
+    testWidgets('returns defaults when extra is null (deep-link compat)', (
+      tester,
+    ) async {
       GoRouterState? capturedState;
 
       final router = GoRouter(
@@ -98,34 +100,37 @@ void main() {
       );
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
-      expect(
-        () => capturedState!.unpackHabitDetail(),
-        throwsA(isA<TypeError>()),
-      );
+      final params = capturedState!.unpackHabitDetail();
+      expect(params.habitUUID, 'test-id');
+      expect(params.color, isNull);
+      expect(params.adapter, isNull);
     });
 
-    testWidgets('throws when extra is wrong type', (tester) async {
-      GoRouterState? capturedState;
+    testWidgets(
+      'returns defaults when extra is wrong type (deep-link compat)',
+      (tester) async {
+        GoRouterState? capturedState;
 
-      final router = GoRouter(
-        initialLocation: '/habits/test-id',
-        initialExtra: 'wrong-type',
-        routes: [
-          GoRoute(
-            path: '/habits/:habitId',
-            builder: (_, state) {
-              capturedState = state;
-              return const SizedBox.shrink();
-            },
-          ),
-        ],
-      );
-      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+        final router = GoRouter(
+          initialLocation: '/habits/test-id',
+          initialExtra: 'wrong-type',
+          routes: [
+            GoRoute(
+              path: '/habits/:habitId',
+              builder: (_, state) {
+                capturedState = state;
+                return const SizedBox.shrink();
+              },
+            ),
+          ],
+        );
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
-      expect(
-        () => capturedState!.unpackHabitDetail(),
-        throwsA(isA<TypeError>()),
-      );
-    });
+        final params = capturedState!.unpackHabitDetail();
+        expect(params.habitUUID, 'test-id');
+        expect(params.color, isNull);
+        expect(params.adapter, isNull);
+      },
+    );
   });
 }

--- a/test/unit/routes/habit_detail_helper_test.dart
+++ b/test/unit/routes/habit_detail_helper_test.dart
@@ -1,0 +1,131 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mhabit/models/habit_color.dart';
+import 'package:mhabit/models/habit_color_type.dart';
+import 'package:mhabit/routes/helpers/habit_detail_helper.dart';
+
+void main() {
+  group('HabitDetailExtra', () {
+    test(
+      'construct with color only — accessors return color, adapter null',
+      () {
+        const color = HabitColor.builtIn(HabitColorType.cc1);
+        const extra = HabitDetailExtra(color: color);
+
+        expect(extra.color, color);
+        expect(extra.adapter, isNull);
+      },
+    );
+
+    test('construct with no arguments — all fields null', () {
+      const extra = HabitDetailExtra();
+
+      expect(extra.color, isNull);
+      expect(extra.adapter, isNull);
+    });
+
+    test('construct with same color — accessor returns same value', () {
+      const color = HabitColor.builtIn(HabitColorType.cc5);
+      const extra = HabitDetailExtra(color: color);
+
+      expect(extra.color, const HabitColor.builtIn(HabitColorType.cc5));
+    });
+
+    test('null color stays null', () {
+      const extra = HabitDetailExtra(color: null);
+
+      expect(extra.color, isNull);
+    });
+  });
+
+  group('unpackHabitDetail', () {
+    testWidgets('extracts path parameter and extra correctly', (tester) async {
+      GoRouterState? capturedState;
+      const extra = HabitDetailExtra(
+        color: HabitColor.builtIn(HabitColorType.cc3),
+      );
+
+      final router = GoRouter(
+        initialLocation: '/habits/test-habit-id',
+        initialExtra: extra,
+        routes: [
+          GoRoute(
+            path: '/habits/:habitId',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final params = capturedState!.unpackHabitDetail();
+      expect(params.habitUUID, 'test-habit-id');
+      expect(params.color, const HabitColor.builtIn(HabitColorType.cc3));
+      expect(params.adapter, isNull);
+    });
+
+    testWidgets('throws when extra is null', (tester) async {
+      GoRouterState? capturedState;
+
+      final router = GoRouter(
+        initialLocation: '/habits/test-id',
+        routes: [
+          GoRoute(
+            path: '/habits/:habitId',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      expect(
+        () => capturedState!.unpackHabitDetail(),
+        throwsA(isA<TypeError>()),
+      );
+    });
+
+    testWidgets('throws when extra is wrong type', (tester) async {
+      GoRouterState? capturedState;
+
+      final router = GoRouter(
+        initialLocation: '/habits/test-id',
+        initialExtra: 'wrong-type',
+        routes: [
+          GoRoute(
+            path: '/habits/:habitId',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      expect(
+        () => capturedState!.unpackHabitDetail(),
+        throwsA(isA<TypeError>()),
+      );
+    });
+  });
+}

--- a/test/unit/routes/habit_edit_helper_test.dart
+++ b/test/unit/routes/habit_edit_helper_test.dart
@@ -1,0 +1,182 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mhabit/common/consts.dart';
+import 'package:mhabit/models/habit_color.dart';
+import 'package:mhabit/models/habit_daily_goal.dart';
+import 'package:mhabit/models/habit_date.dart';
+import 'package:mhabit/models/habit_display.dart';
+import 'package:mhabit/models/habit_form.dart';
+import 'package:mhabit/models/habit_freq.dart';
+import 'package:mhabit/routes/app_router.dart';
+import 'package:mhabit/routes/helpers/habit_edit_helper.dart';
+
+HabitForm _editForm({required String uuid}) => HabitForm(
+  name: 'Test Habit',
+  type: HabitType.normal,
+  color: const HabitColor.builtIn(defaultHabitColorType),
+  dailyGoal: HabitDailyGoalData(type: HabitType.normal),
+  frequency: HabitFrequency.daily,
+  startDate: HabitDate.dateTime(DateTime(2026, 1, 1)),
+  targetDays: defaultHabitTargetDays,
+  editMode: HabitDisplayEditMode.edit,
+  editParams: HabitDisplayEditParams(
+    uuid: uuid,
+    createT: DateTime(2026, 1, 1),
+    modifyT: DateTime(2026, 6, 1),
+  ),
+);
+
+void main() {
+  group('HabitEditExtra', () {
+    test('construct with habitId and initForm — accessors return values', () {
+      const habitId = 'edit-habit-uuid';
+      final form = _editForm(uuid: habitId);
+      final extra = HabitEditExtra(habitId: habitId, initForm: form);
+
+      expect(extra.habitId, habitId);
+      expect(extra.initForm, same(form));
+    });
+
+    test(
+      'habitId and initForm.editParams.uuid can differ (assert lives in push, not extra)',
+      () {
+        // The extra container itself does not enforce consistency;
+        // that check lives in pushHabitEdit / unpackHabitEdit.
+        const extraHabitId = 'extra-habit-uuid';
+        const formHabitId = 'form-habit-uuid';
+        final form = _editForm(uuid: formHabitId);
+        final extra = HabitEditExtra(habitId: extraHabitId, initForm: form);
+
+        expect(extra.habitId, extraHabitId);
+        expect(extra.initForm.editParams?.uuid, formHabitId);
+        expect(extra.habitId, isNot(equals(formHabitId)));
+      },
+    );
+  });
+
+  group('unpackHabitEdit', () {
+    testWidgets('extracts habitId and initForm when query matches extra', (
+      tester,
+    ) async {
+      GoRouterState? capturedState;
+      const habitId = 'unpack-edit-uuid';
+      final form = _editForm(uuid: habitId);
+      final extra = HabitEditExtra(habitId: habitId, initForm: form);
+
+      final router = GoRouter(
+        initialLocation: '/habit/edit?habitId=$habitId',
+        initialExtra: extra,
+        routes: [
+          GoRoute(
+            path: '/habit/edit',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final params = capturedState!.unpackHabitEdit();
+      expect(params.habitId, habitId);
+      expect(params.initForm, same(form));
+    });
+
+    testWidgets('assert fails when query habitId differs from extra.habitId', (
+      tester,
+    ) async {
+      GoRouterState? capturedState;
+      const extraHabitId = 'extra-id';
+      final form = _editForm(uuid: extraHabitId);
+      final extra = HabitEditExtra(habitId: extraHabitId, initForm: form);
+
+      final router = GoRouter(
+        initialLocation: '/habit/edit?habitId=wrong-query-id',
+        initialExtra: extra,
+        routes: [
+          GoRoute(
+            path: '/habit/edit',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      expect(
+        () => capturedState!.unpackHabitEdit(),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('pushHabitEdit', () {
+    testWidgets('assert fails when initForm.editParams.uuid != habitId', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/habit/edit',
+            name: AppRoute.habitEdit.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final form = _editForm(uuid: 'correct-uuid');
+      final context = tester.element(find.byType(SizedBox).first);
+
+      expect(
+        () => context.pushHabitEdit(habitId: 'wrong-uuid', initForm: form),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    testWidgets('succeeds when uuids match (no assert)', (tester) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/habit/edit',
+            name: AppRoute.habitEdit.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      const habitId = 'matching-uuid';
+      final form = _editForm(uuid: habitId);
+      final context = tester.element(find.byType(SizedBox).first);
+
+      // Should not throw — navigate starts, future does not need to settle.
+      expect(
+        () => context.pushHabitEdit(habitId: habitId, initForm: form),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/test/unit/routes/habit_edit_helper_test.dart
+++ b/test/unit/routes/habit_edit_helper_test.dart
@@ -126,6 +126,53 @@ void main() {
         throwsA(isA<AssertionError>()),
       );
     });
+
+    testWidgets('throws StateError when extra is null', (tester) async {
+      GoRouterState? capturedState;
+
+      final router = GoRouter(
+        initialLocation: '/habit/edit?habitId=test-id',
+        routes: [
+          GoRoute(
+            path: '/habit/edit',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      expect(
+        () => capturedState!.unpackHabitEdit(),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    testWidgets('throws StateError when extra is wrong type', (tester) async {
+      GoRouterState? capturedState;
+
+      final router = GoRouter(
+        initialLocation: '/habit/edit?habitId=test-id',
+        initialExtra: 'wrong-type',
+        routes: [
+          GoRoute(
+            path: '/habit/edit',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      expect(
+        () => capturedState!.unpackHabitEdit(),
+        throwsA(isA<StateError>()),
+      );
+    });
   });
 
   group('pushHabitEdit', () {

--- a/test/unit/routes/habits_status_changer_helper_test.dart
+++ b/test/unit/routes/habits_status_changer_helper_test.dart
@@ -1,0 +1,141 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mhabit/routes/helpers/habits_status_changer_helper.dart';
+
+void main() {
+  group('HabitsStatusChangerExtra', () {
+    test('construct with uuidList — accessor returns it', () {
+      const uuidList = ['a', 'b', 'c'];
+      const extra = HabitsStatusChangerExtra(uuidList: uuidList);
+
+      expect(extra.uuidList, uuidList);
+    });
+
+    test('construct with no arguments — uuidList is null', () {
+      const extra = HabitsStatusChangerExtra();
+
+      expect(extra.uuidList, isNull);
+    });
+
+    test('construct with null uuidList explicitly — uuidList is null', () {
+      const extra = HabitsStatusChangerExtra(uuidList: null);
+
+      expect(extra.uuidList, isNull);
+    });
+  });
+
+  group('unpackHabitsStatusChanger', () {
+    testWidgets('extra uuidList takes priority over query params', (
+      tester,
+    ) async {
+      GoRouterState? capturedState;
+      const uuidList = ['extra-a', 'extra-b'];
+      const extra = HabitsStatusChangerExtra(uuidList: uuidList);
+
+      final router = GoRouter(
+        initialLocation: '/habits/status?habitId=qp-a&habitId=qp-b',
+        initialExtra: extra,
+        routes: [
+          GoRoute(
+            path: '/habits/status',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final params = capturedState!.unpackHabitsStatusChanger();
+      expect(params.uuidList, uuidList);
+    });
+
+    testWidgets('falls back to queryParametersAll when extra is null', (
+      tester,
+    ) async {
+      GoRouterState? capturedState;
+
+      final router = GoRouter(
+        initialLocation: '/habits/status?habitId=deeplink-a&habitId=deeplink-b',
+        routes: [
+          GoRoute(
+            path: '/habits/status',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final params = capturedState!.unpackHabitsStatusChanger();
+      expect(params.uuidList, ['deeplink-a', 'deeplink-b']);
+    });
+
+    testWidgets(
+      'falls back to queryParametersAll when extra uuidList is null',
+      (tester) async {
+        GoRouterState? capturedState;
+        const extra = HabitsStatusChangerExtra();
+
+        final router = GoRouter(
+          initialLocation: '/habits/status?habitId=qp-only',
+          initialExtra: extra,
+          routes: [
+            GoRoute(
+              path: '/habits/status',
+              builder: (_, state) {
+                capturedState = state;
+                return const SizedBox.shrink();
+              },
+            ),
+          ],
+        );
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+        final params = capturedState!.unpackHabitsStatusChanger();
+        expect(params.uuidList, ['qp-only']);
+      },
+    );
+
+    testWidgets('returns empty list when no source provides uuidList', (
+      tester,
+    ) async {
+      GoRouterState? capturedState;
+
+      final router = GoRouter(
+        initialLocation: '/habits/status',
+        routes: [
+          GoRoute(
+            path: '/habits/status',
+            builder: (_, state) {
+              capturedState = state;
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final params = capturedState!.unpackHabitsStatusChanger();
+      expect(params.uuidList, isEmpty);
+    });
+  });
+}

--- a/test/unit/routes/navigator_helpers_test.dart
+++ b/test/unit/routes/navigator_helpers_test.dart
@@ -1,0 +1,144 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mhabit/common/consts.dart';
+import 'package:mhabit/models/habit_color.dart';
+import 'package:mhabit/models/habit_daily_goal.dart';
+import 'package:mhabit/models/habit_date.dart';
+import 'package:mhabit/models/habit_display.dart';
+import 'package:mhabit/models/habit_form.dart';
+import 'package:mhabit/models/habit_freq.dart';
+import 'package:mhabit/routes/app_router.dart';
+import 'package:mhabit/routes/navigator_helpers.dart';
+
+HabitForm _editForm({required String uuid}) => HabitForm(
+  name: 'Test Habit',
+  type: HabitType.normal,
+  color: const HabitColor.builtIn(defaultHabitColorType),
+  dailyGoal: HabitDailyGoalData(type: HabitType.normal),
+  frequency: HabitFrequency.daily,
+  startDate: HabitDate.dateTime(DateTime(2026, 1, 1)),
+  targetDays: defaultHabitTargetDays,
+  editMode: HabitDisplayEditMode.edit,
+  editParams: HabitDisplayEditParams(
+    uuid: uuid,
+    createT: DateTime(2026, 1, 1),
+    modifyT: DateTime(2026, 6, 1),
+  ),
+);
+
+void main() {
+  group('naviTo* (go_router wrappers)', () {
+    testWidgets('naviToHabitEditPage assert fails when editMode != edit', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/habit/edit',
+            name: AppRoute.habitEdit.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final context = tester.element(find.byType(SizedBox).first);
+      final createForm = HabitForm.empty(); // editMode defaults to create
+
+      expect(
+        () => naviToHabitEditPage(context: context, initForm: createForm),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    testWidgets('naviToHabitEditPage delegates to pushHabitEdit on success', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/habit/edit',
+            name: AppRoute.habitEdit.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      const habitId = 'navi-edit-uuid';
+      final form = _editForm(uuid: habitId);
+      final context = tester.element(find.byType(SizedBox).first);
+
+      // Should not throw — navigation starts.
+      expect(
+        () => naviToHabitEditPage(context: context, initForm: form),
+        returnsNormally,
+      );
+    });
+
+    testWidgets('naviToHabitCreatePage delegates to pushHabitCreate', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/habit/create',
+            name: AppRoute.habitCreate.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final context = tester.element(find.byType(SizedBox).first);
+
+      expect(() => naviToHabitCreatePage(context: context), returnsNormally);
+    });
+
+    testWidgets('naviToHabitDetailPage delegates to pushHabitDetail', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/habits/:habitId',
+            name: AppRoute.habitDetail.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      const habitUUID = 'navi-detail-uuid';
+      final context = tester.element(find.byType(SizedBox).first);
+
+      expect(
+        () => naviToHabitDetailPage(context: context, habitUUID: habitUUID),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/test/unit/routes/navigator_helpers_test.dart
+++ b/test/unit/routes/navigator_helpers_test.dart
@@ -140,5 +140,163 @@ void main() {
         returnsNormally,
       );
     });
+
+    // ---- Step 4: 全量推广 naviTo* delegates ----
+
+    testWidgets('naviToAppSettingPage delegates to pushNamed', (tester) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/settings',
+            name: AppRoute.settings.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      final context = tester.element(find.byType(SizedBox).first);
+      expect(() => naviToAppSettingPage(context: context), returnsNormally);
+    });
+
+    testWidgets('naviToAppAboutPage delegates to pushNamed', (tester) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/settings/about',
+            name: AppRoute.settingsAbout.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      final context = tester.element(find.byType(SizedBox).first);
+      expect(() => naviToAppAboutPage(context: context), returnsNormally);
+    });
+
+    testWidgets('naviToAppSyncPage delegates to pushNamed', (tester) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/settings/sync',
+            name: AppRoute.settingsSync.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      final context = tester.element(find.byType(SizedBox).first);
+      expect(() => naviToAppSyncPage(context: context), returnsNormally);
+    });
+
+    testWidgets('naviToNotifyConfigPage delegates to pushNamed', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/settings/notify',
+            name: AppRoute.settingsNotify.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      final context = tester.element(find.byType(SizedBox).first);
+      expect(() => naviToNotifyConfigPage(context: context), returnsNormally);
+    });
+
+    testWidgets('naviToExperimentalFeaturesPage delegates to pushNamed', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/experimental',
+            name: AppRoute.experimental.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      final context = tester.element(find.byType(SizedBox).first);
+      expect(
+        () => naviToExperimentalFeaturesPage(context: context),
+        returnsNormally,
+      );
+    });
+
+    testWidgets('naviToAppDebuggerPage delegates to pushNamed', (tester) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/debugger',
+            name: AppRoute.debugger.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      final context = tester.element(find.byType(SizedBox).first);
+      expect(() => naviToAppDebuggerPage(context: context), returnsNormally);
+    });
+
+    testWidgets('naviToGroupManagePage delegates with selectedGroupId', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/group/manage',
+            name: AppRoute.groupManage.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      final context = tester.element(find.byType(SizedBox).first);
+      expect(
+        () => naviToGroupManagePage(context: context, selectedGroupId: 'grp-1'),
+        returnsNormally,
+      );
+    });
+
+    testWidgets('naviToHabitsStatusChangerPage delegates with uuidList', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: '/habits/status',
+            name: AppRoute.habitsStatus.name,
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      final context = tester.element(find.byType(SizedBox).first);
+      expect(
+        () => naviToHabitsStatusChangerPage(
+          context: context,
+          uuidList: const ['a', 'b'],
+        ),
+        returnsNormally,
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
Replace the legacy `Navigator`-based page routing with `go_router`, introducing a centralized `AppRouter` and decoupled route helpers for each page. This improves deep-link compatibility, route testability, and separates navigation concerns from page widgets.

## Type of Change
- [x] refactor

## Related Issue
<!-- e.g. Fixes #123, Closes #123, Related to #123 -->

## Checklist
- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change