### PR TITLE
feat(adaptive-ui): avoid iPad window controls

### DIFF
--- a/lib/entries/common/app_root_view.dart
+++ b/lib/entries/common/app_root_view.dart
@@ -14,6 +14,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 
 import '../../common/consts.dart';
 import '../../common/global.dart';
@@ -67,7 +68,7 @@ class AppRootView extends StatelessWidget {
       disableAnimations:
           disableAnimations || MediaQuery.disableAnimationsOf(context),
     ),
-    child: UnfocusOnTap(child: child),
+    child: AdaptiveWindowControlLayout(child: UnfocusOnTap(child: child)),
   );
 
   String _onGenerateTitle(BuildContext context) =>

--- a/lib/pages/app_about/page.dart
+++ b/lib/pages/app_about/page.dart
@@ -16,6 +16,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 import 'package:provider/provider.dart';
 
 import '../../assets/assets.dart';
@@ -104,7 +105,7 @@ class _PageState extends State<_Page> {
     }
 
     return Scaffold(
-      appBar: AppBar(
+      appBar: WindowControlAppBar(
         leading: const PageBackButton(reason: PageBackReason.back),
         title: L10nBuilder(
           builder: (context, l10n) => l10n != null

--- a/lib/pages/app_debugger/page.dart
+++ b/lib/pages/app_debugger/page.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 import 'package:open_file/open_file.dart' show OpenFile;
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
@@ -170,8 +171,8 @@ class _PageState extends State<_Page> with XShare {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        leading: const PageBackButton(),
+      appBar: const WindowControlAppBar(
+        leading: PageBackButton(),
         automaticallyImplyLeading: false,
       ),
       floatingActionButton: Builder(

--- a/lib/pages/app_error/page.dart
+++ b/lib/pages/app_error/page.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 import 'package:sliver_tools/sliver_tools.dart';
 
 import '../../common/app_info.dart';
@@ -104,7 +105,7 @@ class AppErrorPage extends StatelessWidget {
       ),
       body: CustomScrollView(
         slivers: [
-          SliverAppBar(
+          WindowControlSliverAppBar(
             title: L10nBuilder(
               builder: (context, l10n) => Text(
                 l10n?.common_errorPage_title ?? "Unhandled Exception",

--- a/lib/pages/app_notify_config/page.dart
+++ b/lib/pages/app_notify_config/page.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 import 'package:provider/provider.dart';
 
 import '../../l10n/localizations.dart';
@@ -44,7 +45,7 @@ class _AppNotifyConfigView extends State<AppNotifyConfigView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
+      appBar: WindowControlAppBar(
         leading: const PageBackButton(reason: PageBackReason.back),
         title: L10nBuilder(
           builder: (context, l10n) =>

--- a/lib/pages/app_settings/page.dart
+++ b/lib/pages/app_settings/page.dart
@@ -934,7 +934,7 @@ class _PageState extends State<_Page> with XShare {
 
     return ColorfulNavibar(
       child: Scaffold(
-        appBar: AppBar(
+        appBar: WindowControlAppBar(
           title: L10nBuilder(
             builder: (context, l10n) => l10n != null
                 ? Text(l10n.appSetting_appbar_titleText)

--- a/lib/pages/app_sync/page.dart
+++ b/lib/pages/app_sync/page.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 import 'package:provider/provider.dart';
 import 'package:sliver_tools/sliver_tools.dart';
 
@@ -108,7 +109,7 @@ final class _PageState extends State<_Page> {
     return Scaffold(
       body: CustomScrollView(
         slivers: [
-          SliverAppBar(
+          WindowControlSliverAppBar(
             leading: const PageBackButton(reason: PageBackReason.back),
             title: L10nBuilder(
               builder: (context, l10n) =>

--- a/lib/pages/app_sync_server_editor/page.dart
+++ b/lib/pages/app_sync_server_editor/page.dart
@@ -264,7 +264,7 @@ class _PageFullScreenDialog extends StatelessWidget {
   Widget build(BuildContext context) => Dialog.fullscreen(
     child: ColorfulNavibar(
       child: Scaffold(
-        appBar: AppBar(
+        appBar: WindowControlAppBar(
           leading: PageBackButton(
             reason: PageBackReason.close,
             onPressed: onCancelButtonPressed,

--- a/lib/pages/expermental_features/page.dart
+++ b/lib/pages/expermental_features/page.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 import 'package:provider/provider.dart';
 
 import '../../extensions/context_extensions.dart';
@@ -126,7 +127,7 @@ final class _PageState extends State<_Page> {
     ];
 
     return Scaffold(
-      appBar: AppBar(
+      appBar: WindowControlAppBar(
         leading: const PageBackButton(reason: PageBackReason.back),
         title: Text(
           l10n?.appSetting_experimentalFeatureTile_titleText ??

--- a/lib/pages/group_manage/page.dart
+++ b/lib/pages/group_manage/page.dart
@@ -387,7 +387,7 @@ class _GroupManageSliverAppBar extends StatelessWidget {
       final effectiveSortType = context
           .read<GroupManageViewModel>()
           .effectiveSortType;
-      return SliverAppBar(
+      return WindowControlSliverAppBar(
         pinned: true,
         forceElevated: true,
         scrolledUnderElevation: _kCommonEvalation,
@@ -432,7 +432,7 @@ class _GroupManageSliverAppBar extends StatelessWidget {
         ],
       );
     }
-    return SliverAppBar(
+    return WindowControlSliverAppBar(
       floating: true,
       snap: true,
       pinned: true,

--- a/lib/pages/habit_detail/_widgets/habit_detail_appbar.dart
+++ b/lib/pages/habit_detail/_widgets/habit_detail_appbar.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 
 import '../../../extensions/custom_color_extensions.dart';
 import '../../../models/habit_color.dart';
@@ -41,7 +42,7 @@ class HabitDetailAppBar extends StatelessWidget {
         : null;
     final titleFont = themeData.textTheme.titleLarge;
 
-    return SliverAppBar(
+    return WindowControlSliverAppBar(
       pinned: true,
       title: SingleChildScrollView(
         scrollDirection: Axis.horizontal,

--- a/lib/pages/habit_edit/_widgets/habit_edit_app_bar.dart
+++ b/lib/pages/habit_edit/_widgets/habit_edit_app_bar.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 
 import '../../../extensions/custom_color_extensions.dart';
 import '../../../l10n/localizations.dart';
@@ -88,7 +89,7 @@ class HabitEditAppBar extends StatelessWidget {
       );
     }
 
-    return SliverAppBar.large(
+    return WindowControlSliverAppBar.large(
       pinned: true,
       scrolledUnderElevation: scrolledUnderElevation,
       shadowColor: themeData.colorScheme.shadow,

--- a/lib/pages/habits_display/_widgets/habit_display_appbar.dart
+++ b/lib/pages/habits_display/_widgets/habit_display_appbar.dart
@@ -278,7 +278,7 @@ class _MaterialCalendarBar extends StatelessWidget {
   final Widget child;
 
   @override
-  Widget build(BuildContext context) => SliverAppBar(
+  Widget build(BuildContext context) => WindowControlSliverAppBar(
     pinned: true,
     shadowColor: Theme.of(context).colorScheme.shadow,
     backgroundColor: isInEditMode

--- a/lib/pages/habits_status_changer/_widgets/habit_status_changer_appbar.dart
+++ b/lib/pages/habits_status_changer/_widgets/habit_status_changer_appbar.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart' hide PreferredSize;
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 
 import '../../../widgets/widgets.dart';
 
@@ -30,7 +31,7 @@ class HabitStatusChangerAppbar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SliverAppBar(
+    return WindowControlSliverAppBar(
       leading: PageBackButton(
         reason: PageBackReason.close,
         onPressed: onCloseButtonPressed,

--- a/packages/mhabit_adaptive_ui/lib/mhabit_adaptive_ui.dart
+++ b/packages/mhabit_adaptive_ui/lib/mhabit_adaptive_ui.dart
@@ -23,3 +23,6 @@ export 'src/shell/adaptive_branch_route_observer.dart';
 export 'src/shell/adaptive_nav_scope.dart';
 export 'src/shell/adaptive_nav_visibility.dart';
 export 'src/shell/adaptive_navigation.dart';
+export 'src/window_control/cupertino_navigation_bar.dart';
+export 'src/window_control/material_app_bar.dart';
+export 'src/window_control/window_control_layout.dart';

--- a/packages/mhabit_adaptive_ui/lib/src/adaptive/adaptive_sliver_app_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/adaptive/adaptive_sliver_app_bar.dart
@@ -2,14 +2,15 @@ import 'package:flutter/material.dart';
 
 import '../adaptive_style.dart';
 import '../cupertino/cupertino_sliver_app_bar.dart';
+import '../window_control/material_app_bar.dart';
+import '../window_control/toolbar_geometry.dart';
 
 const List<Widget> _kDefaultActions = <Widget>[];
 
 /// Style config for the Material branch of [AdaptiveSliverAppBar].
 ///
-/// Every field maps 1:1 to a [SliverAppBar] parameter; constructor defaults
-/// reproduce the pre-config baseline, so partial overrides only need to
-/// specify the deltas.
+/// App-bar fields map to [SliverAppBar]. [windowControlEdgePadding] is the
+/// Material visual baseline added only on sides with window-control avoidance.
 class AppBarMaterialStyle {
   const AppBarMaterialStyle({
     this.centerTitle = true,
@@ -20,6 +21,7 @@ class AppBarMaterialStyle {
     this.scrolledUnderElevation,
     this.shadowColor = Colors.transparent,
     this.bottom,
+    this.windowControlEdgePadding = materialWindowControlEdgePadding,
   });
 
   final bool centerTitle;
@@ -31,6 +33,9 @@ class AppBarMaterialStyle {
   final Color? shadowColor;
   final PreferredSizeWidget? bottom;
 
+  /// {@macro mhabit.windowControlEdgePadding}
+  final EdgeInsetsDirectional windowControlEdgePadding;
+
   AppBarMaterialStyle copyWith({
     bool? centerTitle,
     bool? floating,
@@ -40,6 +45,7 @@ class AppBarMaterialStyle {
     double? scrolledUnderElevation,
     Color? shadowColor,
     PreferredSizeWidget? bottom,
+    EdgeInsetsDirectional? windowControlEdgePadding,
   }) => AppBarMaterialStyle(
     centerTitle: centerTitle ?? this.centerTitle,
     floating: floating ?? this.floating,
@@ -50,6 +56,8 @@ class AppBarMaterialStyle {
         scrolledUnderElevation ?? this.scrolledUnderElevation,
     shadowColor: shadowColor ?? this.shadowColor,
     bottom: bottom ?? this.bottom,
+    windowControlEdgePadding:
+        windowControlEdgePadding ?? this.windowControlEdgePadding,
   );
 
   @override
@@ -62,7 +70,8 @@ class AppBarMaterialStyle {
       other.forceElevated == forceElevated &&
       other.scrolledUnderElevation == scrolledUnderElevation &&
       other.shadowColor == shadowColor &&
-      other.bottom == bottom;
+      other.bottom == bottom &&
+      other.windowControlEdgePadding == windowControlEdgePadding;
 
   @override
   int get hashCode => Object.hash(
@@ -74,13 +83,15 @@ class AppBarMaterialStyle {
     scrolledUnderElevation,
     shadowColor,
     bottom,
+    windowControlEdgePadding,
   );
 }
 
 /// Style config for the apple branch of [AdaptiveSliverAppBar].
 ///
-/// Every field maps to a [CupertinoSliverNavigationBar] parameter; null
-/// fields fall back to the Cupertino defaults.
+/// App-bar fields map to [CupertinoSliverNavigationBar].
+/// [windowControlEdgePadding] is the Cupertino visual baseline retained before
+/// adding window-control avoidance.
 class AppBarAppleStyle {
   const AppBarAppleStyle({
     this.collapsible = false,
@@ -89,6 +100,7 @@ class AppBarAppleStyle {
     this.backgroundColor,
     this.padding,
     this.stretch = false,
+    this.windowControlEdgePadding = cupertinoWindowControlEdgePadding,
   });
 
   final bool collapsible;
@@ -98,6 +110,9 @@ class AppBarAppleStyle {
   final EdgeInsetsDirectional? padding;
   final bool stretch;
 
+  /// {@macro mhabit.windowControlEdgePadding}
+  final EdgeInsetsDirectional windowControlEdgePadding;
+
   AppBarAppleStyle copyWith({
     bool? collapsible,
     bool? enableBackgroundFilterBlur,
@@ -105,6 +120,7 @@ class AppBarAppleStyle {
     Color? backgroundColor,
     EdgeInsetsDirectional? padding,
     bool? stretch,
+    EdgeInsetsDirectional? windowControlEdgePadding,
   }) => AppBarAppleStyle(
     collapsible: collapsible ?? this.collapsible,
     enableBackgroundFilterBlur:
@@ -113,6 +129,8 @@ class AppBarAppleStyle {
     backgroundColor: backgroundColor ?? this.backgroundColor,
     padding: padding ?? this.padding,
     stretch: stretch ?? this.stretch,
+    windowControlEdgePadding:
+        windowControlEdgePadding ?? this.windowControlEdgePadding,
   );
 
   @override
@@ -123,7 +141,8 @@ class AppBarAppleStyle {
       other.border == border &&
       other.backgroundColor == backgroundColor &&
       other.padding == padding &&
-      other.stretch == stretch;
+      other.stretch == stretch &&
+      other.windowControlEdgePadding == windowControlEdgePadding;
 
   @override
   int get hashCode => Object.hash(
@@ -133,6 +152,7 @@ class AppBarAppleStyle {
     backgroundColor,
     padding,
     stretch,
+    windowControlEdgePadding,
   );
 }
 
@@ -233,7 +253,7 @@ class AdaptiveSliverAppBar extends StatelessWidget {
 
   Widget _buildMaterial(AppBarMaterialStyle config) {
     // Equivalent of the app's current `SliverTopAppBar` baseline.
-    return SliverAppBar(
+    return WindowControlSliverAppBar(
       floating: config.floating,
       snap: config.snap,
       pinned: config.pinned,
@@ -253,6 +273,7 @@ class AdaptiveSliverAppBar extends StatelessWidget {
                   icon: const Icon(Icons.arrow_back),
                 )),
       actions: actions.isEmpty ? null : actions,
+      windowControlEdgePadding: config.windowControlEdgePadding,
     );
   }
 
@@ -267,5 +288,6 @@ class AdaptiveSliverAppBar extends StatelessWidget {
     backgroundColor: config.backgroundColor,
     padding: config.padding,
     stretch: config.stretch,
+    windowControlEdgePadding: config.windowControlEdgePadding,
   );
 }

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_sliver_app_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_sliver_app_bar.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/cupertino.dart';
 
 import '../breakpoints/window_size_class.dart';
+import '../window_control/cupertino_navigation_bar.dart';
+import '../window_control/toolbar_geometry.dart';
 import 'cupertino_toolbar_padding.dart';
 
 const List<Widget> _kDefaultActions = <Widget>[];
@@ -19,6 +21,8 @@ class CupertinoSliverAppBar extends StatelessWidget {
     this.backgroundColor,
     this.padding,
     this.stretch = false,
+    this.windowControlAvoidance,
+    this.windowControlEdgePadding = cupertinoWindowControlEdgePadding,
   });
 
   final Widget title;
@@ -31,6 +35,8 @@ class CupertinoSliverAppBar extends StatelessWidget {
   final Color? backgroundColor;
   final EdgeInsetsDirectional? padding;
   final bool stretch;
+  final EdgeInsetsDirectional? windowControlAvoidance;
+  final EdgeInsetsDirectional windowControlEdgePadding;
 
   Widget? get _effectiveLeading =>
       leading ??
@@ -59,6 +65,8 @@ class CupertinoSliverAppBar extends StatelessWidget {
         border: border,
         backgroundColor: backgroundColor,
         padding: padding,
+        windowControlAvoidance: windowControlAvoidance,
+        windowControlEdgePadding: windowControlEdgePadding,
       );
     }
     return _CollapsibleCupertinoSliverAppBar(
@@ -70,6 +78,8 @@ class CupertinoSliverAppBar extends StatelessWidget {
       backgroundColor: backgroundColor,
       padding: padding,
       stretch: stretch,
+      windowControlAvoidance: windowControlAvoidance,
+      windowControlEdgePadding: windowControlEdgePadding,
     );
   }
 }
@@ -84,6 +94,8 @@ class _FixedCupertinoSliverAppBar extends StatelessWidget {
     required this.border,
     required this.backgroundColor,
     required this.padding,
+    required this.windowControlAvoidance,
+    required this.windowControlEdgePadding,
   });
 
   final Widget title;
@@ -94,6 +106,8 @@ class _FixedCupertinoSliverAppBar extends StatelessWidget {
   final Border? border;
   final Color? backgroundColor;
   final EdgeInsetsDirectional? padding;
+  final EdgeInsetsDirectional? windowControlAvoidance;
+  final EdgeInsetsDirectional windowControlEdgePadding;
 
   @override
   Widget build(BuildContext context) {
@@ -125,6 +139,8 @@ class _FixedCupertinoSliverAppBar extends StatelessWidget {
                   leading: leading,
                   trailing: trailing,
                   padding: padding,
+                  windowControlAvoidance: windowControlAvoidance,
+                  windowControlEdgePadding: windowControlEdgePadding,
                 ),
               ),
             ],
@@ -141,26 +157,51 @@ class _CupertinoToolbar extends StatelessWidget {
     required this.leading,
     required this.trailing,
     required this.padding,
+    required this.windowControlAvoidance,
+    required this.windowControlEdgePadding,
   });
 
   final Widget title;
   final Widget? leading;
   final Widget? trailing;
   final EdgeInsetsDirectional? padding;
+  final EdgeInsetsDirectional? windowControlAvoidance;
+  final EdgeInsetsDirectional windowControlEdgePadding;
 
   @override
-  Widget build(BuildContext context) => DefaultTextStyle(
-    style: CupertinoTheme.of(context).textTheme.navTitleTextStyle,
-    child: Padding(
-      padding: padding ?? CupertinoToolbarPadding.resolve(context),
-      child: NavigationToolbar(
-        leading: leading,
-        middle: title,
-        trailing: trailing,
-        middleSpacing: 6.0,
+  Widget build(BuildContext context) {
+    final contentPadding = CupertinoToolbarPadding.resolveDirectional(
+      context,
+      contentPadding: padding,
+      edgePadding: windowControlEdgePadding,
+    );
+    final geometry = WindowControlToolbarGeometry.resolve(
+      context,
+      avoidance: windowControlAvoidance,
+      edgePadding: contentPadding,
+    );
+    final insets = geometry.cupertinoInsets;
+    final effectiveLeading = Padding(
+      padding: EdgeInsetsDirectional.only(start: insets.start),
+      child: leading ?? const SizedBox.shrink(),
+    );
+    final effectiveTrailing = Padding(
+      padding: EdgeInsetsDirectional.only(end: insets.end),
+      child: trailing ?? const SizedBox.shrink(),
+    );
+    return DefaultTextStyle(
+      style: CupertinoTheme.of(context).textTheme.navTitleTextStyle,
+      child: Padding(
+        padding: EdgeInsets.only(top: insets.top, bottom: insets.bottom),
+        child: NavigationToolbar(
+          leading: effectiveLeading,
+          middle: title,
+          trailing: effectiveTrailing,
+          middleSpacing: 6.0,
+        ),
       ),
-    ),
-  );
+    );
+  }
 }
 
 class _CollapsibleCupertinoSliverAppBar extends StatelessWidget {
@@ -173,6 +214,8 @@ class _CollapsibleCupertinoSliverAppBar extends StatelessWidget {
     required this.backgroundColor,
     required this.padding,
     required this.stretch,
+    required this.windowControlAvoidance,
+    required this.windowControlEdgePadding,
   });
 
   final Widget title;
@@ -183,6 +226,8 @@ class _CollapsibleCupertinoSliverAppBar extends StatelessWidget {
   final Color? backgroundColor;
   final EdgeInsetsDirectional? padding;
   final bool stretch;
+  final EdgeInsetsDirectional? windowControlAvoidance;
+  final EdgeInsetsDirectional windowControlEdgePadding;
 
   @override
   Widget build(BuildContext context) {
@@ -192,7 +237,7 @@ class _CollapsibleCupertinoSliverAppBar extends StatelessWidget {
         MediaQuery.orientationOf(context) == Orientation.portrait;
     final useLargeTitle =
         isPortrait || WindowSize.of(context).width == WindowSizeClass.compact;
-    return CupertinoSliverNavigationBar(
+    return WindowControlCupertinoSliverNavigationBar(
       middle: useLargeTitle ? null : title,
       largeTitle: useLargeTitle ? title : null,
       leading: leading,
@@ -200,8 +245,14 @@ class _CollapsibleCupertinoSliverAppBar extends StatelessWidget {
       enableBackgroundFilterBlur: enableBackgroundFilterBlur,
       border: border,
       backgroundColor: backgroundColor,
-      padding: padding,
+      padding: CupertinoToolbarPadding.resolveDirectional(
+        context,
+        contentPadding: padding,
+        edgePadding: windowControlEdgePadding,
+      ),
       stretch: stretch,
+      windowControlAvoidance: windowControlAvoidance,
+      windowControlEdgePadding: EdgeInsetsDirectional.zero,
     );
   }
 }

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_sliver_search_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_sliver_search_bar.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart' show Easing;
 
 import '../breakpoints/breakpoints.dart';
 import '../breakpoints/window_size_class.dart';
+import '../window_control/toolbar_geometry.dart';
 import 'cupertino_toolbar_padding.dart';
 
 typedef _CupertinoSearchOverflowPressed =
@@ -395,118 +396,130 @@ class _CupertinoSearchToolbar extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) => Padding(
-    padding: CupertinoToolbarPadding.resolve(context),
-    child: LayoutBuilder(
-      builder: (context, constraints) {
-        const itemExtent = _CupertinoSliverSearchBarState._toolbarItemExtent;
-        const minimumPersistentSearchWidth = 100.0;
-        final preferredTitleExtent = _measureTitleExtent(context);
-        final leadingWidth = leading == null ? 0.0 : itemExtent;
-        final fixedActionWidth = fixedActions.length * itemExtent;
-        final availableWidth = math.max(
-          0.0,
-          constraints.maxWidth - leadingWidth,
-        );
-        final fullActionWidth = actions.length * itemExtent + fixedActionWidth;
-        final minimumAdaptiveWidth = actions.isEmpty ? 0.0 : itemExtent;
-        final automaticSearchWidth = math.max(
-          0.0,
-          availableWidth - fullActionWidth,
-        );
-        final effectiveMinimumPersistentWidth = math.min(
-          minimumPersistentSearchWidth,
-          math.max(itemExtent, maxSearchWidth),
-        );
-        final persistent =
-            preferPersistentSearch &&
-            automaticSearchWidth >= effectiveMinimumPersistentWidth;
-        final expanded = persistent || manuallyExpanded;
-        final preferredSearchWidth = persistent
-            ? math.min(maxSearchWidth, automaticSearchWidth)
-            : expanded
-            ? maxSearchWidth
-            : itemExtent;
-        final searchWidth = math.min(
-          preferredSearchWidth,
-          math.max(
+  Widget build(BuildContext context) {
+    final contentPadding = CupertinoToolbarPadding.resolveDirectional(context);
+    final insets = WindowControlToolbarGeometry.resolve(
+      context,
+      edgePadding: contentPadding,
+    ).cupertinoInsets;
+    return Padding(
+      padding: EdgeInsets.only(top: insets.top, bottom: insets.bottom),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          const itemExtent = _CupertinoSliverSearchBarState._toolbarItemExtent;
+          const minimumPersistentSearchWidth = 100.0;
+          final preferredTitleExtent = _measureTitleExtent(context);
+          final leadingWidth = leading == null ? 0.0 : itemExtent;
+          final fixedActionWidth = fixedActions.length * itemExtent;
+          final contentWidth = math.max(
             0.0,
-            availableWidth - fixedActionWidth - minimumAdaptiveWidth,
-          ),
-        );
-        final showCenteredTitle = showTitle && centerTitle && !expanded;
-        final centeredTitleActionLimit = showCenteredTitle
-            ? math.max(
-                0.0,
-                constraints.maxWidth / 2 -
-                    preferredTitleExtent / 2 -
-                    searchWidth,
-              )
-            : null;
-        return Stack(
-          fit: StackFit.expand,
-          children: [
-            TextFieldTapRegion(
-              onTapOutside: onTapOutside,
-              child: Row(
-                children: [
-                  if (leading case final leading?)
-                    SizedBox(
-                      width: itemExtent,
-                      height: itemExtent,
-                      child: leading,
-                    ),
-                  Expanded(
-                    child: _CupertinoCommandRegion(
-                      title: title,
-                      showTitle: showTitle && !centerTitle,
-                      maxActionRegionWidth: centeredTitleActionLimit,
-                      preferredTitleExtent: expanded
-                          ? 0.0
-                          : preferredTitleExtent,
-                      actions: actions,
-                      fixedActions: fixedActions,
-                      searchExpanded: expanded,
-                      onOverflowMenuOpened: onOverflowMenuOpened,
-                      onOverflowMenuClosed: onOverflowMenuClosed,
-                      onOverflowPressed: onOverflowPressed,
-                    ),
-                  ),
-                  _CupertinoExpandableSearchItem(
-                    expanded: expanded,
-                    persistent: persistent,
-                    controller: controller,
-                    focusNode: focusNode,
-                    hintText: hintText,
-                    maxSearchWidth: searchWidth,
-                    onChanged: onChanged,
-                    onSubmitted: onSubmitted,
-                    onSearchActivated: onSearchActivated,
-                  ),
-                ],
-              ),
+            constraints.maxWidth - insets.start - insets.end,
+          );
+          final availableWidth = math.max(0.0, contentWidth - leadingWidth);
+          final fullActionWidth =
+              actions.length * itemExtent + fixedActionWidth;
+          final minimumAdaptiveWidth = actions.isEmpty ? 0.0 : itemExtent;
+          final automaticSearchWidth = math.max(
+            0.0,
+            availableWidth - fullActionWidth,
+          );
+          final effectiveMinimumPersistentWidth = math.min(
+            minimumPersistentSearchWidth,
+            math.max(itemExtent, maxSearchWidth),
+          );
+          final persistent =
+              preferPersistentSearch &&
+              automaticSearchWidth >= effectiveMinimumPersistentWidth;
+          final expanded = persistent || manuallyExpanded;
+          final preferredSearchWidth = persistent
+              ? math.min(maxSearchWidth, automaticSearchWidth)
+              : expanded
+              ? maxSearchWidth
+              : itemExtent;
+          final searchWidth = math.min(
+            preferredSearchWidth,
+            math.max(
+              0.0,
+              availableWidth - fixedActionWidth - minimumAdaptiveWidth,
             ),
-            if (showCenteredTitle)
-              IgnorePointer(
-                child: Center(
-                  child: SizedBox(
-                    key: const ValueKey('cupertino-search-title'),
-                    width: preferredTitleExtent,
-                    child: DefaultTextStyle.merge(
-                      maxLines: 1,
-                      softWrap: false,
-                      overflow: TextOverflow.ellipsis,
-                      textAlign: TextAlign.center,
-                      child: title,
+          );
+          final showCenteredTitle = showTitle && centerTitle && !expanded;
+          final centeredTitleActionLimit = showCenteredTitle
+              ? math.max(
+                  0.0,
+                  constraints.maxWidth / 2 -
+                      preferredTitleExtent / 2 -
+                      searchWidth -
+                      insets.end,
+                )
+              : null;
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              TextFieldTapRegion(
+                onTapOutside: onTapOutside,
+                child: Row(
+                  children: [
+                    SizedBox(width: insets.start),
+                    if (leading case final leading?)
+                      SizedBox(
+                        width: itemExtent,
+                        height: itemExtent,
+                        child: leading,
+                      ),
+                    Expanded(
+                      child: _CupertinoCommandRegion(
+                        title: title,
+                        showTitle: showTitle && !centerTitle,
+                        maxActionRegionWidth: centeredTitleActionLimit,
+                        preferredTitleExtent: expanded
+                            ? 0.0
+                            : preferredTitleExtent,
+                        actions: actions,
+                        fixedActions: fixedActions,
+                        searchExpanded: expanded,
+                        onOverflowMenuOpened: onOverflowMenuOpened,
+                        onOverflowMenuClosed: onOverflowMenuClosed,
+                        onOverflowPressed: onOverflowPressed,
+                      ),
+                    ),
+                    _CupertinoExpandableSearchItem(
+                      expanded: expanded,
+                      persistent: persistent,
+                      controller: controller,
+                      focusNode: focusNode,
+                      hintText: hintText,
+                      maxSearchWidth: searchWidth,
+                      onChanged: onChanged,
+                      onSubmitted: onSubmitted,
+                      onSearchActivated: onSearchActivated,
+                    ),
+                    SizedBox(width: insets.end),
+                  ],
+                ),
+              ),
+              if (showCenteredTitle)
+                IgnorePointer(
+                  child: Center(
+                    child: SizedBox(
+                      key: const ValueKey('cupertino-search-title'),
+                      width: preferredTitleExtent,
+                      child: DefaultTextStyle.merge(
+                        maxLines: 1,
+                        softWrap: false,
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.center,
+                        child: title,
+                      ),
                     ),
                   ),
                 ),
-              ),
-          ],
-        );
-      },
-    ),
-  );
+            ],
+          );
+        },
+      ),
+    );
+  }
 }
 
 class _CupertinoCommandRegion extends StatelessWidget {

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_toolbar_padding.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_toolbar_padding.dart
@@ -4,14 +4,28 @@ import 'package:flutter/widgets.dart';
 
 import '../breakpoints/breakpoints.dart';
 import '../breakpoints/window_size_class.dart';
+import '../window_control/toolbar_geometry.dart';
 
-const double _cupertinoToolbarEdgePadding = 16.0;
 const double _maximumPhoneSafeAreaBonus = 16.0;
 
 /// Keeps the standard Cupertino edge margin while adding only a small
 /// hardware-aware cushion on phone-shaped windows.
 abstract final class CupertinoToolbarPadding {
-  static EdgeInsets resolve(BuildContext context) {
+  static EdgeInsets resolve(
+    BuildContext context, {
+    EdgeInsetsDirectional? contentPadding,
+    EdgeInsetsDirectional edgePadding = cupertinoWindowControlEdgePadding,
+  }) => resolveDirectional(
+    context,
+    contentPadding: contentPadding,
+    edgePadding: edgePadding,
+  ).resolve(Directionality.of(context));
+
+  static EdgeInsetsDirectional resolveDirectional(
+    BuildContext context, {
+    EdgeInsetsDirectional? contentPadding,
+    EdgeInsetsDirectional edgePadding = cupertinoWindowControlEdgePadding,
+  }) {
     final mediaQuery = MediaQuery.of(context);
     final breakpoints = Breakpoints.of(context);
     final widthClass = breakpoints.widthClass(mediaQuery.size.width);
@@ -20,15 +34,25 @@ abstract final class CupertinoToolbarPadding {
         widthClass == WindowSizeClass.compact ||
         heightClass == WindowSizeClass.compact;
     final safePadding = mediaQuery.padding;
-    final leftBonus = isPhoneFormFactor
-        ? math.min(safePadding.left, _maximumPhoneSafeAreaBonus)
+    final textDirection = Directionality.of(context);
+    final safeStart = textDirection == TextDirection.ltr
+        ? safePadding.left
+        : safePadding.right;
+    final safeEnd = textDirection == TextDirection.ltr
+        ? safePadding.right
+        : safePadding.left;
+    final startBonus = contentPadding == null && isPhoneFormFactor
+        ? math.min(safeStart, _maximumPhoneSafeAreaBonus)
         : 0.0;
-    final rightBonus = isPhoneFormFactor
-        ? math.min(safePadding.right, _maximumPhoneSafeAreaBonus)
+    final endBonus = contentPadding == null && isPhoneFormFactor
+        ? math.min(safeEnd, _maximumPhoneSafeAreaBonus)
         : 0.0;
-    return EdgeInsets.only(
-      left: _cupertinoToolbarEdgePadding + leftBonus,
-      right: _cupertinoToolbarEdgePadding + rightBonus,
+    final effectiveContentPadding = contentPadding ?? edgePadding;
+    return EdgeInsetsDirectional.fromSTEB(
+      effectiveContentPadding.start + startBonus,
+      effectiveContentPadding.top,
+      effectiveContentPadding.end + endBonus,
+      effectiveContentPadding.bottom,
     );
   }
 }

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_sliver_search_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_sliver_search_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../breakpoints/window_size_class.dart';
+import '../window_control/material_app_bar.dart';
 import 'material_expandable_search_bar.dart';
 
 const List<Widget> _kDefaultActions = <Widget>[];
@@ -83,7 +84,7 @@ class MaterialSliverSearchBar extends StatelessWidget {
 
     // TODO(adaptive-actions): Migrate the Material and Cupertino action
     // regions after adaptive_actions is published as a stable package.
-    return SliverAppBar(
+    return WindowControlSliverAppBar(
       key: const ValueKey('material-sliver-search-bar'),
       floating: true,
       snap: true,

--- a/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
@@ -10,6 +10,86 @@ import '../window_control/window_control_layout.dart';
 import 'adaptive_nav_scope.dart';
 import 'adaptive_nav_visibility.dart';
 
+/// Extended navigation rail sizing configuration.
+///
+/// [collapsed] controls the icon-only rail. The extended interval grows from
+/// [minimum] to [maximum] as the window moves from [rampStart] to [rampEnd].
+/// The default constructor expresses a fixed logical-pixel target inside that
+/// interval. Use [fromRatio] to express a relative position instead, where 0
+/// selects the minimum and 1 the current upper bound.
+class NavigationRailExtent {
+  const NavigationRailExtent(
+    double width, {
+    this.collapsed = 72.0,
+    this.minimum = 180.0,
+    this.maximum = 360.0,
+    this.rampStart = 600.0,
+    this.rampEnd = 1600.0,
+  }) : assert(width >= 0),
+       assert(collapsed > 0),
+       assert(minimum > 0),
+       assert(minimum >= collapsed),
+       assert(maximum >= minimum),
+       assert(rampEnd > rampStart),
+       _width = width,
+       _ratio = null;
+
+  const NavigationRailExtent.fromRatio(
+    double ratio, {
+    this.collapsed = 72.0,
+    this.minimum = 180.0,
+    this.maximum = 360.0,
+    this.rampStart = 600.0,
+    this.rampEnd = 1600.0,
+  }) : assert(ratio >= 0 && ratio <= 1),
+       assert(collapsed > 0),
+       assert(minimum > 0),
+       assert(minimum >= collapsed),
+       assert(maximum >= minimum),
+       assert(rampEnd > rampStart),
+       _width = null,
+       _ratio = ratio;
+
+  /// Width of the collapsed icon rail.
+  final double collapsed;
+
+  /// Smallest extended rail width.
+  final double minimum;
+
+  /// Largest extended rail width available to manual resizing.
+  final double maximum;
+
+  /// Window width where the available upper bound equals [minimum].
+  final double rampStart;
+
+  /// Window width where the available upper bound reaches [maximum].
+  final double rampEnd;
+
+  final double? _width;
+  final double? _ratio;
+
+  /// Largest rail width available at [windowWidth].
+  double upperBoundAt(double windowWidth) {
+    final t = ((windowWidth - rampStart) / (rampEnd - rampStart)).clamp(
+      0.0,
+      1.0,
+    );
+    return minimum + (maximum - minimum) * t;
+  }
+
+  /// Resolves the automatic rail width at [windowWidth].
+  double resolve(double windowWidth) {
+    final upperBound = upperBoundAt(windowWidth);
+    final width = _width;
+    if (width != null) return width.clamp(minimum, upperBound);
+    return minimum + (upperBound - minimum) * _ratio!;
+  }
+
+  /// Clamps a manually requested [width] to the interval at [windowWidth].
+  double clamp(double width, {required double windowWidth}) =>
+      width.clamp(minimum, upperBoundAt(windowWidth));
+}
+
 /// Adaptive navigation chrome around [child].
 ///
 /// The form follows the window's width and height classes ([WindowSize.of]):
@@ -20,13 +100,12 @@ import 'adaptive_nav_visibility.dart';
 /// The chrome animates when the form changes; the content area always fills
 /// the remaining width without a maximum-width cap.
 ///
-/// The extended rail width follows the window width between the M3 drawer
-/// bounds — the interval's upper bound grows up to the M3 recommended width
-/// at the extra-large boundary, and the default sits inside the interval
-/// rather than at an extreme. Users can drag the rail's trailing edge within
-/// the current interval; a manual value stays in memory and hands off
-/// continuously to the automatic width when the window shrinks (the system
-/// never rewrites it, so it resumes when the window grows back).
+/// The extended rail uses a compact fixed target, clamped to the width
+/// currently available in the resizable interval. Users can drag the rail's
+/// trailing edge farther, up to the M3 drawer width, within that interval; a
+/// manual value stays in memory and hands off continuously to the automatic
+/// width when the window shrinks (the system never rewrites it, so it resumes
+/// when the window grows back).
 ///
 /// In the compact form, bar visibility is derived from
 /// [compactRouteVisible] and the page's current scroll wish
@@ -41,6 +120,7 @@ class AdaptiveNavigationShell extends StatefulWidget {
     required this.destinations,
     required this.onDestinationSelected,
     this.compactRouteVisible = true,
+    this.railExtent = const NavigationRailExtent(224.0),
   });
 
   /// Content displayed beside or underneath the navigation chrome.
@@ -63,6 +143,13 @@ class AdaptiveNavigationShell extends StatefulWidget {
   /// visibility also respects the page's current scroll wish. Ignored in
   /// non-compact forms, where navigation is always visible.
   final bool compactRouteVisible;
+
+  /// Extended-rail sizing configuration.
+  ///
+  /// Controls the automatic width, resizable interval, and its window-width
+  /// growth. This is a component-level layout input only and defaults to a
+  /// compact 224dp target inside the 180–360dp interval.
+  final NavigationRailExtent railExtent;
 
   @override
   State<AdaptiveNavigationShell> createState() =>
@@ -221,6 +308,7 @@ class _AdaptiveNavigationShellState extends State<AdaptiveNavigationShell> {
           selectedIndex: widget.selectedIndex,
           destinations: widget.destinations,
           onDestinationSelected: _onDestinationSelected,
+          railExtent: widget.railExtent,
           child: widget.child,
         ),
         // Owning the bar as Scaffold chrome makes this the root Scaffold
@@ -310,6 +398,7 @@ class _NavigationShellBody extends StatelessWidget {
     required this.selectedIndex,
     required this.destinations,
     required this.onDestinationSelected,
+    required this.railExtent,
     required this.child,
   });
 
@@ -319,6 +408,7 @@ class _NavigationShellBody extends StatelessWidget {
   final int selectedIndex;
   final List<NavigationDestination> destinations;
   final ValueChanged<int> onDestinationSelected;
+  final NavigationRailExtent railExtent;
   final Widget child;
 
   @override
@@ -342,6 +432,7 @@ class _NavigationShellBody extends StatelessWidget {
               selectedIndex: selectedIndex,
               destinations: destinations,
               onDestinationSelected: onDestinationSelected,
+              railExtent: railExtent,
             ),
             Expanded(child: child),
           ],
@@ -394,12 +485,14 @@ class _NavigationRailRegion extends StatefulWidget {
     required this.selectedIndex,
     required this.destinations,
     required this.onDestinationSelected,
+    required this.railExtent,
   });
 
   final _ShellForm form;
   final int selectedIndex;
   final List<NavigationDestination> destinations;
   final ValueChanged<int> onDestinationSelected;
+  final NavigationRailExtent railExtent;
 
   @override
   State<_NavigationRailRegion> createState() => _NavigationRailRegionState();
@@ -407,22 +500,6 @@ class _NavigationRailRegion extends StatefulWidget {
 
 class _NavigationRailRegionState extends State<_NavigationRailRegion> {
   static const double _minimumRailButtonExtent = 44.0;
-
-  /// Extended rail width bounds.
-  static const double _railMinWidth = 180.0;
-  static const double _railMaxWidth = 360.0;
-
-  /// Collapsed rail width (icon rail).
-  static const double _railCollapsedWidth = 72.0;
-
-  /// Where the auto width sits inside the effective interval (interior, not
-  /// an extreme).
-  static const double _railAutoRatio = 0.7;
-
-  /// Window widths between which the effective interval grows from
-  /// [_railMinWidth] to [_railMaxWidth].
-  static const double _railWidthRampStart = 600.0;
-  static const double _railWidthRampEnd = 1600.0;
 
   /// Whether the rail is extended.
   ///
@@ -444,7 +521,7 @@ class _NavigationRailRegionState extends State<_NavigationRailRegion> {
 
   /// Accumulated rail width during a drag; assigned to [_manualWidth] on
   /// every update.
-  double _dragCurrentWidth = _railMinWidth;
+  double _dragCurrentWidth = 0.0;
 
   /// Whether a rail resize drag is in progress (disables width animation).
   bool _dragging = false;
@@ -462,22 +539,9 @@ class _NavigationRailRegionState extends State<_NavigationRailRegion> {
     _extended = widget.form == _ShellForm.railExtended;
   }
 
-  /// Drag upper bound at [windowWidth]: the interval grows from
-  /// [_railMinWidth] at the medium boundary to the full [_railMaxWidth] at
-  /// the extra-large boundary.
-  double _railUpperBound(double windowWidth) {
-    final t =
-        ((windowWidth - _railWidthRampStart) /
-                (_railWidthRampEnd - _railWidthRampStart))
-            .clamp(0.0, 1.0);
-    return _railMinWidth + (_railMaxWidth - _railMinWidth) * t;
-  }
-
-  /// Auto rail width at [windowWidth]: interior of the effective interval,
-  /// reaching its maximum at the extra-large boundary.
+  /// Auto rail width at [windowWidth], resolved by the configured extent.
   double _railAutoWidth(double windowWidth) =>
-      _railMinWidth +
-      (_railUpperBound(windowWidth) - _railMinWidth) * _railAutoRatio;
+      widget.railExtent.resolve(windowWidth);
 
   /// Effective extended rail width at [windowWidth].
   ///
@@ -490,7 +554,7 @@ class _NavigationRailRegionState extends State<_NavigationRailRegion> {
     final manual = _manualWidth;
     if (manual == null) return _railAutoWidth(windowWidth);
     final bound = _manualAboveAuto
-        ? _railUpperBound(windowWidth)
+        ? widget.railExtent.upperBoundAt(windowWidth)
         : _railAutoWidth(windowWidth);
     return min(manual, bound);
   }
@@ -532,7 +596,7 @@ class _NavigationRailRegionState extends State<_NavigationRailRegion> {
   Widget _buildRail(BuildContext context, double windowWidth) {
     final width = _extended
         ? _effectiveRailWidth(windowWidth)
-        : _railCollapsedWidth;
+        : widget.railExtent.collapsed;
     final horizontalAvoidance =
         AdaptiveWindowControlLayoutScope.railHorizontalAvoidanceOf(context);
     final verticalAvoidance =
@@ -555,7 +619,7 @@ class _NavigationRailRegionState extends State<_NavigationRailRegion> {
           selectedIndex: widget.selectedIndex,
           onDestinationSelected: widget.onDestinationSelected,
           extended: _extended,
-          minWidth: _railCollapsedWidth,
+          minWidth: widget.railExtent.collapsed,
           minExtendedWidth: width,
           leading: SizedBox(
             width: width,
@@ -607,9 +671,9 @@ class _NavigationRailRegionState extends State<_NavigationRailRegion> {
         },
         onHorizontalDragUpdate: (details) {
           setState(() {
-            _dragCurrentWidth = (_dragCurrentWidth + details.delta.dx).clamp(
-              _railMinWidth,
-              _railUpperBound(windowWidth),
+            _dragCurrentWidth = widget.railExtent.clamp(
+              _dragCurrentWidth + details.delta.dx,
+              windowWidth: windowWidth,
             );
             _manualWidth = _dragCurrentWidth;
             _manualAboveAuto = _dragCurrentWidth > _railAutoWidth(windowWidth);

--- a/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import '../adaptive/adaptive_navigation_bar.dart';
 import '../adaptive/adaptive_navigation_rail.dart';
 import '../breakpoints/window_size_class.dart';
+import '../window_control/window_control_layout.dart';
 import 'adaptive_nav_scope.dart';
 import 'adaptive_nav_visibility.dart';
 
@@ -180,6 +181,9 @@ class _AdaptiveNavigationShellState extends State<AdaptiveNavigationShell> {
   @override
   Widget build(BuildContext context) {
     final compact = _form == _ShellForm.bar;
+    final windowControlLayout = AdaptiveWindowControlLayoutScope.maybeOf(
+      context,
+    );
     final padding = MediaQuery.paddingOf(context);
     final viewPadding = MediaQuery.viewPaddingOf(context);
     const barHeight = _narrowNavHeight;
@@ -196,7 +200,7 @@ class _AdaptiveNavigationShellState extends State<AdaptiveNavigationShell> {
       onDestinationSelected: _onDestinationSelected,
     );
 
-    return AdaptiveNavScope(
+    final shell = AdaptiveNavScope(
       visible: compact ? _navVisibility : null,
       scrollWish: compact ? _scrollWish : null,
       contextualChrome: _contextualChrome,
@@ -219,9 +223,9 @@ class _AdaptiveNavigationShellState extends State<AdaptiveNavigationShell> {
           onDestinationSelected: _onDestinationSelected,
           child: widget.child,
         ),
-        // Owning the bar as Scaffold chrome makes this the root Scaffold for
-        // the ambient ScaffoldMessenger. SnackBars are therefore laid out
-        // above the compact bar instead of being painted below its overlay.
+        // Owning the bar as Scaffold chrome makes this the root Scaffold
+        // for the ambient ScaffoldMessenger. SnackBars are therefore laid
+        // out above the compact bar instead of below its overlay.
         bottomNavigationBar: AnimatedSwitcher(
           duration: _animationDuration,
           switchInCurve: Curves.easeOut,
@@ -241,6 +245,53 @@ class _AdaptiveNavigationShellState extends State<AdaptiveNavigationShell> {
               : const SizedBox.shrink(key: ValueKey('bottom-bar-hidden')),
         ),
       ),
+    );
+    if (windowControlLayout != null) {
+      return _WindowControlLayoutOwner(
+        horizontalAvoidance: windowControlLayout.horizontalAvoidance,
+        verticalAvoidance: windowControlLayout.verticalAvoidance,
+        railOwnsAvoidance: !compact,
+        child: shell,
+      );
+    }
+    return AdaptiveWindowControlLayout(
+      child: Builder(
+        builder: (context) {
+          final layout = AdaptiveWindowControlLayoutScope.maybeOf(context)!;
+          return _WindowControlLayoutOwner(
+            horizontalAvoidance: layout.horizontalAvoidance,
+            verticalAvoidance: layout.verticalAvoidance,
+            railOwnsAvoidance: !compact,
+            child: shell,
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _WindowControlLayoutOwner extends StatelessWidget {
+  const _WindowControlLayoutOwner({
+    required this.horizontalAvoidance,
+    required this.verticalAvoidance,
+    required this.railOwnsAvoidance,
+    required this.child,
+  });
+
+  final EdgeInsetsDirectional horizontalAvoidance;
+  final EdgeInsetsDirectional verticalAvoidance;
+  final bool railOwnsAvoidance;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveWindowControlLayoutScope(
+      horizontalAvoidance: horizontalAvoidance,
+      verticalAvoidance: verticalAvoidance,
+      owner: railOwnsAvoidance
+          ? WindowControlLayoutOwner.rail
+          : WindowControlLayoutOwner.appBar,
+      child: child,
     );
   }
 }
@@ -355,6 +406,8 @@ class _NavigationRailRegion extends StatefulWidget {
 }
 
 class _NavigationRailRegionState extends State<_NavigationRailRegion> {
+  static const double _minimumRailButtonExtent = 44.0;
+
   /// Extended rail width bounds.
   static const double _railMinWidth = 180.0;
   static const double _railMaxWidth = 360.0;
@@ -461,7 +514,7 @@ class _NavigationRailRegionState extends State<_NavigationRailRegion> {
         _ShellForm.railCollapsed || _ShellForm.railExtended => Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            _buildRail(windowWidth),
+            _buildRail(context, windowWidth),
             // Divider between the rail and the branch content, matching
             // the NavigationDrawer sample layout.
             const VerticalDivider(width: 1),
@@ -476,10 +529,24 @@ class _NavigationRailRegionState extends State<_NavigationRailRegion> {
   /// The extended width follows the auto value unless a manual value
   /// applies (inside the current interval); collapsed keeps the fixed
   /// icon-rail width.
-  Widget _buildRail(double windowWidth) {
+  Widget _buildRail(BuildContext context, double windowWidth) {
     final width = _extended
         ? _effectiveRailWidth(windowWidth)
         : _railCollapsedWidth;
+    final horizontalAvoidance =
+        AdaptiveWindowControlLayoutScope.railHorizontalAvoidanceOf(context);
+    final verticalAvoidance =
+        AdaptiveWindowControlLayoutScope.railVerticalAvoidanceOf(context);
+    final safeWidth =
+        width - horizontalAvoidance.start - horizontalAvoidance.end;
+    final useVerticalFallback =
+        !_extended && safeWidth < _minimumRailButtonExtent;
+    final leadingHorizontalAvoidance = useVerticalFallback
+        ? EdgeInsetsDirectional.zero
+        : horizontalAvoidance;
+    final leadingTopAvoidance = useVerticalFallback
+        ? verticalAvoidance.top
+        : 0.0;
 
     return Stack(
       children: [
@@ -490,12 +557,26 @@ class _NavigationRailRegionState extends State<_NavigationRailRegion> {
           extended: _extended,
           minWidth: _railCollapsedWidth,
           minExtendedWidth: width,
-          leading: IconButton(
-            tooltip: _extended
-                ? 'Collapse navigation rail'
-                : 'Expand navigation rail',
-            icon: Icon(_extended ? Icons.menu_open : Icons.menu),
-            onPressed: () => setState(() => _extended = !_extended),
+          leading: SizedBox(
+            width: width,
+            child: Padding(
+              key: const ValueKey('rail-leading-safe-span'),
+              padding: EdgeInsetsDirectional.only(
+                start: leadingHorizontalAvoidance.start,
+                top: leadingTopAvoidance,
+                end: leadingHorizontalAvoidance.end,
+              ),
+              child: Align(
+                child: IconButton(
+                  key: const ValueKey('rail-toggle-button'),
+                  tooltip: _extended
+                      ? 'Collapse navigation rail'
+                      : 'Expand navigation rail',
+                  icon: Icon(_extended ? Icons.menu_open : Icons.menu),
+                  onPressed: () => setState(() => _extended = !_extended),
+                ),
+              ),
+            ),
           ),
           destinations: widget.destinations,
         ),

--- a/packages/mhabit_adaptive_ui/lib/src/window_control/cupertino_navigation_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/window_control/cupertino_navigation_bar.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/cupertino.dart';
+
+import 'toolbar_geometry.dart';
+
+/// A [CupertinoNavigationBar] that pads only its leading and trailing controls.
+///
+/// The middle keeps Flutter's full-width centering and native collision clamp.
+class WindowControlCupertinoNavigationBar extends StatelessWidget
+    implements ObstructingPreferredSizeWidget {
+  const WindowControlCupertinoNavigationBar({
+    super.key,
+    this.leading,
+    this.automaticallyImplyLeading = true,
+    this.automaticallyImplyMiddle = true,
+    this.previousPageTitle,
+    this.middle,
+    this.trailing,
+    this.border,
+    this.backgroundColor,
+    this.automaticBackgroundVisibility = true,
+    this.enableBackgroundFilterBlur = true,
+    this.brightness,
+    this.padding,
+    this.transitionBetweenRoutes = true,
+    this.bottom,
+    this.windowControlAvoidance,
+    this.windowControlEdgePadding = cupertinoWindowControlEdgePadding,
+  });
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.leading}
+  final Widget? leading;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.automaticallyImplyLeading}
+  final bool automaticallyImplyLeading;
+
+  /// See [CupertinoNavigationBar.automaticallyImplyMiddle].
+  final bool automaticallyImplyMiddle;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.previousPageTitle}
+  final String? previousPageTitle;
+
+  /// See [CupertinoNavigationBar.middle].
+  final Widget? middle;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.trailing}
+  final Widget? trailing;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.border}
+  final Border? border;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.backgroundColor}
+  final Color? backgroundColor;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.automaticBackgroundVisibility}
+  final bool automaticBackgroundVisibility;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.enableBackgroundFilterBlur}
+  final bool enableBackgroundFilterBlur;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.brightness}
+  final Brightness? brightness;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.padding}
+  final EdgeInsetsDirectional? padding;
+
+  /// See [CupertinoNavigationBar.transitionBetweenRoutes].
+  final bool transitionBetweenRoutes;
+
+  /// See [CupertinoNavigationBar.bottom].
+  final PreferredSizeWidget? bottom;
+
+  /// {@macro mhabit.windowControlAvoidance}
+  final EdgeInsetsDirectional? windowControlAvoidance;
+
+  /// {@macro mhabit.windowControlEdgePadding}
+  final EdgeInsetsDirectional windowControlEdgePadding;
+
+  CupertinoNavigationBar _createNavigationBar({
+    EdgeInsetsDirectional? effectivePadding,
+  }) => CupertinoNavigationBar(
+    leading: leading,
+    automaticallyImplyLeading: automaticallyImplyLeading,
+    automaticallyImplyMiddle: automaticallyImplyMiddle,
+    previousPageTitle: previousPageTitle,
+    middle: middle,
+    trailing: trailing,
+    border: border,
+    backgroundColor: backgroundColor,
+    automaticBackgroundVisibility: automaticBackgroundVisibility,
+    enableBackgroundFilterBlur: enableBackgroundFilterBlur,
+    brightness: brightness,
+    padding: effectivePadding,
+    transitionBetweenRoutes: transitionBetweenRoutes,
+    bottom: bottom,
+  );
+
+  // Delegate framework-owned geometry and dynamic-color resolution instead of
+  // copying Flutter's private navigation-bar behavior into this wrapper.
+  @override
+  Size get preferredSize =>
+      _createNavigationBar(effectivePadding: padding).preferredSize;
+
+  @override
+  bool shouldFullyObstruct(BuildContext context) => _createNavigationBar(
+    effectivePadding: padding,
+  ).shouldFullyObstruct(context);
+
+  @override
+  Widget build(BuildContext context) => _createNavigationBar(
+    effectivePadding: _resolveCupertinoPadding(
+      context,
+      padding: padding,
+      avoidance: windowControlAvoidance,
+      edgePadding: windowControlEdgePadding,
+    ),
+  );
+}
+
+/// A [CupertinoSliverNavigationBar] with window-control-aware toolbar padding.
+///
+/// Large-title geometry remains owned by Flutter; avoidance applies to the
+/// compact toolbar controls only.
+class WindowControlCupertinoSliverNavigationBar extends StatelessWidget {
+  const WindowControlCupertinoSliverNavigationBar({
+    super.key,
+    this.largeTitle,
+    this.leading,
+    this.automaticallyImplyLeading = true,
+    this.automaticallyImplyTitle = true,
+    this.previousPageTitle,
+    this.middle,
+    this.trailing,
+    this.border,
+    this.backgroundColor,
+    this.automaticBackgroundVisibility = true,
+    this.enableBackgroundFilterBlur = true,
+    this.brightness,
+    this.padding,
+    this.stretch = false,
+    this.bottom,
+    this.windowControlAvoidance,
+    this.windowControlEdgePadding = cupertinoWindowControlEdgePadding,
+  });
+
+  /// See [CupertinoSliverNavigationBar.largeTitle].
+  final Widget? largeTitle;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.leading}
+  final Widget? leading;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.automaticallyImplyLeading}
+  final bool automaticallyImplyLeading;
+
+  /// See [CupertinoSliverNavigationBar.automaticallyImplyTitle].
+  final bool automaticallyImplyTitle;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.previousPageTitle}
+  final String? previousPageTitle;
+
+  /// See [CupertinoSliverNavigationBar.middle].
+  final Widget? middle;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.trailing}
+  final Widget? trailing;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.border}
+  final Border? border;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.backgroundColor}
+  final Color? backgroundColor;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.automaticBackgroundVisibility}
+  final bool automaticBackgroundVisibility;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.enableBackgroundFilterBlur}
+  final bool enableBackgroundFilterBlur;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.brightness}
+  final Brightness? brightness;
+
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.padding}
+  final EdgeInsetsDirectional? padding;
+
+  /// See [CupertinoSliverNavigationBar.stretch].
+  final bool stretch;
+
+  /// See [CupertinoSliverNavigationBar.bottom].
+  final PreferredSizeWidget? bottom;
+
+  /// {@macro mhabit.windowControlAvoidance}
+  final EdgeInsetsDirectional? windowControlAvoidance;
+
+  /// {@macro mhabit.windowControlEdgePadding}
+  final EdgeInsetsDirectional windowControlEdgePadding;
+
+  @override
+  Widget build(BuildContext context) => CupertinoSliverNavigationBar(
+    largeTitle: largeTitle,
+    leading: leading,
+    automaticallyImplyLeading: automaticallyImplyLeading,
+    automaticallyImplyTitle: automaticallyImplyTitle,
+    previousPageTitle: previousPageTitle,
+    middle: middle,
+    trailing: trailing,
+    border: border,
+    backgroundColor: backgroundColor,
+    automaticBackgroundVisibility: automaticBackgroundVisibility,
+    enableBackgroundFilterBlur: enableBackgroundFilterBlur,
+    brightness: brightness,
+    padding: _resolveCupertinoPadding(
+      context,
+      padding: padding,
+      avoidance: windowControlAvoidance,
+      edgePadding: windowControlEdgePadding,
+    ),
+    stretch: stretch,
+    bottom: bottom,
+  );
+}
+
+EdgeInsetsDirectional _resolveCupertinoPadding(
+  BuildContext context, {
+  required EdgeInsetsDirectional? padding,
+  required EdgeInsetsDirectional? avoidance,
+  required EdgeInsetsDirectional edgePadding,
+}) {
+  final geometry = WindowControlToolbarGeometry.resolve(
+    context,
+    avoidance: avoidance,
+    edgePadding: padding ?? edgePadding,
+  );
+  return geometry.cupertinoInsets;
+}

--- a/packages/mhabit_adaptive_ui/lib/src/window_control/material_app_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/window_control/material_app_bar.dart
@@ -1,0 +1,574 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'toolbar_geometry.dart';
+
+/// A Material [AppBar] whose leading and action slots avoid window controls.
+///
+/// The title, background, flexible space, and bottom keep the full app-bar
+/// width. A null [windowControlAvoidance] inherits the adaptive layout scope;
+/// an explicit zero disables avoidance.
+class WindowControlAppBar extends StatelessWidget
+    implements PreferredSizeWidget {
+  const WindowControlAppBar({
+    super.key,
+    this.leading,
+    this.automaticallyImplyLeading = true,
+    this.title,
+    this.actions,
+    this.automaticallyImplyActions = true,
+    this.flexibleSpace,
+    this.bottom,
+    this.elevation,
+    this.scrolledUnderElevation,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.shape,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.iconTheme,
+    this.actionsIconTheme,
+    this.primary = true,
+    this.centerTitle,
+    this.titleSpacing,
+    this.toolbarHeight,
+    this.leadingWidth,
+    this.systemOverlayStyle,
+    this.forceMaterialTransparency = false,
+    this.actionsPadding,
+    this.windowControlAvoidance,
+    this.windowControlEdgePadding = materialWindowControlEdgePadding,
+  });
+
+  /// {@macro flutter.material.appbar.leading}
+  final Widget? leading;
+
+  /// {@macro flutter.material.appbar.automaticallyImplyLeading}
+  final bool automaticallyImplyLeading;
+
+  /// {@macro flutter.material.appbar.title}
+  final Widget? title;
+
+  /// {@macro flutter.material.appbar.actions}
+  final List<Widget>? actions;
+
+  /// {@macro flutter.material.appbar.automaticallyImplyActions}
+  final bool automaticallyImplyActions;
+
+  /// {@macro flutter.material.appbar.flexibleSpace}
+  final Widget? flexibleSpace;
+
+  /// {@macro flutter.material.appbar.bottom}
+  final PreferredSizeWidget? bottom;
+
+  /// {@macro flutter.material.appbar.elevation}
+  final double? elevation;
+
+  /// {@macro flutter.material.appbar.scrolledUnderElevation}
+  final double? scrolledUnderElevation;
+
+  /// {@macro flutter.material.appbar.shadowColor}
+  final Color? shadowColor;
+
+  /// {@macro flutter.material.appbar.surfaceTintColor}
+  final Color? surfaceTintColor;
+
+  /// {@macro flutter.material.appbar.shape}
+  final ShapeBorder? shape;
+
+  /// {@macro flutter.material.appbar.backgroundColor}
+  final Color? backgroundColor;
+
+  /// {@macro flutter.material.appbar.foregroundColor}
+  final Color? foregroundColor;
+
+  /// {@macro flutter.material.appbar.iconTheme}
+  final IconThemeData? iconTheme;
+
+  /// {@macro flutter.material.appbar.actionsIconTheme}
+  final IconThemeData? actionsIconTheme;
+
+  /// {@macro flutter.material.appbar.primary}
+  final bool primary;
+
+  /// {@macro flutter.material.appbar.centerTitle}
+  final bool? centerTitle;
+
+  /// {@macro flutter.material.appbar.titleSpacing}
+  final double? titleSpacing;
+
+  /// {@macro flutter.material.appbar.toolbarHeight}
+  final double? toolbarHeight;
+
+  /// {@macro flutter.material.appbar.leadingWidth}
+  final double? leadingWidth;
+
+  /// {@macro flutter.material.appbar.systemOverlayStyle}
+  final SystemUiOverlayStyle? systemOverlayStyle;
+
+  /// {@macro flutter.material.appbar.forceMaterialTransparency}
+  final bool forceMaterialTransparency;
+
+  /// {@macro flutter.material.appbar.actionsPadding}
+  final EdgeInsetsGeometry? actionsPadding;
+
+  /// {@macro mhabit.windowControlAvoidance}
+  final EdgeInsetsDirectional? windowControlAvoidance;
+
+  /// {@macro mhabit.windowControlEdgePadding}
+  final EdgeInsetsDirectional windowControlEdgePadding;
+
+  @override
+  Size get preferredSize => Size.fromHeight(
+    (toolbarHeight ?? kToolbarHeight) + (bottom?.preferredSize.height ?? 0),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final slots = _resolveMaterialToolbarSlots(
+      context,
+      leading: leading,
+      automaticallyImplyLeading: automaticallyImplyLeading,
+      actions: actions,
+      automaticallyImplyActions: automaticallyImplyActions,
+      leadingWidth: leadingWidth,
+      avoidance: windowControlAvoidance,
+      edgePadding: windowControlEdgePadding,
+    );
+    return AppBar(
+      leading: slots.leading,
+      automaticallyImplyLeading: slots.automaticallyImplyLeading,
+      title: title,
+      actions: slots.actions,
+      automaticallyImplyActions: slots.automaticallyImplyActions,
+      flexibleSpace: flexibleSpace,
+      bottom: bottom,
+      elevation: elevation,
+      scrolledUnderElevation: scrolledUnderElevation,
+      shadowColor: shadowColor,
+      surfaceTintColor: surfaceTintColor,
+      shape: shape,
+      backgroundColor: backgroundColor,
+      foregroundColor: foregroundColor,
+      iconTheme: iconTheme,
+      actionsIconTheme: actionsIconTheme,
+      primary: primary,
+      centerTitle: centerTitle,
+      titleSpacing: titleSpacing,
+      toolbarHeight: toolbarHeight,
+      leadingWidth: slots.leadingWidth,
+      systemOverlayStyle: systemOverlayStyle,
+      forceMaterialTransparency: forceMaterialTransparency,
+      actionsPadding: actionsPadding,
+    );
+  }
+}
+
+enum _WindowControlSliverAppBarVariant { small, large }
+
+/// A [SliverAppBar] counterpart to [WindowControlAppBar].
+///
+/// The default constructor preserves the small app-bar behavior and [large]
+/// delegates expanded-title layout to [SliverAppBar.large].
+class WindowControlSliverAppBar extends StatelessWidget {
+  const WindowControlSliverAppBar({
+    super.key,
+    this.leading,
+    this.automaticallyImplyLeading = true,
+    this.title,
+    this.actions,
+    this.automaticallyImplyActions = true,
+    this.flexibleSpace,
+    this.bottom,
+    this.elevation,
+    this.scrolledUnderElevation,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.forceElevated = false,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.iconTheme,
+    this.actionsIconTheme,
+    this.primary = true,
+    this.centerTitle,
+    this.titleSpacing,
+    this.collapsedHeight,
+    this.expandedHeight,
+    this.floating = false,
+    this.pinned = false,
+    this.snap = false,
+    this.stretch = false,
+    this.stretchTriggerOffset = 100,
+    this.onStretchTrigger,
+    this.shape,
+    this.toolbarHeight = kToolbarHeight,
+    this.leadingWidth,
+    this.systemOverlayStyle,
+    this.forceMaterialTransparency = false,
+    this.actionsPadding,
+    this.windowControlAvoidance,
+    this.windowControlEdgePadding = materialWindowControlEdgePadding,
+  }) : _variant = _WindowControlSliverAppBarVariant.small;
+
+  const WindowControlSliverAppBar.large({
+    super.key,
+    this.leading,
+    this.automaticallyImplyLeading = true,
+    this.title,
+    this.actions,
+    this.automaticallyImplyActions = true,
+    this.flexibleSpace,
+    this.bottom,
+    this.elevation,
+    this.scrolledUnderElevation,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.forceElevated = false,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.iconTheme,
+    this.actionsIconTheme,
+    this.primary = true,
+    this.centerTitle,
+    this.titleSpacing,
+    this.collapsedHeight,
+    this.expandedHeight,
+    this.floating = false,
+    this.pinned = true,
+    this.snap = false,
+    this.stretch = false,
+    this.stretchTriggerOffset = 100,
+    this.onStretchTrigger,
+    this.shape,
+    this.toolbarHeight,
+    this.leadingWidth,
+    this.systemOverlayStyle,
+    this.forceMaterialTransparency = false,
+    this.actionsPadding,
+    this.windowControlAvoidance,
+    this.windowControlEdgePadding = materialWindowControlEdgePadding,
+  }) : _variant = _WindowControlSliverAppBarVariant.large;
+
+  /// {@macro flutter.material.appbar.leading}
+  final Widget? leading;
+
+  /// {@macro flutter.material.appbar.automaticallyImplyLeading}
+  final bool automaticallyImplyLeading;
+
+  /// {@macro flutter.material.appbar.title}
+  final Widget? title;
+
+  /// {@macro flutter.material.appbar.actions}
+  final List<Widget>? actions;
+
+  /// {@macro flutter.material.appbar.automaticallyImplyActions}
+  final bool automaticallyImplyActions;
+
+  /// {@macro flutter.material.appbar.flexibleSpace}
+  final Widget? flexibleSpace;
+
+  /// {@macro flutter.material.appbar.bottom}
+  final PreferredSizeWidget? bottom;
+
+  /// {@macro flutter.material.appbar.elevation}
+  final double? elevation;
+
+  /// {@macro flutter.material.appbar.scrolledUnderElevation}
+  final double? scrolledUnderElevation;
+
+  /// {@macro flutter.material.appbar.shadowColor}
+  final Color? shadowColor;
+
+  /// {@macro flutter.material.appbar.surfaceTintColor}
+  final Color? surfaceTintColor;
+
+  /// See [SliverAppBar.forceElevated].
+  final bool forceElevated;
+
+  /// {@macro flutter.material.appbar.backgroundColor}
+  final Color? backgroundColor;
+
+  /// {@macro flutter.material.appbar.foregroundColor}
+  final Color? foregroundColor;
+
+  /// {@macro flutter.material.appbar.iconTheme}
+  final IconThemeData? iconTheme;
+
+  /// {@macro flutter.material.appbar.actionsIconTheme}
+  final IconThemeData? actionsIconTheme;
+
+  /// {@macro flutter.material.appbar.primary}
+  final bool primary;
+
+  /// {@macro flutter.material.appbar.centerTitle}
+  final bool? centerTitle;
+
+  /// {@macro flutter.material.appbar.titleSpacing}
+  final double? titleSpacing;
+
+  /// See [SliverAppBar.collapsedHeight].
+  final double? collapsedHeight;
+
+  /// See [SliverAppBar.expandedHeight].
+  final double? expandedHeight;
+
+  /// See [SliverAppBar.floating].
+  final bool floating;
+
+  /// See [SliverAppBar.pinned].
+  final bool pinned;
+
+  /// See [SliverAppBar.snap].
+  final bool snap;
+
+  /// See [SliverAppBar.stretch].
+  final bool stretch;
+
+  /// See [SliverAppBar.stretchTriggerOffset].
+  final double stretchTriggerOffset;
+
+  /// See [SliverAppBar.onStretchTrigger].
+  final AsyncCallback? onStretchTrigger;
+
+  /// {@macro flutter.material.appbar.shape}
+  final ShapeBorder? shape;
+
+  /// {@macro flutter.material.appbar.toolbarHeight}
+  final double? toolbarHeight;
+
+  /// {@macro flutter.material.appbar.leadingWidth}
+  final double? leadingWidth;
+
+  /// {@macro flutter.material.appbar.systemOverlayStyle}
+  final SystemUiOverlayStyle? systemOverlayStyle;
+
+  /// {@macro flutter.material.appbar.forceMaterialTransparency}
+  final bool forceMaterialTransparency;
+
+  /// {@macro flutter.material.appbar.actionsPadding}
+  final EdgeInsetsGeometry? actionsPadding;
+
+  /// {@macro mhabit.windowControlAvoidance}
+  final EdgeInsetsDirectional? windowControlAvoidance;
+
+  /// {@macro mhabit.windowControlEdgePadding}
+  final EdgeInsetsDirectional windowControlEdgePadding;
+  final _WindowControlSliverAppBarVariant _variant;
+
+  @override
+  Widget build(BuildContext context) {
+    final slots = _resolveMaterialToolbarSlots(
+      context,
+      leading: leading,
+      automaticallyImplyLeading: automaticallyImplyLeading,
+      actions: actions,
+      automaticallyImplyActions: automaticallyImplyActions,
+      leadingWidth: leadingWidth,
+      avoidance: windowControlAvoidance,
+      edgePadding: windowControlEdgePadding,
+    );
+    return switch (_variant) {
+      _WindowControlSliverAppBarVariant.small => SliverAppBar(
+        leading: slots.leading,
+        automaticallyImplyLeading: slots.automaticallyImplyLeading,
+        title: title,
+        actions: slots.actions,
+        automaticallyImplyActions: slots.automaticallyImplyActions,
+        flexibleSpace: flexibleSpace,
+        bottom: bottom,
+        elevation: elevation,
+        scrolledUnderElevation: scrolledUnderElevation,
+        shadowColor: shadowColor,
+        surfaceTintColor: surfaceTintColor,
+        forceElevated: forceElevated,
+        backgroundColor: backgroundColor,
+        foregroundColor: foregroundColor,
+        iconTheme: iconTheme,
+        actionsIconTheme: actionsIconTheme,
+        primary: primary,
+        centerTitle: centerTitle,
+        titleSpacing: titleSpacing,
+        collapsedHeight: collapsedHeight,
+        expandedHeight: expandedHeight,
+        floating: floating,
+        pinned: pinned,
+        snap: snap,
+        stretch: stretch,
+        stretchTriggerOffset: stretchTriggerOffset,
+        onStretchTrigger: onStretchTrigger,
+        shape: shape,
+        toolbarHeight: toolbarHeight ?? kToolbarHeight,
+        leadingWidth: slots.leadingWidth,
+        systemOverlayStyle: systemOverlayStyle,
+        forceMaterialTransparency: forceMaterialTransparency,
+        actionsPadding: actionsPadding,
+      ),
+      _WindowControlSliverAppBarVariant.large => _buildLarge(slots),
+    };
+  }
+
+  Widget _buildLarge(_MaterialToolbarSlots slots) {
+    final toolbarHeight = this.toolbarHeight;
+    if (toolbarHeight == null) {
+      return SliverAppBar.large(
+        leading: slots.leading,
+        automaticallyImplyLeading: slots.automaticallyImplyLeading,
+        title: title,
+        actions: slots.actions,
+        automaticallyImplyActions: slots.automaticallyImplyActions,
+        flexibleSpace: flexibleSpace,
+        bottom: bottom,
+        elevation: elevation,
+        scrolledUnderElevation: scrolledUnderElevation,
+        shadowColor: shadowColor,
+        surfaceTintColor: surfaceTintColor,
+        forceElevated: forceElevated,
+        backgroundColor: backgroundColor,
+        foregroundColor: foregroundColor,
+        iconTheme: iconTheme,
+        actionsIconTheme: actionsIconTheme,
+        primary: primary,
+        centerTitle: centerTitle,
+        titleSpacing: titleSpacing,
+        collapsedHeight: collapsedHeight,
+        expandedHeight: expandedHeight,
+        floating: floating,
+        pinned: pinned,
+        snap: snap,
+        stretch: stretch,
+        stretchTriggerOffset: stretchTriggerOffset,
+        onStretchTrigger: onStretchTrigger,
+        shape: shape,
+        leadingWidth: slots.leadingWidth,
+        systemOverlayStyle: systemOverlayStyle,
+        forceMaterialTransparency: forceMaterialTransparency,
+        actionsPadding: actionsPadding,
+      );
+    }
+    return SliverAppBar.large(
+      leading: slots.leading,
+      automaticallyImplyLeading: slots.automaticallyImplyLeading,
+      title: title,
+      actions: slots.actions,
+      automaticallyImplyActions: slots.automaticallyImplyActions,
+      flexibleSpace: flexibleSpace,
+      bottom: bottom,
+      elevation: elevation,
+      scrolledUnderElevation: scrolledUnderElevation,
+      shadowColor: shadowColor,
+      surfaceTintColor: surfaceTintColor,
+      forceElevated: forceElevated,
+      backgroundColor: backgroundColor,
+      foregroundColor: foregroundColor,
+      iconTheme: iconTheme,
+      actionsIconTheme: actionsIconTheme,
+      primary: primary,
+      centerTitle: centerTitle,
+      titleSpacing: titleSpacing,
+      collapsedHeight: collapsedHeight,
+      expandedHeight: expandedHeight,
+      floating: floating,
+      pinned: pinned,
+      snap: snap,
+      stretch: stretch,
+      stretchTriggerOffset: stretchTriggerOffset,
+      onStretchTrigger: onStretchTrigger,
+      shape: shape,
+      toolbarHeight: toolbarHeight,
+      leadingWidth: slots.leadingWidth,
+      systemOverlayStyle: systemOverlayStyle,
+      forceMaterialTransparency: forceMaterialTransparency,
+      actionsPadding: actionsPadding,
+    );
+  }
+}
+
+final class _MaterialToolbarSlots {
+  const _MaterialToolbarSlots({
+    required this.leading,
+    required this.automaticallyImplyLeading,
+    required this.leadingWidth,
+    required this.actions,
+    required this.automaticallyImplyActions,
+  });
+
+  final Widget? leading;
+  final bool automaticallyImplyLeading;
+  final double? leadingWidth;
+  final List<Widget>? actions;
+  final bool automaticallyImplyActions;
+}
+
+_MaterialToolbarSlots _resolveMaterialToolbarSlots(
+  BuildContext context, {
+  required Widget? leading,
+  required bool automaticallyImplyLeading,
+  required List<Widget>? actions,
+  required bool automaticallyImplyActions,
+  required double? leadingWidth,
+  required EdgeInsetsDirectional? avoidance,
+  required EdgeInsetsDirectional edgePadding,
+}) {
+  final geometry = WindowControlToolbarGeometry.resolve(
+    context,
+    avoidance: avoidance,
+    edgePadding: edgePadding,
+  );
+  final startInset = geometry.materialStartInset;
+  final endInset = geometry.materialEndInset;
+  final scaffold = startInset > 0 || endInset > 0
+      ? Scaffold.maybeOf(context)
+      : null;
+  var effectiveLeading = leading;
+  var effectiveAutomaticallyImplyLeading = automaticallyImplyLeading;
+  if (startInset > 0 && effectiveLeading == null && automaticallyImplyLeading) {
+    final route = ModalRoute.of(context);
+    if (scaffold?.hasDrawer ?? false) {
+      effectiveLeading = const DrawerButton();
+    } else if (route?.impliesAppBarDismissal ?? false) {
+      effectiveLeading = route is PageRoute<dynamic> && route.fullscreenDialog
+          ? const CloseButton()
+          : const BackButton();
+    }
+  }
+  if (startInset > 0) effectiveAutomaticallyImplyLeading = false;
+
+  List<Widget>? effectiveActions = actions;
+  var effectiveAutomaticallyImplyActions = automaticallyImplyActions;
+  if (endInset > 0 &&
+      (effectiveActions == null || effectiveActions.isEmpty) &&
+      automaticallyImplyActions &&
+      (scaffold?.hasEndDrawer ?? false)) {
+    effectiveActions = const [EndDrawerButton()];
+  }
+  if (endInset > 0) effectiveAutomaticallyImplyActions = false;
+
+  Widget? paddedLeading;
+  double? effectiveLeadingWidth = leadingWidth;
+  if (startInset > 0 && effectiveLeading != null) {
+    final baseLeadingWidth =
+        leadingWidth ?? AppBarTheme.of(context).leadingWidth ?? kToolbarHeight;
+    paddedLeading = Padding(
+      padding: EdgeInsetsDirectional.only(start: startInset),
+      child: effectiveLeading,
+    );
+    effectiveLeadingWidth = baseLeadingWidth + startInset;
+  } else if (startInset > 0) {
+    paddedLeading = const SizedBox.shrink();
+    effectiveLeadingWidth = startInset;
+  }
+
+  if (endInset > 0) {
+    effectiveActions = [...?effectiveActions, SizedBox(width: endInset)];
+    if (effectiveActions.isEmpty) effectiveActions = null;
+  }
+
+  return _MaterialToolbarSlots(
+    leading: startInset > 0 ? paddedLeading : leading,
+    automaticallyImplyLeading: effectiveAutomaticallyImplyLeading,
+    leadingWidth: effectiveLeadingWidth,
+    actions: effectiveActions,
+    automaticallyImplyActions: effectiveAutomaticallyImplyActions,
+  );
+}

--- a/packages/mhabit_adaptive_ui/lib/src/window_control/toolbar_geometry.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/window_control/toolbar_geometry.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/widgets.dart';
+
+import 'window_control_layout.dart';
+
+/// Default visual edge padding for Material window-control-aware app bars.
+const materialWindowControlEdgePadding = EdgeInsetsDirectional.fromSTEB(
+  12,
+  0,
+  16,
+  0,
+);
+
+/// Default visual edge padding for Cupertino window-control-aware app bars.
+const cupertinoWindowControlEdgePadding = EdgeInsetsDirectional.symmetric(
+  horizontal: 16,
+);
+
+/// Resolves the shared toolbar avoidance and platform visual baselines.
+final class WindowControlToolbarGeometry {
+  const WindowControlToolbarGeometry({
+    required this.avoidance,
+    required this.edgePadding,
+  });
+
+  /// {@template mhabit.windowControlAvoidance}
+  /// Additional directional space reserved for platform window controls.
+  ///
+  /// On wrapper widgets, a null value inherits
+  /// [AdaptiveWindowControlLayoutScope.appBarAvoidanceOf], while an explicit
+  /// [EdgeInsetsDirectional.zero] disables avoidance.
+  /// {@endtemplate}
+  final EdgeInsetsDirectional avoidance;
+
+  /// {@template mhabit.windowControlEdgePadding}
+  /// Visual spacing between window controls and the app-bar controls.
+  ///
+  /// This is added to active avoidance and does not replace it.
+  /// {@endtemplate}
+  final EdgeInsetsDirectional edgePadding;
+
+  /// Resolves [avoidance] from the explicit value or the adaptive scope.
+  static WindowControlToolbarGeometry resolve(
+    BuildContext context, {
+    EdgeInsetsDirectional? avoidance,
+    required EdgeInsetsDirectional edgePadding,
+  }) => WindowControlToolbarGeometry(
+    avoidance:
+        avoidance ??
+        AdaptiveWindowControlLayoutScope.appBarAvoidanceOf(context),
+    edgePadding: edgePadding,
+  );
+
+  /// Effective Material inset for the leading control slot.
+  double get materialStartInset =>
+      avoidance.start > 0 ? avoidance.start + edgePadding.start : 0;
+
+  /// Effective Material inset for the trailing actions slot.
+  double get materialEndInset =>
+      avoidance.end > 0 ? avoidance.end + edgePadding.end : 0;
+
+  /// Effective Cupertino content insets on all directional edges.
+  EdgeInsetsDirectional get cupertinoInsets => EdgeInsetsDirectional.fromSTEB(
+    edgePadding.start + avoidance.start,
+    edgePadding.top,
+    edgePadding.end + avoidance.end,
+    edgePadding.bottom,
+  );
+}

--- a/packages/mhabit_adaptive_ui/lib/src/window_control/window_control_layout.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/window_control/window_control_layout.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:ios_window_control_layout/ios_window_control_layout.dart';
+
+enum WindowControlLayoutOwner { appBar, rail }
+
+/// Queries iOS window-control layout once above an application's navigators.
+///
+/// Root routes and overlays default to app-bar ownership. A nested
+/// [AdaptiveNavigationShell] overrides that allocation when a rail is visible.
+class AdaptiveWindowControlLayout extends StatelessWidget {
+  const AdaptiveWindowControlLayout({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => IosWindowControlLayout(
+    child: Builder(
+      builder: (context) {
+        final layout = IosWindowControlLayout.of(context);
+        return AdaptiveWindowControlLayoutScope(
+          horizontalAvoidance: layout.horizontalAvoidance,
+          verticalAvoidance: layout.verticalAvoidance,
+          owner: WindowControlLayoutOwner.appBar,
+          child: child,
+        );
+      },
+    ),
+  );
+}
+
+/// Distributes platform window-control avoidance between chrome consumers.
+///
+/// The application root defaults to app-bar ownership. A navigation shell
+/// overrides this scope so rail layouts expose avoidance to the rail instead.
+class AdaptiveWindowControlLayoutScope extends InheritedWidget {
+  const AdaptiveWindowControlLayoutScope({
+    super.key,
+    required this.horizontalAvoidance,
+    required this.verticalAvoidance,
+    required this.owner,
+    required super.child,
+  });
+
+  final EdgeInsetsDirectional horizontalAvoidance;
+  final EdgeInsetsDirectional verticalAvoidance;
+  final WindowControlLayoutOwner owner;
+
+  EdgeInsetsDirectional get appBarHorizontalAvoidance =>
+      owner == WindowControlLayoutOwner.appBar
+      ? horizontalAvoidance
+      : EdgeInsetsDirectional.zero;
+
+  EdgeInsetsDirectional get railHorizontalAvoidance =>
+      owner == WindowControlLayoutOwner.rail
+      ? horizontalAvoidance
+      : EdgeInsetsDirectional.zero;
+
+  EdgeInsetsDirectional get railVerticalAvoidance =>
+      owner == WindowControlLayoutOwner.rail
+      ? verticalAvoidance
+      : EdgeInsetsDirectional.zero;
+
+  static AdaptiveWindowControlLayoutScope? maybeOf(
+    BuildContext context,
+  ) => context
+      .dependOnInheritedWidgetOfExactType<AdaptiveWindowControlLayoutScope>();
+
+  static EdgeInsetsDirectional appBarAvoidanceOf(BuildContext context) =>
+      maybeOf(context)?.appBarHorizontalAvoidance ?? EdgeInsetsDirectional.zero;
+
+  static EdgeInsetsDirectional railHorizontalAvoidanceOf(
+    BuildContext context,
+  ) => maybeOf(context)?.railHorizontalAvoidance ?? EdgeInsetsDirectional.zero;
+
+  static EdgeInsetsDirectional railVerticalAvoidanceOf(BuildContext context) =>
+      maybeOf(context)?.railVerticalAvoidance ?? EdgeInsetsDirectional.zero;
+
+  @override
+  bool updateShouldNotify(AdaptiveWindowControlLayoutScope oldWidget) =>
+      horizontalAvoidance != oldWidget.horizontalAvoidance ||
+      verticalAvoidance != oldWidget.verticalAvoidance ||
+      owner != oldWidget.owner;
+}

--- a/packages/mhabit_adaptive_ui/pubspec.yaml
+++ b/packages/mhabit_adaptive_ui/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   adaptive_actions: ^0.2.2
   flutter:
     sdk: flutter
+  ios_window_control_layout: ^0.1.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -311,6 +311,45 @@ void _resetWindowControlLayoutMock() {
 }
 
 void main() {
+  group('NavigationRailExtent', () {
+    test('fixed target clamps to the available interval', () {
+      const extent = NavigationRailExtent(224);
+
+      expect(extent.resolve(1600), 224);
+      expect(extent.resolve(800), 216);
+    });
+
+    test('ratio resolves between the available bounds', () {
+      const extent = NavigationRailExtent.fromRatio(0.5);
+
+      expect(extent.resolve(1600), 270);
+      expect(extent.resolve(800), 198);
+    });
+
+    test('owns interval growth and manual clamping', () {
+      const extent = NavigationRailExtent(
+        240,
+        collapsed: 64,
+        minimum: 200,
+        maximum: 320,
+        rampStart: 800,
+        rampEnd: 1400,
+      );
+
+      expect(extent.collapsed, 64);
+      expect(extent.upperBoundAt(1100), 260);
+      expect(extent.resolve(1100), 240);
+      expect(extent.clamp(300, windowWidth: 1100), 260);
+    });
+
+    test('requires the extended minimum to fit the collapsed rail', () {
+      expect(
+        () => NavigationRailExtent(100, collapsed: 200),
+        throwsAssertionError,
+      );
+    });
+  });
+
   testWidgets('scope lookups distinguish listening from read access', (
     tester,
   ) async {
@@ -1192,10 +1231,38 @@ void main() {
 
       expect(find.byType(NavigationDrawer), findsNothing);
       expect(find.byType(NavigationRail), findsOneWidget);
-      // Auto width tops out at 180 + 0.7 * (360 - 180) = 306.
+      // Auto width uses the compact fixed target inside the interval.
       final panel = tester.widget<NavigationRail>(find.byType(NavigationRail));
-      expect(panel.minExtendedWidth, closeTo(306, 0.01));
+      expect(panel.minExtendedWidth, closeTo(224, 0.01));
       expect(find.byIcon(Icons.menu_open), findsOneWidget);
+    });
+
+    testWidgets('accepts a ratio-based automatic rail extent', (tester) async {
+      _setSurfaceSize(tester, const Size(1800, 800));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AdaptiveNavigationShell(
+            selectedIndex: 0,
+            destinations: const [
+              NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
+              NavigationDestination(
+                icon: Icon(Icons.settings),
+                label: 'Settings',
+              ),
+            ],
+            onDestinationSelected: (_) {},
+            railExtent: const NavigationRailExtent.fromRatio(
+              0.5,
+              collapsed: 64,
+            ),
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      final panel = tester.widget<NavigationRail>(find.byType(NavigationRail));
+      expect(panel.minWidth, 64);
+      expect(panel.minExtendedWidth, closeTo(270, 0.01));
     });
 
     testWidgets('rail auto width follows the window within the interval', (
@@ -1207,16 +1274,14 @@ void main() {
 
       NavigationRail panel() =>
           tester.widget<NavigationRail>(find.byType(NavigationRail));
-      // Upper bound: 180 + 180 * (1200-600)/1000 = 288;
-      // auto: 180 + 0.7 * 108 = 255.6.
-      expect(panel().minExtendedWidth, closeTo(255.6, 0.01));
+      // The fixed 224dp target fits the current 180-288dp interval.
+      expect(panel().minExtendedWidth, closeTo(224, 0.01));
 
-      tester.view.physicalSize = const Size(900, 800);
+      tester.view.physicalSize = const Size(840, 800);
       await tester.pumpAndSettle();
 
-      // Upper bound: 180 + 180 * (900-600)/1000 = 234;
-      // auto: 180 + 0.7 * 54 = 217.8.
-      expect(panel().minExtendedWidth, closeTo(217.8, 0.01));
+      // The interval's 223.2dp upper bound clamps the fixed target.
+      expect(panel().minExtendedWidth, closeTo(223.2, 0.01));
     });
 
     testWidgets('drag resizes the rail and clamps to the interval', (
@@ -1228,7 +1293,7 @@ void main() {
 
       NavigationRail panel() =>
           tester.widget<NavigationRail>(find.byType(NavigationRail));
-      expect(panel().minExtendedWidth, closeTo(306, 0.01));
+      expect(panel().minExtendedWidth, closeTo(224, 0.01));
 
       // Drag far left: many small moves accumulate and clamp to the minimum.
       var gesture = await tester.startGesture(
@@ -1290,39 +1355,40 @@ void main() {
       final router = _buildRouter();
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
-      // Drag slightly narrower than the auto width (306) -> 276.
+      // Drag slightly narrower than the auto width (224) -> 219.
       final gesture = await tester.startGesture(
         tester.getCenter(find.byKey(const ValueKey('rail-resize-handle'))),
       );
-      for (var i = 0; i < 3; i++) {
-        await gesture.moveBy(const Offset(-10, 0));
-        await tester.pump();
-      }
+      await gesture.moveBy(const Offset(-5, 0));
+      await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle();
       NavigationRail panel() =>
           tester.widget<NavigationRail>(find.byType(NavigationRail));
-      expect(panel().minExtendedWidth, closeTo(276, 0.01));
+      expect(panel().minExtendedWidth, closeTo(219, 0.01));
 
-      // 1400: auto 280.8 > manual -> manual holds.
+      // The fixed auto target remains above the manual width, so it holds.
       tester.view.physicalSize = const Size(1400, 800);
       await tester.pumpAndSettle();
-      expect(panel().minExtendedWidth, closeTo(276, 0.01));
+      expect(panel().minExtendedWidth, closeTo(219, 0.01));
 
-      // 1300: auto 268.2 < manual -> follows the auto value down.
-      tester.view.physicalSize = const Size(1300, 800);
+      // Medium resets to collapsed; expanding it applies the interval-clamped
+      // auto width because it has fallen below the remembered manual width.
+      tester.view.physicalSize = const Size(700, 800);
       await tester.pumpAndSettle();
-      expect(panel().minExtendedWidth, closeTo(268.2, 0.01));
+      await tester.tap(find.byIcon(Icons.menu));
+      await tester.pumpAndSettle();
+      expect(panel().minExtendedWidth, closeTo(198, 0.01));
 
-      // 1150: auto 249.3 -> keeps following the auto value.
-      tester.view.physicalSize = const Size(1150, 800);
+      // The auto value keeps following the interval down.
+      tester.view.physicalSize = const Size(650, 800);
       await tester.pumpAndSettle();
-      expect(panel().minExtendedWidth, closeTo(249.3, 0.01));
+      expect(panel().minExtendedWidth, closeTo(189, 0.01));
 
       // Grow back: the remembered manual value resumes.
       tester.view.physicalSize = const Size(1800, 800);
       await tester.pumpAndSettle();
-      expect(panel().minExtendedWidth, closeTo(276, 0.01));
+      expect(panel().minExtendedWidth, closeTo(219, 0.01));
     });
 
     testWidgets('drag while the panel animation is running does not crash', (
@@ -1463,7 +1529,7 @@ void main() {
       final router = _buildRouter();
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
-      // Drag slightly narrower than the auto width (306) -> 276.
+      // Drag slightly narrower than the auto width (224) -> 194.
       final gesture = await tester.startGesture(
         tester.getCenter(find.byKey(const ValueKey('rail-resize-handle'))),
       );
@@ -1484,7 +1550,7 @@ void main() {
       tester.view.physicalSize = const Size(1800, 800);
       await tester.pumpAndSettle();
       final rail = tester.widget<NavigationRail>(find.byType(NavigationRail));
-      expect(rail.minExtendedWidth, closeTo(276, 0.01));
+      expect(rail.minExtendedWidth, closeTo(194, 0.01));
     });
   });
 

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
@@ -273,6 +274,42 @@ void _setSurfaceSize(WidgetTester tester, Size size) {
   addTearDown(tester.view.reset);
 }
 
+const MethodChannel _windowControlChannel = MethodChannel(
+  'ios_window_control_layout',
+);
+
+Map<String, double> _windowInsets({
+  double start = 0,
+  double top = 0,
+  double end = 0,
+  double bottom = 0,
+}) => <String, double>{
+  'start': start,
+  'top': top,
+  'end': end,
+  'bottom': bottom,
+};
+
+void _mockWindowControlLayout() {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_windowControlChannel, (call) async {
+        return <String, Object>{
+          'schemaVersion': 1,
+          'isAvailable': true,
+          'baseMargins': _windowInsets(),
+          'horizontalMargins': _windowInsets(start: 40, end: 12),
+          'verticalMargins': _windowInsets(top: 64),
+        };
+      });
+}
+
+void _resetWindowControlLayoutMock() {
+  debugDefaultTargetPlatformOverride = null;
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_windowControlChannel, null);
+}
+
 void main() {
   testWidgets('scope lookups distinguish listening from read access', (
     tester,
@@ -307,6 +344,115 @@ void main() {
   });
 
   group('AdaptiveNavigationShell', () {
+    testWidgets('provides adaptive window control layout to branch content', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(400, 800));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final context = tester.element(find.text('habits page'));
+      final layout = AdaptiveWindowControlLayoutScope.maybeOf(context)!;
+      expect(layout.horizontalAvoidance, EdgeInsetsDirectional.zero);
+      expect(layout.verticalAvoidance, EdgeInsetsDirectional.zero);
+      expect(layout.owner, WindowControlLayoutOwner.appBar);
+    });
+
+    testWidgets('assigns avoidance to app bar or rail without overlap', (
+      tester,
+    ) async {
+      _mockWindowControlLayout();
+      try {
+        _setSurfaceSize(tester, const Size(400, 800));
+        final router = _buildRouter();
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+        await tester.pumpAndSettle();
+
+        var context = tester.element(find.text('habits page'));
+        var layout = AdaptiveWindowControlLayoutScope.maybeOf(context)!;
+        expect(
+          layout.appBarHorizontalAvoidance,
+          const EdgeInsetsDirectional.only(start: 40, end: 12),
+        );
+        expect(layout.railHorizontalAvoidance, EdgeInsetsDirectional.zero);
+        expect(layout.railVerticalAvoidance, EdgeInsetsDirectional.zero);
+
+        tester.view.physicalSize = const Size(700, 800);
+        await tester.pumpAndSettle();
+
+        context = tester.element(find.text('habits page'));
+        layout = AdaptiveWindowControlLayoutScope.maybeOf(context)!;
+        expect(layout.appBarHorizontalAvoidance, EdgeInsetsDirectional.zero);
+        expect(
+          layout.railHorizontalAvoidance,
+          const EdgeInsetsDirectional.only(start: 40, end: 12),
+        );
+        expect(
+          layout.railVerticalAvoidance,
+          const EdgeInsetsDirectional.only(top: 64),
+        );
+
+        final safeSpan = find.byKey(const ValueKey('rail-leading-safe-span'));
+        final toggle = find.byKey(const ValueKey('rail-toggle-button'));
+        expect(
+          tester.getTopLeft(toggle).dy - tester.getTopLeft(safeSpan).dy,
+          64,
+        );
+
+        await tester.tap(toggle);
+        await tester.pumpAndSettle();
+
+        final rail = find.byKey(const ValueKey('rail-panel'));
+        expect(
+          tester.getCenter(toggle).dx,
+          moreOrLessEquals(
+            tester.getTopLeft(rail).dx + tester.getSize(rail).width / 2 + 14,
+            epsilon: 0.01,
+          ),
+        );
+      } finally {
+        _resetWindowControlLayoutMock();
+      }
+    });
+
+    testWidgets('extended rail centers in the RTL safe span', (tester) async {
+      _mockWindowControlLayout();
+      try {
+        _setSurfaceSize(tester, const Size(1000, 800));
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Directionality(
+              textDirection: TextDirection.rtl,
+              child: AdaptiveNavigationShell(
+                selectedIndex: 0,
+                destinations: const [
+                  NavigationDestination(
+                    icon: Icon(Icons.home_outlined),
+                    label: 'Habits',
+                  ),
+                ],
+                onDestinationSelected: (_) {},
+                child: const Text('content'),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final rail = find.byKey(const ValueKey('rail-panel'));
+        final toggle = find.byKey(const ValueKey('rail-toggle-button'));
+        expect(
+          tester.getCenter(toggle).dx,
+          moreOrLessEquals(
+            tester.getTopLeft(rail).dx + tester.getSize(rail).width / 2 - 14,
+            epsilon: 0.01,
+          ),
+        );
+      } finally {
+        _resetWindowControlLayoutMock();
+      }
+    });
+
     testWidgets('renders destinations and switches branch on tap', (
       tester,
     ) async {

--- a/packages/mhabit_adaptive_ui/test/adaptive_sliver_widgets_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_sliver_widgets_test.dart
@@ -255,6 +255,66 @@ void main() {
       expect(find.byType(CupertinoNavigationBar), findsNothing);
     });
 
+    testWidgets('apple fixed toolbar adds window-control avoidance', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AdaptiveWindowControlLayoutScope(
+            horizontalAvoidance: EdgeInsetsDirectional.only(start: 40, end: 12),
+            verticalAvoidance: EdgeInsetsDirectional.zero,
+            owner: WindowControlLayoutOwner.appBar,
+            child: Scaffold(
+              body: CustomScrollView(
+                slivers: [
+                  AdaptiveSliverAppBar.apple(title: Text('title'), height: 52),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final toolbar = tester
+          .widgetList<NavigationToolbar>(find.byType(NavigationToolbar))
+          .singleWhere((widget) => widget.leading is Padding);
+      expect(
+        (toolbar.leading! as Padding).padding,
+        const EdgeInsetsDirectional.only(start: 56),
+      );
+      expect(
+        (toolbar.trailing! as Padding).padding,
+        const EdgeInsetsDirectional.only(end: 28),
+      );
+    });
+
+    testWidgets('apple collapsible toolbar adds window-control avoidance', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AdaptiveWindowControlLayoutScope(
+            horizontalAvoidance: EdgeInsetsDirectional.only(start: 40, end: 12),
+            verticalAvoidance: EdgeInsetsDirectional.zero,
+            owner: WindowControlLayoutOwner.appBar,
+            child: Scaffold(
+              body: CustomScrollView(
+                slivers: [AdaptiveSliverAppBar.apple(title: Text('title'))],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final appBar = tester.widget<CupertinoSliverNavigationBar>(
+        find.byType(CupertinoSliverNavigationBar),
+      );
+      expect(
+        appBar.padding,
+        const EdgeInsetsDirectional.only(start: 56, end: 28),
+      );
+    });
+
     testWidgets('material knobs pass through to the SliverAppBar', (
       tester,
     ) async {
@@ -343,6 +403,77 @@ void main() {
       expect(bar.stretch, isTrue);
     });
 
+    testWidgets('platform configs override their visual edge padding', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AdaptiveWindowControlLayoutScope(
+            horizontalAvoidance: EdgeInsetsDirectional.only(start: 10),
+            verticalAvoidance: EdgeInsetsDirectional.zero,
+            owner: WindowControlLayoutOwner.appBar,
+            child: Scaffold(
+              body: CustomScrollView(
+                slivers: [
+                  AdaptiveSliverAppBar.material(
+                    title: Text('title'),
+                    leading: SizedBox.expand(key: ValueKey('leading')),
+                    styles: AppBarStyles(
+                      material: AppBarMaterialStyle(
+                        windowControlEdgePadding: EdgeInsetsDirectional.only(
+                          start: 3,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      expect(tester.getTopLeft(find.byKey(const ValueKey('leading'))).dx, 13);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AdaptiveWindowControlLayoutScope(
+            horizontalAvoidance: EdgeInsetsDirectional.only(start: 10),
+            verticalAvoidance: EdgeInsetsDirectional.zero,
+            owner: WindowControlLayoutOwner.appBar,
+            child: Scaffold(
+              body: CustomScrollView(
+                slivers: [
+                  AdaptiveSliverAppBar.apple(
+                    title: Text('title'),
+                    height: 52,
+                    styles: AppBarStyles(
+                      apple: AppBarAppleStyle(
+                        windowControlEdgePadding: EdgeInsetsDirectional.only(
+                          start: 5,
+                          end: 7,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      final toolbar = tester
+          .widgetList<NavigationToolbar>(find.byType(NavigationToolbar))
+          .singleWhere((widget) => widget.leading is Padding);
+      expect(
+        (toolbar.leading! as Padding).padding,
+        const EdgeInsetsDirectional.only(start: 15),
+      );
+      expect(
+        (toolbar.trailing! as Padding).padding,
+        const EdgeInsetsDirectional.only(end: 7),
+      );
+    });
+
     testWidgets('forced style ignores the other style config', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
@@ -365,13 +496,17 @@ void main() {
 
   group('AppBar style configs', () {
     test('AppBarMaterialStyle.copyWith overrides only the given fields', () {
-      const base = AppBarMaterialStyle();
-      final updated = base.copyWith(floating: false, pinned: false);
+      const original = AppBarMaterialStyle();
+      final updated = original.copyWith(floating: false, pinned: false);
       expect(updated.floating, isFalse);
       expect(updated.pinned, isFalse);
-      expect(updated.snap, base.snap);
-      expect(updated.centerTitle, base.centerTitle);
-      expect(updated.forceElevated, base.forceElevated);
+      expect(updated.snap, original.snap);
+      expect(updated.centerTitle, original.centerTitle);
+      expect(updated.forceElevated, original.forceElevated);
+      expect(
+        updated.windowControlEdgePadding,
+        original.windowControlEdgePadding,
+      );
     });
 
     test('AppBarMaterialStyle equality follows the fields', () {
@@ -384,15 +519,19 @@ void main() {
     });
 
     test('AppBarAppleStyle.copyWith overrides only the given fields', () {
-      const base = AppBarAppleStyle();
-      final updated = base.copyWith(
+      const original = AppBarAppleStyle();
+      final updated = original.copyWith(
         collapsible: true,
         enableBackgroundFilterBlur: false,
       );
       expect(updated.collapsible, isTrue);
       expect(updated.enableBackgroundFilterBlur, isFalse);
-      expect(updated.stretch, base.stretch);
-      expect(updated.border, base.border);
+      expect(updated.stretch, original.stretch);
+      expect(updated.border, original.border);
+      expect(
+        updated.windowControlEdgePadding,
+        original.windowControlEdgePadding,
+      );
     });
 
     test('AppBarStyles.copyWith keeps the other style config', () {

--- a/packages/mhabit_adaptive_ui/test/cupertino/cupertino_sliver_search_bar_test.dart
+++ b/packages/mhabit_adaptive_ui/test/cupertino/cupertino_sliver_search_bar_test.dart
@@ -8,16 +8,22 @@ Widget _host(
   CupertinoSliverSearchBar searchBar, {
   TextDirection textDirection = TextDirection.ltr,
   double? contentWidth,
+  EdgeInsetsDirectional appBarAvoidance = EdgeInsetsDirectional.zero,
 }) => MaterialApp(
   theme: ThemeData(platform: TargetPlatform.iOS),
   home: Directionality(
     textDirection: textDirection,
-    child: Scaffold(
-      body: Align(
-        alignment: Alignment.topLeft,
-        child: SizedBox(
-          width: contentWidth,
-          child: CustomScrollView(slivers: [searchBar]),
+    child: AdaptiveWindowControlLayoutScope(
+      horizontalAvoidance: appBarAvoidance,
+      verticalAvoidance: EdgeInsetsDirectional.zero,
+      owner: WindowControlLayoutOwner.appBar,
+      child: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: contentWidth,
+            child: CustomScrollView(slivers: [searchBar]),
+          ),
         ),
       ),
     ),
@@ -238,6 +244,33 @@ void main() {
     tester.view.physicalSize = const Size(1000, 800);
     await tester.pumpAndSettle();
     expect(tester.getTopRight(searchRegion).dx, 1000 - 16);
+  });
+
+  testWidgets('adds window-control avoidance to Cupertino toolbar padding', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(800, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      _host(
+        buildBar(),
+        appBarAvoidance: const EdgeInsetsDirectional.only(start: 40, end: 12),
+      ),
+    );
+
+    final searchRegion = find.byKey(
+      const ValueKey('cupertino-expandable-search-region'),
+    );
+    expect(tester.getTopRight(searchRegion).dx, 800 - 16 - 12);
+    expect(
+      tester.getTopLeft(find.byKey(const ValueKey('info'))).dx,
+      greaterThanOrEqualTo(16 + 40),
+    );
+    expect(
+      tester.getCenter(find.byKey(const ValueKey('cupertino-search-title'))).dx,
+      closeTo(400, 1),
+    );
   });
 
   testWidgets('bottom shares the toolbar glass and extends its pinned extent', (

--- a/packages/mhabit_adaptive_ui/test/window_control_layout_test.dart
+++ b/packages/mhabit_adaptive_ui/test/window_control_layout_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
+
+void main() {
+  Widget materialHost({
+    required PreferredSizeWidget appBar,
+    EdgeInsetsDirectional avoidance = EdgeInsetsDirectional.zero,
+    WindowControlLayoutOwner owner = WindowControlLayoutOwner.appBar,
+    TextDirection textDirection = TextDirection.ltr,
+  }) => MaterialApp(
+    home: Directionality(
+      textDirection: textDirection,
+      child: AdaptiveWindowControlLayoutScope(
+        horizontalAvoidance: avoidance,
+        verticalAvoidance: EdgeInsetsDirectional.zero,
+        owner: owner,
+        child: Scaffold(appBar: appBar),
+      ),
+    ),
+  );
+
+  testWidgets('Material moves slots while keeping title at window center', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(400, 800);
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      materialHost(
+        avoidance: const EdgeInsetsDirectional.only(start: 40, end: 12),
+        appBar: const WindowControlAppBar(
+          centerTitle: true,
+          title: SizedBox(
+            key: ValueKey('title'),
+            width: 80,
+            child: Text('Title'),
+          ),
+          leading: SizedBox.expand(key: ValueKey('leading')),
+          actions: [SizedBox(width: 48, key: ValueKey('action'))],
+        ),
+      ),
+    );
+
+    expect(tester.getCenter(find.byKey(const ValueKey('title'))).dx, 200);
+    expect(tester.getTopLeft(find.byKey(const ValueKey('leading'))).dx, 52);
+    expect(tester.getTopRight(find.byKey(const ValueKey('action'))).dx, 372);
+  });
+
+  testWidgets('zero avoidance matches stock Material toolbar geometry', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(400, 800);
+    addTearDown(tester.view.reset);
+
+    Future<List<Rect>> pumpAndMeasure(PreferredSizeWidget appBar) async {
+      await tester.pumpWidget(materialHost(appBar: appBar));
+      return [
+        tester.getRect(find.byKey(const ValueKey('leading'))),
+        tester.getRect(find.byKey(const ValueKey('title'))),
+        tester.getRect(find.byKey(const ValueKey('action'))),
+      ];
+    }
+
+    const leading = SizedBox.expand(key: ValueKey('leading'));
+    const title = SizedBox(
+      key: ValueKey('title'),
+      width: 80,
+      child: Text('Title'),
+    );
+    const actions = [SizedBox(width: 48, key: ValueKey('action'))];
+    final stockGeometry = await pumpAndMeasure(
+      AppBar(
+        centerTitle: true,
+        leading: leading,
+        title: title,
+        actions: actions,
+      ),
+    );
+    final wrappedGeometry = await pumpAndMeasure(
+      const WindowControlAppBar(
+        centerTitle: true,
+        leading: leading,
+        title: title,
+        actions: actions,
+      ),
+    );
+
+    expect(wrappedGeometry, stockGeometry);
+  });
+
+  testWidgets('Material explicit zero and rail owner disable avoidance', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(400, 800);
+    addTearDown(tester.view.reset);
+
+    Future<double> leadingLeft({
+      EdgeInsetsDirectional? explicitAvoidance,
+      WindowControlLayoutOwner owner = WindowControlLayoutOwner.appBar,
+    }) async {
+      await tester.pumpWidget(
+        materialHost(
+          avoidance: const EdgeInsetsDirectional.only(start: 40),
+          owner: owner,
+          appBar: WindowControlAppBar(
+            windowControlAvoidance: explicitAvoidance,
+            leading: const SizedBox.expand(key: ValueKey('leading')),
+          ),
+        ),
+      );
+      return tester.getTopLeft(find.byKey(const ValueKey('leading'))).dx;
+    }
+
+    expect(await leadingLeft(explicitAvoidance: EdgeInsetsDirectional.zero), 0);
+    expect(await leadingLeft(owner: WindowControlLayoutOwner.rail), 0);
+  });
+
+  testWidgets('Material edge padding is configurable and directional', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(400, 800);
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      materialHost(
+        textDirection: TextDirection.rtl,
+        avoidance: const EdgeInsetsDirectional.only(start: 20, end: 8),
+        appBar: const WindowControlAppBar(
+          windowControlEdgePadding: EdgeInsetsDirectional.only(
+            start: 4,
+            end: 6,
+          ),
+          leading: SizedBox.expand(key: ValueKey('leading')),
+          actions: [SizedBox(width: 48, key: ValueKey('action'))],
+        ),
+      ),
+    );
+
+    expect(tester.getTopRight(find.byKey(const ValueKey('leading'))).dx, 376);
+    expect(tester.getTopLeft(find.byKey(const ValueKey('action'))).dx, 14);
+  });
+
+  testWidgets('Cupertino keeps middle centered and pads controls internally', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(400, 800);
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: AdaptiveWindowControlLayoutScope(
+          horizontalAvoidance: EdgeInsetsDirectional.only(start: 40, end: 12),
+          verticalAvoidance: EdgeInsetsDirectional.zero,
+          owner: WindowControlLayoutOwner.appBar,
+          child: CupertinoPageScaffold(
+            navigationBar: WindowControlCupertinoNavigationBar(
+              automaticallyImplyLeading: false,
+              middle: SizedBox(
+                key: ValueKey('middle'),
+                width: 80,
+                child: Text('Title'),
+              ),
+              leading: SizedBox(width: 44, key: ValueKey('leading')),
+              trailing: SizedBox(width: 44, key: ValueKey('trailing')),
+            ),
+            child: SizedBox.shrink(),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getCenter(find.byKey(const ValueKey('middle'))).dx, 200);
+    expect(tester.getTopLeft(find.byKey(const ValueKey('leading'))).dx, 56);
+    expect(tester.getTopRight(find.byKey(const ValueKey('trailing'))).dx, 372);
+  });
+
+  testWidgets('sliver large title uses internal toolbar avoidance', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AdaptiveWindowControlLayoutScope(
+          horizontalAvoidance: EdgeInsetsDirectional.only(start: 20),
+          verticalAvoidance: EdgeInsetsDirectional.zero,
+          owner: WindowControlLayoutOwner.appBar,
+          child: Scaffold(
+            body: CustomScrollView(
+              slivers: [
+                WindowControlSliverAppBar.large(
+                  title: Text('Large'),
+                  leading: SizedBox.expand(key: ValueKey('large-leading')),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getTopLeft(find.byKey(const ValueKey('large-leading'))).dx,
+      32,
+    );
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -886,6 +886,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  ios_window_control_layout:
+    dependency: transitive
+    description:
+      name: ios_window_control_layout
+      sha256: "3882d2997985734fef099ae27dac8c74b70d7f5e8ef2e17c1acf86c18e752e8f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   jni:
     dependency: transitive
     description:

--- a/test/feature/app_settings/app_settings_page_smoke_test.dart
+++ b/test/feature/app_settings/app_settings_page_smoke_test.dart
@@ -30,6 +30,8 @@ import 'package:mhabit/providers/workflow/app_reminder.dart';
 import 'package:mhabit/providers/workflow/app_sync.dart';
 import 'package:mhabit/storage/db_helper_provider.dart';
 import 'package:mhabit/storage/profile_provider.dart';
+import 'package:mhabit/widgets/widgets.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -138,5 +140,9 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.text('Settings'), findsOneWidget);
+    expect(find.byType(WindowControlAppBar), findsOneWidget);
+    final appBar = tester.widget<AppBar>(find.byType(AppBar));
+    expect(appBar.leading, isA<PageBackButton>());
+    expect(appBar.title, isA<L10nBuilder>());
   });
 }

--- a/test/unit/entries/app_root_view_test.dart
+++ b/test/unit/entries/app_root_view_test.dart
@@ -12,10 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mhabit/entries/common/app_root_view.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
+
+const MethodChannel _windowControlChannel = MethodChannel(
+  'ios_window_control_layout',
+);
+
+Map<String, double> _insets({double start = 0, double end = 0}) =>
+    <String, double>{'start': start, 'top': 0, 'end': end, 'bottom': 0};
 
 void main() {
   group('AppRootView', () {
@@ -102,6 +112,62 @@ void main() {
       expect(find.text('home-key-test'), findsOneWidget);
       expect(find.byType(MaterialApp), findsOneWidget);
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('window-control layout reaches root GoRouter pages', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(_windowControlChannel, (_) async {
+            return <String, Object>{
+              'schemaVersion': 1,
+              'isAvailable': true,
+              'baseMargins': _insets(),
+              'horizontalMargins': _insets(start: 40, end: 12),
+              'verticalMargins': _insets(),
+            };
+          });
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, _) => Scaffold(
+              body: TextButton(
+                onPressed: () => context.push('/settings'),
+                child: const Text('open page'),
+              ),
+            ),
+          ),
+          GoRoute(
+            path: '/settings',
+            builder: (_, _) => const Scaffold(
+              appBar: WindowControlAppBar(
+                leading: SizedBox.expand(key: ValueKey('pushed-leading')),
+              ),
+            ),
+          ),
+        ],
+      );
+      try {
+        await tester.pumpWidget(
+          AppRootView.router(themeMode: ThemeMode.system, config: router),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('open page'));
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getTopLeft(find.byKey(const ValueKey('pushed-leading'))).dx,
+          52,
+        );
+      } finally {
+        router.dispose();
+        debugDefaultTargetPlatformOverride = null;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(_windowControlChannel, null);
+      }
     });
   });
 }

--- a/test/unit/pages/window_control_app_bar_migration_test.dart
+++ b/test/unit/pages/window_control_app_bar_migration_test.dart
@@ -1,0 +1,120 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mhabit/models/habit_color.dart';
+import 'package:mhabit/models/habit_color_type.dart';
+import 'package:mhabit/pages/habit_detail/_widgets/habit_detail_appbar.dart';
+import 'package:mhabit/pages/habit_edit/_widgets/habit_edit_app_bar.dart';
+import 'package:mhabit/pages/habits_status_changer/_widgets/habit_status_changer_appbar.dart';
+import 'package:mhabit/widgets/widgets.dart';
+import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
+
+Widget _host(Widget appBar) => MaterialApp(
+  home: Scaffold(body: CustomScrollView(slivers: [appBar])),
+);
+
+void main() {
+  testWidgets('HabitDetailAppBar preserves its sliver configuration', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(
+        HabitDetailAppBar(
+          title: const Text('Detail'),
+          actionBuilder: (_) => const SizedBox(key: ValueKey('detail-action')),
+        ),
+      ),
+    );
+
+    final wrapper = tester.widget<WindowControlSliverAppBar>(
+      find.byType(WindowControlSliverAppBar),
+    );
+    final appBar = tester.widget<SliverAppBar>(find.byType(SliverAppBar));
+    expect(wrapper.pinned, isTrue);
+    expect(wrapper.leading, isA<PageBackButton>());
+    expect(wrapper.actions, hasLength(1));
+    expect(find.text('Detail'), findsOneWidget);
+    expect(find.byKey(const ValueKey('detail-action')), findsOneWidget);
+    expect(appBar.pinned, isTrue);
+  });
+
+  testWidgets('HabitEditAppBar preserves large app-bar behavior and actions', (
+    tester,
+  ) async {
+    var saved = false;
+    await tester.pumpWidget(
+      _host(
+        HabitEditAppBar(
+          name: 'Habit',
+          color: const HabitColor.builtIn(HabitColorType.cc1),
+          scrolledUnderElevation: 3,
+          autofocus: false,
+          isAppbarPinned: false,
+          showInFullscreenDialog: true,
+          onSaveButtonPressed: () => saved = true,
+        ),
+      ),
+    );
+
+    final wrapper = tester.widget<WindowControlSliverAppBar>(
+      find.byType(WindowControlSliverAppBar),
+    );
+    final appBar = tester.widget<SliverAppBar>(find.byType(SliverAppBar));
+    expect(wrapper.pinned, isTrue);
+    expect(wrapper.automaticallyImplyLeading, isFalse);
+    expect(wrapper.scrolledUnderElevation, 3);
+    expect(wrapper.flexibleSpace, isNotNull);
+    expect(wrapper.leading, isA<PageBackButton>());
+    expect(appBar.pinned, isTrue);
+    expect(appBar.automaticallyImplyLeading, isFalse);
+    expect(appBar.flexibleSpace, isNotNull);
+
+    await tester.tap(find.text('Save'));
+    expect(saved, isTrue);
+  });
+
+  testWidgets(
+    'HabitStatusChangerAppbar preserves toolbar and bottom behavior',
+    (tester) async {
+      var closed = false;
+      await tester.pumpWidget(
+        _host(
+          HabitStatusChangerAppbar(
+            title: const Text('Batch'),
+            bottomWidget: const SizedBox(key: ValueKey('batch-bottom')),
+            onCloseButtonPressed: () => closed = true,
+          ),
+        ),
+      );
+
+      final wrapper = tester.widget<WindowControlSliverAppBar>(
+        find.byType(WindowControlSliverAppBar),
+      );
+      final appBar = tester.widget<SliverAppBar>(find.byType(SliverAppBar));
+      expect(wrapper.pinned, isTrue);
+      expect(wrapper.floating, isTrue);
+      expect(wrapper.automaticallyImplyLeading, isFalse);
+      expect(wrapper.bottom?.preferredSize.height, kToolbarHeight);
+      expect(find.text('Batch'), findsOneWidget);
+      expect(find.byKey(const ValueKey('batch-bottom')), findsOneWidget);
+      expect(appBar.pinned, isTrue);
+      expect(appBar.floating, isTrue);
+
+      await tester.tap(find.byType(PageBackButton));
+      expect(closed, isTrue);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Add iPad window-control-aware layout handling and configurable adaptive navigation rail sizing. This keeps app bars and navigation rails clear of system window controls while preserving the existing adaptive navigation behavior across supported platforms.

## Type of Change
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] style
- [ ] test
- [ ] chore

## Related Issue

Not applicable.

## Checklist
- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change

---

> _Templates_: [weblate.md](?template=weblate.md)