### PR TITLE
Fix adaptive navigation scroll response

### DIFF
--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_shell.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
 import '../material/material_navigation_rail.dart' show NavigationRailExtent;
+import '../shell/navigation_scroll_wish_policy.dart';
 import '../shell/navigation_shell_frame.dart';
 import 'cupertino_adaptive_navigation_bar.dart';
 import 'cupertino_floating_surface.dart';
@@ -66,6 +67,10 @@ class CupertinoNavigationShell extends StatelessWidget {
         floatingBottomMargin: appleBarStyle.floatingBottomMargin,
       ),
       keepVisibleOnScroll: true,
+      scrollWishPolicy: const NavigationScrollWishPolicy.flingThreshold(
+        distanceFactor: 1.5,
+        velocityFactor: 1.5,
+      ),
       switchDuration: disableAnimations
           ? Duration.zero
           : navigationShellAnimationDuration,

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_shell.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
+import '../shell/navigation_scroll_wish_policy.dart';
 import '../shell/navigation_shell_frame.dart';
 import 'material_navigation_bar.dart';
 import 'material_navigation_rail.dart';
@@ -53,6 +54,7 @@ class MaterialNavigationShell extends StatelessWidget {
       barHeight: _barHeight,
       navHeight: _barHeight + MediaQuery.paddingOf(context).bottom,
       keepVisibleOnScroll: false,
+      scrollWishPolicy: const NavigationScrollWishPolicy.directional(),
       leadingBuilder: (context, form, onSelected) =>
           MaterialNavigationRailRegion(
             form: form,

--- a/packages/mhabit_adaptive_ui/lib/src/shell/navigation_scroll_wish_policy.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/navigation_scroll_wish_policy.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/foundation.dart';
+
+/// Converts vertical scrolling into navigation visibility wishes.
+sealed class NavigationScrollWishPolicy {
+  const NavigationScrollWishPolicy();
+
+  /// Reacts immediately to every non-zero scroll update.
+  const factory NavigationScrollWishPolicy.directional() =
+      DirectionalNavigationScrollWishPolicy;
+
+  /// Reacts only after a drag reaches scaled platform fling thresholds.
+  const factory NavigationScrollWishPolicy.flingThreshold({
+    double distanceFactor,
+    double velocityFactor,
+  }) = FlingThresholdNavigationScrollWishPolicy;
+
+  /// Creates isolated gesture state for one navigation shell.
+  NavigationScrollWishTracker createTracker();
+}
+
+/// Immediate direction-driven navigation wishes.
+@immutable
+final class DirectionalNavigationScrollWishPolicy
+    extends NavigationScrollWishPolicy {
+  const DirectionalNavigationScrollWishPolicy();
+
+  @override
+  NavigationScrollWishTracker createTracker() =>
+      _DirectionalNavigationScrollWishTracker();
+}
+
+/// Platform-fling navigation wishes with configurable tolerance factors.
+@immutable
+final class FlingThresholdNavigationScrollWishPolicy
+    extends NavigationScrollWishPolicy {
+  const FlingThresholdNavigationScrollWishPolicy({
+    this.distanceFactor = 1,
+    this.velocityFactor = 1,
+  }) : assert(distanceFactor > 0),
+       assert(velocityFactor > 0);
+
+  /// Multiplier applied to [ScrollPhysics.minFlingDistance].
+  final double distanceFactor;
+
+  /// Multiplier applied to [ScrollPhysics.minFlingVelocity].
+  final double velocityFactor;
+
+  @override
+  NavigationScrollWishTracker createTracker() =>
+      _FlingThresholdNavigationScrollWishTracker(
+        distanceFactor: distanceFactor,
+        velocityFactor: velocityFactor,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is FlingThresholdNavigationScrollWishPolicy &&
+      distanceFactor == other.distanceFactor &&
+      velocityFactor == other.velocityFactor;
+
+  @override
+  int get hashCode => Object.hash(distanceFactor, velocityFactor);
+}
+
+/// Gesture-local state created by a [NavigationScrollWishPolicy].
+abstract interface class NavigationScrollWishTracker {
+  /// Starts a new scroll gesture or activity.
+  void start(Duration? timestamp);
+
+  /// Returns `true` to show/expand navigation, `false` to hide/minimize it,
+  /// or `null` to retain the current presentation.
+  bool? update({
+    required double extentBefore,
+    required double delta,
+    required bool directDrag,
+    required Duration? timestamp,
+    required double minFlingDistance,
+    required double minFlingVelocity,
+  });
+
+  /// Clears gesture-local state when scrolling ends.
+  void end();
+}
+
+final class _DirectionalNavigationScrollWishTracker
+    implements NavigationScrollWishTracker {
+  @override
+  void start(Duration? timestamp) {}
+
+  @override
+  bool? update({
+    required double extentBefore,
+    required double delta,
+    required bool directDrag,
+    required Duration? timestamp,
+    required double minFlingDistance,
+    required double minFlingVelocity,
+  }) => extentBefore <= 0 ? true : delta < 0;
+
+  @override
+  void end() {}
+}
+
+final class _FlingThresholdNavigationScrollWishTracker
+    implements NavigationScrollWishTracker {
+  _FlingThresholdNavigationScrollWishTracker({
+    required this.distanceFactor,
+    required this.velocityFactor,
+  });
+
+  final double distanceFactor;
+  final double velocityFactor;
+
+  Duration? _startedAt;
+  double _distance = 0;
+  double _direction = 0;
+
+  void _reset({Duration? startedAt}) {
+    _startedAt = startedAt;
+    _distance = 0;
+    _direction = 0;
+  }
+
+  @override
+  void start(Duration? timestamp) => _reset(startedAt: timestamp);
+
+  @override
+  bool? update({
+    required double extentBefore,
+    required double delta,
+    required bool directDrag,
+    required Duration? timestamp,
+    required double minFlingDistance,
+    required double minFlingVelocity,
+  }) {
+    if (extentBefore <= 0) {
+      _reset(startedAt: timestamp);
+      return true;
+    }
+    if (!directDrag) return delta < 0;
+
+    final direction = delta.sign;
+    if (_direction != 0 && _direction != direction) {
+      _reset(startedAt: timestamp);
+    }
+    _direction = direction;
+    final startedAt = _startedAt ?? timestamp;
+    _startedAt = startedAt;
+    _distance += delta.abs();
+    if (timestamp == null || startedAt == null) return null;
+
+    final elapsed = timestamp - startedAt;
+    if (elapsed <= Duration.zero) return null;
+    final seconds = elapsed.inMicroseconds / Duration.microsecondsPerSecond;
+    final velocity = _distance / seconds;
+    final reachedThreshold =
+        _distance >= minFlingDistance * distanceFactor &&
+        velocity >= minFlingVelocity * velocityFactor;
+    return reachedThreshold ? delta < 0 : null;
+  }
+
+  @override
+  void end() => _reset();
+}

--- a/packages/mhabit_adaptive_ui/lib/src/shell/navigation_shell_frame.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/navigation_shell_frame.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart' show ValueListenable;
+import 'package:flutter/gestures.dart' show kMinFlingVelocity, kTouchSlop;
 import 'package:flutter/material.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
@@ -6,6 +7,7 @@ import '../breakpoints/window_size_class.dart';
 import '../window_control/window_control_layout.dart';
 import 'adaptive_nav_scope.dart';
 import 'adaptive_nav_visibility.dart';
+import 'navigation_scroll_wish_policy.dart';
 
 /// Navigation form selected from the current window size classes.
 ///
@@ -86,6 +88,7 @@ class NavigationShellFrame extends StatefulWidget {
     required this.barHeight,
     required this.navHeight,
     required this.keepVisibleOnScroll,
+    required this.scrollWishPolicy,
     required this.leadingBuilder,
     required this.compactNavigationBuilder,
     this.floatingActionButtonBuilder,
@@ -121,6 +124,9 @@ class NavigationShellFrame extends StatefulWidget {
   ///
   /// The themed renderer may still present a minimized surface inside it.
   final bool keepVisibleOnScroll;
+
+  /// Converts compact vertical scrolling into navigation presentation wishes.
+  final NavigationScrollWishPolicy scrollWishPolicy;
 
   /// Builds the rail region for non-compact shell forms.
   final NavigationShellLeadingBuilder leadingBuilder;
@@ -246,6 +252,7 @@ class _NavigationShellFrameState extends State<NavigationShellFrame> {
         resizeToAvoidBottomInset: false,
         body: _NavigationScrollWishObserver(
           onVisibilityChanged: _scrollWish.report,
+          policy: widget.scrollWishPolicy,
           child: _NavigationShellBody(
             ambientPadding: padding,
             ambientViewPadding: viewPadding,
@@ -378,27 +385,58 @@ class _CompactNavigationClipper extends CustomClipper<Rect> {
       oldClipper.topOverflow != topOverflow;
 }
 
-class _NavigationScrollWishObserver extends StatelessWidget {
+class _NavigationScrollWishObserver extends StatefulWidget {
   const _NavigationScrollWishObserver({
     required this.onVisibilityChanged,
+    required this.policy,
     required this.child,
   });
 
   final ValueChanged<bool> onVisibilityChanged;
+  final NavigationScrollWishPolicy policy;
   final Widget child;
+
+  @override
+  State<_NavigationScrollWishObserver> createState() =>
+      _NavigationScrollWishObserverState();
+}
+
+class _NavigationScrollWishObserverState
+    extends State<_NavigationScrollWishObserver> {
+  late NavigationScrollWishTracker _tracker = widget.policy.createTracker();
+
+  @override
+  void didUpdateWidget(covariant _NavigationScrollWishObserver oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.policy == widget.policy) return;
+    _tracker = widget.policy.createTracker();
+  }
 
   bool _handleNotification(ScrollNotification notification) {
     if (notification.depth != 0 || notification.metrics.axis != Axis.vertical) {
       return false;
     }
-    if (notification.metrics.extentBefore <= 0) {
-      onVisibilityChanged(true);
-      return false;
+    if (notification case ScrollStartNotification(:final dragDetails)) {
+      _tracker.start(dragDetails?.sourceTimeStamp);
+    } else if (notification is ScrollEndNotification) {
+      _tracker.end();
     }
     if (notification is! ScrollUpdateNotification) return false;
     final delta = notification.scrollDelta;
     if (delta == null || delta == 0) return false;
-    onVisibilityChanged(delta < 0);
+    final scrollable = notification.context == null
+        ? null
+        : Scrollable.maybeOf(notification.context!);
+    final physics = scrollable?.position.physics;
+    final wish = _tracker.update(
+      extentBefore: notification.metrics.extentBefore,
+      delta: delta,
+      directDrag: notification.dragDetails != null,
+      timestamp: notification.dragDetails?.sourceTimeStamp,
+      minFlingDistance: physics?.minFlingDistance ?? kTouchSlop,
+      minFlingVelocity: physics?.minFlingVelocity ?? kMinFlingVelocity,
+    );
+    if (wish != null) widget.onVisibilityChanged(wish);
     return false;
   }
 
@@ -406,7 +444,7 @@ class _NavigationScrollWishObserver extends StatelessWidget {
   Widget build(BuildContext context) =>
       NotificationListener<ScrollNotification>(
         onNotification: _handleNotification,
-        child: child,
+        child: widget.child,
       );
 }
 

--- a/packages/mhabit_adaptive_ui/lib/src/shell/navigation_shell_frame.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/navigation_shell_frame.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart' show ScrollDirection;
 
 import '../adaptive/adaptive_navigation_destination.dart';
 import '../breakpoints/window_size_class.dart';
@@ -388,24 +387,24 @@ class _NavigationScrollWishObserver extends StatelessWidget {
   final ValueChanged<bool> onVisibilityChanged;
   final Widget child;
 
-  bool _handleNotification(UserScrollNotification notification) {
+  bool _handleNotification(ScrollNotification notification) {
     if (notification.depth != 0 || notification.metrics.axis != Axis.vertical) {
       return false;
     }
-    switch (notification.direction) {
-      case ScrollDirection.forward:
-        onVisibilityChanged(true);
-      case ScrollDirection.reverse:
-        onVisibilityChanged(false);
-      case ScrollDirection.idle:
-        break;
+    if (notification.metrics.extentBefore <= 0) {
+      onVisibilityChanged(true);
+      return false;
     }
+    if (notification is! ScrollUpdateNotification) return false;
+    final delta = notification.scrollDelta;
+    if (delta == null || delta == 0) return false;
+    onVisibilityChanged(delta < 0);
     return false;
   }
 
   @override
   Widget build(BuildContext context) =>
-      NotificationListener<UserScrollNotification>(
+      NotificationListener<ScrollNotification>(
         onNotification: _handleNotification,
         child: child,
       );

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -752,9 +752,10 @@ void main() {
         findsOneWidget,
       );
 
-      await tester.drag(
+      await tester.fling(
         find.byKey(const ValueKey('today-scroll')),
         const Offset(0, -300),
+        1200,
       );
       await tester.pumpAndSettle();
       expect(
@@ -762,9 +763,10 @@ void main() {
         findsOneWidget,
       );
 
-      await tester.drag(
+      await tester.fling(
         find.byKey(const ValueKey('today-scroll')),
         const Offset(0, 150),
+        1200,
       );
       await tester.pumpAndSettle();
       expect(
@@ -795,6 +797,173 @@ void main() {
         find.byKey(const ValueKey('cupertino-navigation-expanded')),
         findsOneWidget,
       );
+    });
+
+    testWidgets('keeps Apple navigation expanded during a slow drag', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(400, 800));
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          home: const _BranchContractHarness(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.timedDrag(
+        find.byKey(const ValueKey('habits-scroll')),
+        const Offset(0, -80),
+        const Duration(seconds: 2),
+      );
+      await tester.pumpAndSettle();
+
+      final scrollable = Scrollable.of(
+        tester.element(find.text('branch 0 item 1')),
+      );
+      expect(scrollable.position.pixels, greaterThan(0));
+      expect(
+        find.byKey(const ValueKey('cupertino-navigation-expanded')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('minimizes Apple navigation during a fast direct drag', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(400, 800));
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          home: const _BranchContractHarness(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final scroll = find.byKey(const ValueKey('habits-scroll'));
+      final gesture = await tester.startGesture(tester.getCenter(scroll));
+      await gesture.moveBy(
+        const Offset(0, -24),
+        timeStamp: const Duration(milliseconds: 16),
+      );
+      await tester.pump();
+      await gesture.moveBy(
+        const Offset(0, -48),
+        timeStamp: const Duration(milliseconds: 32),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('cupertino-navigation-minimized')),
+        findsOneWidget,
+      );
+      await gesture.up(timeStamp: const Duration(milliseconds: 48));
+    });
+
+    testWidgets('keeps Apple navigation minimized during a slow reverse drag', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(400, 800));
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          home: const _BranchContractHarness(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final item = find.text('branch 0 item 1');
+      final scrollable = Scrollable.of(tester.element(item));
+      scrollable.position.jumpTo(300);
+      final scope = AdaptiveNavScope.of(tester.element(item));
+      scope.reportScrollWish(false);
+      await tester.pumpAndSettle();
+
+      await tester.timedDrag(
+        find.byKey(const ValueKey('habits-scroll')),
+        const Offset(0, 80),
+        const Duration(seconds: 2),
+      );
+      await tester.pumpAndSettle();
+
+      expect(scrollable.position.pixels, greaterThan(0));
+      expect(
+        find.byKey(const ValueKey('cupertino-navigation-minimized')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('expands Apple navigation during a fast direct reverse drag', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(400, 800));
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          home: const _BranchContractHarness(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final item = find.text('branch 0 item 1');
+      final scrollable = Scrollable.of(tester.element(item));
+      scrollable.position.jumpTo(300);
+      final scope = AdaptiveNavScope.of(tester.element(item));
+      scope.reportScrollWish(false);
+      await tester.pumpAndSettle();
+
+      final scroll = find.byKey(const ValueKey('habits-scroll'));
+      final gesture = await tester.startGesture(tester.getCenter(scroll));
+      await gesture.moveBy(
+        const Offset(0, 24),
+        timeStamp: const Duration(milliseconds: 16),
+      );
+      await tester.pump();
+      await gesture.moveBy(
+        const Offset(0, 48),
+        timeStamp: const Duration(milliseconds: 32),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('cupertino-navigation-expanded')),
+        findsOneWidget,
+      );
+      await gesture.up(timeStamp: const Duration(milliseconds: 48));
+    });
+
+    testWidgets('keeps Material navigation direction-driven in both ways', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(400, 800));
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.android),
+          home: const _BranchContractHarness(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.timedDrag(
+        find.byKey(const ValueKey('habits-scroll')),
+        const Offset(0, -80),
+        const Duration(seconds: 2),
+      );
+      await tester.pumpAndSettle();
+
+      final scope = AdaptiveNavScope.of(
+        tester.element(find.text('branch 0 item 1')),
+      );
+      expect(scope.visible.value, isFalse);
+
+      await tester.timedDrag(
+        find.byKey(const ValueKey('habits-scroll')),
+        const Offset(0, 20),
+        const Duration(seconds: 1),
+      );
+      await tester.pumpAndSettle();
+
+      expect(scope.visible.value, isTrue);
     });
 
     testWidgets('animates the Apple action with route visibility', (

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -307,7 +307,9 @@ class _ScopeLookupProbe extends StatelessWidget {
 }
 
 class _BranchContractHarness extends StatefulWidget {
-  const _BranchContractHarness();
+  const _BranchContractHarness({this.itemCount = 40});
+
+  final int itemCount;
 
   @override
   State<_BranchContractHarness> createState() => _BranchContractHarnessState();
@@ -363,7 +365,7 @@ class _BranchContractHarnessState extends State<_BranchContractHarness> {
                   key: ValueKey(index == 0 ? 'habits-scroll' : 'today-scroll'),
                   slivers: [
                     SliverList.builder(
-                      itemCount: 40,
+                      itemCount: widget.itemCount,
                       itemBuilder: (context, itemIndex) => SizedBox(
                         height: 56,
                         child: Text('branch $index item $itemIndex'),
@@ -765,6 +767,30 @@ void main() {
         const Offset(0, 150),
       );
       await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('cupertino-navigation-expanded')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('keeps Apple navigation expanded without scroll extent', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(400, 800));
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          home: const _BranchContractHarness(itemCount: 1),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.drag(
+        find.byKey(const ValueKey('habits-scroll')),
+        const Offset(0, -300),
+      );
+      await tester.pumpAndSettle();
+
       expect(
         find.byKey(const ValueKey('cupertino-navigation-expanded')),
         findsOneWidget,

--- a/packages/mhabit_adaptive_ui/test/navigation_scroll_wish_policy_test.dart
+++ b/packages/mhabit_adaptive_ui/test/navigation_scroll_wish_policy_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mhabit_adaptive_ui/src/shell/navigation_scroll_wish_policy.dart';
+
+void main() {
+  const minDistance = 18.0;
+  const minVelocity = 100.0;
+
+  bool? update(
+    NavigationScrollWishTracker tracker, {
+    required double delta,
+    required Duration timestamp,
+    double extentBefore = 100,
+    bool directDrag = true,
+  }) => tracker.update(
+    extentBefore: extentBefore,
+    delta: delta,
+    directDrag: directDrag,
+    timestamp: timestamp,
+    minFlingDistance: minDistance,
+    minFlingVelocity: minVelocity,
+  );
+
+  test('directional policy reacts immediately in both directions', () {
+    final tracker = const NavigationScrollWishPolicy.directional()
+        .createTracker();
+
+    expect(update(tracker, delta: 1, timestamp: Duration.zero), isFalse);
+    expect(update(tracker, delta: -1, timestamp: Duration.zero), isTrue);
+  });
+
+  test('fling policy tolerates slow drags in both directions', () {
+    final tracker = const NavigationScrollWishPolicy.flingThreshold(
+      distanceFactor: 1.5,
+      velocityFactor: 1.5,
+    ).createTracker();
+    tracker.start(Duration.zero);
+
+    expect(
+      update(tracker, delta: 80, timestamp: const Duration(seconds: 2)),
+      isNull,
+    );
+    expect(
+      update(tracker, delta: -80, timestamp: const Duration(seconds: 4)),
+      isNull,
+    );
+  });
+
+  test('fling policy switches after scaled thresholds in both directions', () {
+    final tracker = const NavigationScrollWishPolicy.flingThreshold(
+      distanceFactor: 1.5,
+      velocityFactor: 1.5,
+    ).createTracker();
+    tracker.start(Duration.zero);
+
+    expect(
+      update(tracker, delta: 20, timestamp: const Duration(milliseconds: 10)),
+      isNull,
+    );
+    expect(
+      update(tracker, delta: 10, timestamp: const Duration(milliseconds: 20)),
+      isFalse,
+    );
+    expect(
+      update(tracker, delta: -20, timestamp: const Duration(milliseconds: 30)),
+      isNull,
+    );
+    expect(
+      update(tracker, delta: -10, timestamp: const Duration(milliseconds: 40)),
+      isTrue,
+    );
+  });
+
+  test('fling policy expands immediately at the leading edge', () {
+    final tracker = const NavigationScrollWishPolicy.flingThreshold(
+      distanceFactor: 1.5,
+      velocityFactor: 1.5,
+    ).createTracker();
+
+    expect(
+      update(tracker, delta: 1, timestamp: Duration.zero, extentBefore: 0),
+      isTrue,
+    );
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,22 +76,24 @@ melos:
         dart run melos run format
     test:
       description: Run the root app and internal package test suites.
-      run: |
-        flutter test --reporter github
-        dart run melos exec \
-          --category=internal_packages \
-          --no-flutter \
-          --dir-exists=test \
-          --fail-fast \
-          --concurrency=1 \
-          -- "dart test --reporter github"
-        dart run melos exec \
-          --category=internal_packages \
-          --flutter \
-          --dir-exists=test \
-          --fail-fast \
-          --concurrency=1 \
-          -- "flutter test --reporter github"
+      steps:
+        - flutter test --reporter github
+        - >-
+          dart run melos exec \
+            --category=internal_packages \
+            --no-flutter \
+            --dir-exists=test \
+            --fail-fast \
+            --concurrency=1 \
+            -- "dart test --reporter github"
+        - >-
+          dart run melos exec \
+            --category=internal_packages \
+            --flutter \
+            --dir-exists=test \
+            --fail-fast \
+            --concurrency=1 \
+            -- "flutter test --reporter github"
     test-ci:
       description: |
         Run app and package test suites for CI with machine-readable results.

--- a/test/feature/habits_display/habit_display_page_test.dart
+++ b/test/feature/habits_display/habit_display_page_test.dart
@@ -427,6 +427,24 @@ Future<HabitSummaryViewModel> _pumpHabitsTabPage(
       .read<HabitSummaryViewModel>();
 }
 
+Future<void> _fastDirectDrag(
+  WidgetTester tester,
+  Finder finder, {
+  required double direction,
+}) async {
+  final gesture = await tester.startGesture(tester.getCenter(finder));
+  await gesture.moveBy(
+    Offset(0, 48 * direction),
+    timeStamp: const Duration(milliseconds: 16),
+  );
+  await tester.pump();
+  await gesture.moveBy(
+    Offset(0, 96 * direction),
+    timeStamp: const Duration(milliseconds: 32),
+  );
+  await gesture.cancel(timeStamp: const Duration(milliseconds: 48));
+}
+
 void main() {
   testWidgets('created habit updates the page-owned summary provider', (
     tester,
@@ -963,7 +981,7 @@ void main() {
     await tester.pump();
     expect(compactPrimaryAction, findsOneWidget);
 
-    await tester.drag(find.byType(CustomScrollView), const Offset(0, -300));
+    await _fastDirectDrag(tester, find.byType(CustomScrollView), direction: -1);
     await tester.pump(const Duration(milliseconds: 350));
 
     expect(
@@ -973,7 +991,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
     expect(tester.getSize(compactPrimaryAction), const Size.square(44));
 
-    await tester.drag(find.byType(CustomScrollView), const Offset(0, 100));
+    await _fastDirectDrag(tester, find.byType(CustomScrollView), direction: 1);
     await tester.pump(const Duration(milliseconds: 350));
 
     expect(
@@ -1012,14 +1030,14 @@ void main() {
       findsOneWidget,
     );
 
-    await tester.drag(find.byType(CustomScrollView), const Offset(0, -300));
+    await _fastDirectDrag(tester, find.byType(CustomScrollView), direction: -1);
     await tester.pump(const Duration(milliseconds: 350));
     expect(
       find.byKey(const ValueKey('cupertino-navigation-minimized')),
       findsOneWidget,
     );
 
-    await tester.drag(find.byType(CustomScrollView), const Offset(0, 150));
+    await _fastDirectDrag(tester, find.byType(CustomScrollView), direction: 1);
     await tester.pump(const Duration(milliseconds: 350));
     expect(
       find.byKey(const ValueKey('cupertino-navigation-expanded')),


### PR DESCRIPTION
## Summary

- Fix adaptive navigation visibility updates when scrolling through nested content.
- Centralize scroll wish handling in a reusable navigation policy.
- Expand adaptive navigation tests for scroll notifications and Apple navigation visibility.

## Testing

- [x] `adaptive_navigation_test.dart` and `navigation_scroll_wish_policy_test.dart` (71 tests)
- [x] `git diff main...HEAD --check`

## Notes

This keeps navigation behavior consistent across Material and Cupertino shells while avoiding redundant visibility updates.