### PR TITLE
Fix navigation insets, imports, and today refresh

### DIFF
--- a/lib/models/thirdparty_import.dart
+++ b/lib/models/thirdparty_import.dart
@@ -43,20 +43,29 @@ final class LoopImporterVersion extends ImporterVersion {
       Uri.parse('https://github.com/iSoron/uhabits/releases/tag/v$version');
 }
 
+/// Identifies a supported third-party import file format.
+enum ThirdPartyImportFormat {
+  /// Loop Habit Tracker CSV export packaged as a ZIP archive.
+  loopCsvArchive,
+}
+
 /// Identifies a supported third-party habit tracker that mhabit can import from.
 enum ThirdPartyProvider {
   /// [Loop Habit Tracker](https://github.com/iSoron/uhabits) CSV export.
-  loopHabitTracker(fileExtensions: ['zip'], displayName: 'Loop Habit Tracker');
-
-  /// File extensions accepted by the file picker for this provider.
-  final List<String> fileExtensions;
+  loopHabitTracker(
+    displayName: 'Loop Habit Tracker',
+    importFormats: [ThirdPartyImportFormat.loopCsvArchive],
+  );
 
   /// Human-readable name shown in the UI (confirm dialogs, error messages).
   final String displayName;
 
+  /// Import file formats produced by this provider.
+  final List<ThirdPartyImportFormat> importFormats;
+
   const ThirdPartyProvider({
-    required this.fileExtensions,
     required this.displayName,
+    required this.importFormats,
   });
 }
 

--- a/lib/pages/habits_display/_providers/habits_today.dart
+++ b/lib/pages/habits_display/_providers/habits_today.dart
@@ -360,6 +360,7 @@ class HabitsTodayViewModel extends ChangeNotifier
     _reloadBridge.eventSubs
       ?..subscribe<ReloadDataEvent>()
       ..subscribe<HabitStatusChangedEvent>()
+      ..subscribe<HabitDataChangedEvent>()
       ..subscribe<HabitRecordsChangedEvent>();
   }
 

--- a/lib/providers/workflow/thirdparty_file_importer.dart
+++ b/lib/providers/workflow/thirdparty_file_importer.dart
@@ -22,6 +22,23 @@ import '../../models/loop_import.dart';
 import '../../models/thirdparty_import.dart';
 import '../support/commons.dart';
 
+typedef ThirdPartyFilePicker =
+    Future<XFile?> Function({required List<XTypeGroup> acceptedTypeGroups});
+
+Future<XFile?> _openThirdPartyFile({
+  required List<XTypeGroup> acceptedTypeGroups,
+}) => openFile(acceptedTypeGroups: acceptedTypeGroups);
+
+extension _ThirdPartyImportFormatFileSelector on ThirdPartyImportFormat {
+  XTypeGroup get fileTypeGroup => switch (this) {
+    ThirdPartyImportFormat.loopCsvArchive => const XTypeGroup(
+      label: 'Loop Habit Tracker export',
+      extensions: ['zip'],
+      uniformTypeIdentifiers: ['public.zip-archive'],
+    ),
+  };
+}
+
 /// Return the [ThirdPartyImporter.supportedVersion] for [provider].
 ///
 /// This is a thin lookup so callers (e.g. the provider selection dialog)
@@ -36,7 +53,11 @@ ImporterVersion getThirdPartyImporterVersion(ThirdPartyProvider provider) {
 
 final class ThirdPartyImportOwner extends ChangeNotifier
     implements ProviderMounted {
+  final ThirdPartyFilePicker _pickFile;
   bool _mounted = true;
+
+  ThirdPartyImportOwner({ThirdPartyFilePicker? pickFile})
+    : _pickFile = pickFile ?? _openThirdPartyFile;
 
   @override
   void dispose() {
@@ -87,26 +108,33 @@ final class ThirdPartyImportOwner extends ChangeNotifier
     return result;
   }
 
-  /// Open a file picker filtered to [provider]'s file extensions, read the
-  /// selected file, parse it, and return importable JSON.
+  /// Open a file picker filtered to [provider]'s supported file types, read
+  /// the selected file, parse it, and return importable JSON.
   ///
   /// Returns `null` when the user cancels the file picker.
   Future<Iterable<Object?>?> loadHabitsData(
     ThirdPartyProvider provider, {
     bool listen = true,
   }) async {
-    final file =
-        await openFile(
-          acceptedTypeGroups: [XTypeGroup(extensions: provider.fileExtensions)],
-        ).catchError((e, s) {
-          appLog.load.error(
-            '$runtimeType.loadHabitsData',
-            ex: ["Can't open file picker"],
-            error: e,
-            stackTrace: LoggerStackTrace.from(s),
-          );
-          return null;
-        });
+    final XFile? file;
+    try {
+      file = await _pickFile(
+        acceptedTypeGroups: provider.importFormats
+            .map((format) => format.fileTypeGroup)
+            .toList(),
+      );
+    } catch (e, s) {
+      appLog.load.error(
+        '$runtimeType.loadHabitsData',
+        ex: ["Can't open file picker"],
+        error: e,
+        stackTrace: LoggerStackTrace.from(s),
+      );
+      throw ThirdPartyImportException(
+        ThirdPartyImportErrorType.unknown,
+        detail: e.toString(),
+      );
+    }
 
     if (file == null) return null;
 

--- a/packages/mhabit_adaptive_ui/lib/src/shell/navigation_shell_frame.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/navigation_shell_frame.dart
@@ -440,10 +440,35 @@ class _NavigationShellBody extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             leadingBuilder(context, form, onDestinationSelected),
-            Expanded(child: child),
+            Expanded(
+              child: _NavigationShellBranch(form: form, child: child),
+            ),
           ],
         ),
       ),
+    );
+  }
+}
+
+class _NavigationShellBranch extends StatelessWidget {
+  const _NavigationShellBranch({required this.form, required this.child});
+
+  final NavigationShellForm form;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (form == NavigationShellForm.bar) return child;
+
+    // NavigationRail's SafeArea owns the shell's logical-start system inset.
+    // Remove that consumed inset from the sibling branch so page SafeAreas do
+    // not reserve it again. Keep the opposite side available to page content.
+    final removeLeft = Directionality.of(context) == TextDirection.ltr;
+    return MediaQuery.removePadding(
+      context: context,
+      removeLeft: removeLeft,
+      removeRight: !removeLeft,
+      child: child,
     );
   }
 }

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -245,6 +245,28 @@ class _StubPage extends StatelessWidget {
   }
 }
 
+class _BranchInsetsProbe extends StatelessWidget {
+  const _BranchInsetsProbe();
+
+  @override
+  Widget build(BuildContext context) {
+    final padding = MediaQuery.paddingOf(context);
+    final viewPadding = MediaQuery.viewPaddingOf(context);
+    return Column(
+      children: [
+        SizedBox(
+          key: const ValueKey('branch-horizontal-padding'),
+          width: padding.left + padding.right,
+        ),
+        SizedBox(
+          key: const ValueKey('branch-horizontal-view-padding'),
+          width: viewPadding.left + viewPadding.right,
+        ),
+      ],
+    );
+  }
+}
+
 class _FabStubPage extends StatelessWidget {
   const _FabStubPage();
 
@@ -1529,6 +1551,73 @@ void main() {
       expect(scope.barHeight, 80);
       expect(scope.navHeight, 104);
     });
+
+    for (final textDirection in TextDirection.values) {
+      testWidgets('rail owns the branch start inset in $textDirection', (
+        tester,
+      ) async {
+        tester.view.padding = const FakeViewPadding(left: 44, right: 20);
+        tester.view.viewPadding = const FakeViewPadding(left: 50, right: 30);
+        _setSurfaceSize(tester, const Size(800, 400));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Directionality(
+              textDirection: textDirection,
+              child: AdaptiveNavigationShell(
+                selectedIndex: 0,
+                destinations: const [
+                  AdaptiveNavigationDestination(
+                    label: 'Habits',
+                    icons: NavigationDestinationIcons(
+                      material: Icon(Icons.home_outlined),
+                      materialSelected: Icon(Icons.home),
+                      apple: Icon(Icons.home_outlined),
+                      appleSelected: Icon(Icons.home),
+                    ),
+                  ),
+                ],
+                onDestinationSelected: (_) {},
+                child: const _BranchInsetsProbe(),
+              ),
+            ),
+          ),
+        );
+
+        final expectedBranchInset = switch (textDirection) {
+          TextDirection.ltr => 20.0,
+          TextDirection.rtl => 44.0,
+        };
+        final expectedBranchViewInset = switch (textDirection) {
+          TextDirection.ltr => 36.0,
+          TextDirection.rtl => 60.0,
+        };
+        expect(
+          tester
+              .getSize(find.byKey(const ValueKey('branch-horizontal-padding')))
+              .width,
+          expectedBranchInset,
+        );
+        expect(
+          tester
+              .getSize(
+                find.byKey(const ValueKey('branch-horizontal-view-padding')),
+              )
+              .width,
+          expectedBranchViewInset,
+        );
+
+        final railContext = tester.element(find.byType(NavigationRail));
+        expect(
+          MediaQuery.paddingOf(railContext),
+          const EdgeInsets.only(left: 44, right: 20),
+        );
+        expect(
+          MediaQuery.viewPaddingOf(railContext),
+          const EdgeInsets.only(left: 50, right: 30),
+        );
+      });
+    }
 
     for (final bottomInset in [24.0, 34.0]) {
       testWidgets(

--- a/test/unit/pages/habits_display/habits_today_viewmodel_test.dart
+++ b/test/unit/pages/habits_display/habits_today_viewmodel_test.dart
@@ -28,6 +28,31 @@ Map<AppEventPageSource, Set<AppEventFunctionSource>> _trace(
 
 void main() {
   group('HabitsTodayViewModel:event', () {
+    test('reloads when a habit is created', () async {
+      final bus = AppEventBus();
+      final vm = HabitsTodayViewModel();
+      vm.updateAppEvent(bus);
+      addTearDown(() {
+        vm.dispose();
+        bus.dispose();
+      });
+
+      vm.consumeForceReloadFlag();
+
+      bus.push(
+        const HabitDataChangedEvent(
+          uuidList: ['u1'],
+          changeType: HabitDataChangeType.created,
+          trace: {
+            AppEventPageSource.habitEdit: {AppEventFunctionSource.habitCreated},
+          },
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(vm.consumeForceReloadFlag(), isTrue);
+    });
+
     test(
       'reloads when RecordsChangedEvent contains today in dateList',
       () async {

--- a/test/unit/providers/thirdparty_file_importer_test.dart
+++ b/test/unit/providers/thirdparty_file_importer_test.dart
@@ -15,12 +15,57 @@
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
+import 'package:file_selector/file_selector.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mhabit/common/exceptions.dart';
 import 'package:mhabit/models/thirdparty_import.dart';
 import 'package:mhabit/providers/workflow/thirdparty_file_importer.dart';
 
 void main() {
+  group('ThirdPartyImportOwner.loadHabitsData', () {
+    const provider = ThirdPartyProvider.loopHabitTracker;
+
+    test('passes ZIP filters for extension and Apple UTI', () async {
+      List<XTypeGroup>? capturedTypeGroups;
+      final owner = ThirdPartyImportOwner(
+        pickFile: ({required acceptedTypeGroups}) async {
+          capturedTypeGroups = acceptedTypeGroups;
+          return null;
+        },
+      );
+      addTearDown(owner.dispose);
+
+      expect(await owner.loadHabitsData(provider), isNull);
+      expect(capturedTypeGroups, hasLength(1));
+
+      final typeGroup = capturedTypeGroups!.single;
+      expect(typeGroup.extensions, ['zip']);
+      expect(typeGroup.uniformTypeIdentifiers, ['public.zip-archive']);
+    });
+
+    test('keeps picker failure distinct from user cancellation', () async {
+      final owner = ThirdPartyImportOwner(
+        pickFile: ({required acceptedTypeGroups}) async {
+          throw StateError('picker unavailable');
+        },
+      );
+      addTearDown(owner.dispose);
+
+      await expectLater(
+        owner.loadHabitsData(provider),
+        throwsA(
+          isA<ThirdPartyImportException>()
+              .having((e) => e.type, 'type', ThirdPartyImportErrorType.unknown)
+              .having(
+                (e) => e.detail,
+                'detail',
+                contains('picker unavailable'),
+              ),
+        ),
+      );
+    });
+  });
+
   group('ThirdPartyImportOwner.parseThirdPartyFile error handling', () {
     final owner = ThirdPartyImportOwner();
     const provider = ThirdPartyProvider.loopHabitTracker;


### PR DESCRIPTION
## Summary
Fix adaptive navigation inset handling, support third-party archive imports on iOS, and reload the Today view after creating a habit.

## Type of Change
<!-- Check the one that matches this PR's commit type -->
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] style
- [ ] test
- [ ] chore

## Related Issue
<!-- e.g. Fixes #123, Closes #123, Related to #123 -->

## Checklist
<!-- Optional — check what applies -->
- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change