### PR TITLE
Adopt Material 3 adaptive navigation layout

### DIFF
--- a/configs/flatpak_builder/io.github.friesi23.mhabit.yml
+++ b/configs/flatpak_builder/io.github.friesi23.mhabit.yml
@@ -50,6 +50,24 @@ modules:
         url: https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.6.tar.gz
         sha256: f93b6dd7ce796b13d02c108bc9f79812245a82e577581c4c9aabe57075c90ea2
 
+  # Bundle a deterministic CJK font. The app registers this OTF directly with
+  # Flutter at startup instead of relying only on Flatpak's fontconfig bridge.
+  - name: noto-sans-cjk
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 NotoSansCJKsc-Regular.otf /app/share/fonts/NotoSansCJKsc-Regular.otf
+      - install -Dm644 NotoSansCJK.LICENSE.txt /app/share/licenses/${FLATPAK_ID}/NotoSansCJK.LICENSE.txt
+      - fc-cache -f /app/share/fonts
+      - fc-match -f '%{file}\n' 'Noto Sans CJK SC' | grep -Fx /app/share/fonts/NotoSansCJKsc-Regular.otf
+    sources:
+      - type: file
+        url: https://cdn.jsdelivr.net/gh/notofonts/noto-cjk@Sans2.004/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf
+        sha256: 2c76254f6fc379fddfce0a7e84fb5385bb135d3e399294f6eeb6680d0365b74b
+      - type: file
+        url: https://cdn.jsdelivr.net/gh/notofonts/noto-cjk@Sans2.004/LICENSE
+        sha256: 6a73f9541c2de74158c0e7cf6b0a58ef774f5a780bf191f2d7ec9cc53efe2bf2
+        dest-filename: NotoSansCJK.LICENSE.txt
+
   - name: mhabit
     buildsystem: simple
     build-options:

--- a/lib/entries/app/entry.dart
+++ b/lib/entries/app/entry.dart
@@ -287,6 +287,10 @@ class _AppEntryState extends State<_AppEntry> {
               .select<AppDeveloperViewModel, AdaptiveStyle?>(
                 (vm) => vm.adaptiveStyleOverride,
               );
+          final textDirectionOverride = context
+              .select<AppDeveloperViewModel, TextDirection?>(
+                (vm) => vm.textDirectionOverride,
+              );
           return AdaptiveStyleScope(
             override: adaptiveStyleOverride,
             child: MultiProvider(
@@ -299,6 +303,7 @@ class _AppEntryState extends State<_AppEntry> {
                 themeMode: transToMaterialThemeType(themeMode),
                 language: language,
                 disableAnimations: disableAnimations,
+                textDirectionOverride: textDirectionOverride,
                 lightThemeBuilder: () => const AppThemeBuilder().buildLight(
                   themeColor: themeColor,
                   themeMainColor: themeMainColor,

--- a/lib/entries/common/app_root_view.dart
+++ b/lib/entries/common/app_root_view.dart
@@ -30,6 +30,7 @@ class AppRootView extends StatelessWidget {
   final ThemeData Function()? lightThemeBuilder;
   final ThemeData Function()? darkThemeBuilder;
   final bool disableAnimations;
+  final TextDirection? textDirectionOverride;
 
   const AppRootView({
     super.key,
@@ -39,6 +40,7 @@ class AppRootView extends StatelessWidget {
     this.darkThemeBuilder,
     this.child,
     this.disableAnimations = false,
+    this.textDirectionOverride,
   }) : routerConfig = null;
 
   const AppRootView.router({
@@ -49,6 +51,7 @@ class AppRootView extends StatelessWidget {
     this.darkThemeBuilder,
     required GoRouter config,
     this.disableAnimations = false,
+    this.textDirectionOverride,
   }) : child = null,
        routerConfig = config;
 
@@ -60,20 +63,27 @@ class AppRootView extends StatelessWidget {
     this.darkThemeBuilder,
     this.child,
     this.disableAnimations = false,
+    this.textDirectionOverride,
   }) : routerConfig = null;
 
   bool get _useRouter => routerConfig != null;
 
-  Widget _builder(BuildContext context, Widget? child) => MediaQuery(
-    data: MediaQuery.of(context).copyWith(
-      disableAnimations:
-          disableAnimations || MediaQuery.disableAnimationsOf(context),
-    ),
-    child: AdaptiveWindowControlLayout(
-      usesRectangularDisplay: AppInfo().usesRectangularIPhoneDisplay,
-      child: UnfocusOnTap(child: child),
-    ),
-  );
+  Widget _builder(BuildContext context, Widget? child) {
+    final content = MediaQuery(
+      data: MediaQuery.of(context).copyWith(
+        disableAnimations:
+            disableAnimations || MediaQuery.disableAnimationsOf(context),
+      ),
+      child: AdaptiveWindowControlLayout(
+        usesRectangularDisplay: AppInfo().usesRectangularIPhoneDisplay,
+        child: UnfocusOnTap(child: child),
+      ),
+    );
+    final textDirection = textDirectionOverride;
+    return textDirection == null
+        ? content
+        : Directionality(textDirection: textDirection, child: content);
+  }
 
   String _onGenerateTitle(BuildContext context) =>
       L10n.of(context)?.appName ?? appName;

--- a/lib/extensions/adaptive_style_extensions.dart
+++ b/lib/extensions/adaptive_style_extensions.dart
@@ -2,7 +2,7 @@ import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 
 extension AppAdaptiveStyle on AdaptiveStyle {
   static const double materialToolbarHeight = 64.0;
-  static const double appleToolbarHeight = 52.0;
+  static const double appleToolbarHeight = 44.0;
 
   double get appToolbarHeight => switch (this) {
     AdaptiveStyle.material => materialToolbarHeight,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'common/app_info.dart';
 import 'entries/app/entry.dart';
 import 'logging/logger_manager.dart';
 import 'reminders/notification_service.dart';
+import 'theme/linux_bundled_font.dart';
 import 'utils/local_timezone.dart';
 import 'widgets/bingding.dart';
 
@@ -31,6 +32,7 @@ Future<void> main() async {
     WidgetsFlutterBinding.ensureInitialized();
   }
 
+  await loadLinuxBundledFont();
   await AppLoggerMananger(t: AppLoggerHandlerType.debugging).init();
   await AppInfo().init();
   await NotificationService().init();

--- a/lib/pages/app_settings/_widgets/app_setting_develop_subgroup.dart
+++ b/lib/pages/app_settings/_widgets/app_setting_develop_subgroup.dart
@@ -20,8 +20,10 @@ class AppSettingDevelopSubGroup extends StatelessWidget {
   final bool isInDevelopMode;
   final bool isDisplayDebugMenuSelect;
   final AppAdaptiveStyleMode adaptiveStyleMode;
+  final TextDirection? textDirectionOverride;
   final ValueChanged<bool>? onDisplayDebugMenuSelectChanged;
   final ValueChanged<AppAdaptiveStyleMode>? onAdaptiveStyleModeChanged;
+  final ValueChanged<TextDirection?>? onTextDirectionOverrideChanged;
   final void Function(BuildContext context)? onExportDBTilePressed;
   final void Function(BuildContext context)? onClearDBTilePressed;
 
@@ -30,8 +32,10 @@ class AppSettingDevelopSubGroup extends StatelessWidget {
     this.isInDevelopMode = false,
     this.isDisplayDebugMenuSelect = false,
     this.adaptiveStyleMode = AppAdaptiveStyleMode.automatic,
+    this.textDirectionOverride,
     this.onDisplayDebugMenuSelectChanged,
     this.onAdaptiveStyleModeChanged,
+    this.onTextDirectionOverrideChanged,
     this.onExportDBTilePressed,
     this.onClearDBTilePressed,
   });
@@ -45,6 +49,14 @@ class AppSettingDevelopSubGroup extends StatelessWidget {
     ];
     final selectedStyleLabel = adaptiveStyleOptions
         .firstWhere((option) => option.value == adaptiveStyleMode)
+        .label;
+    const List<({TextDirection? value, String label})> textDirectionOptions = [
+      (value: null, label: 'Auto'),
+      (value: TextDirection.ltr, label: 'LTR'),
+      (value: TextDirection.rtl, label: 'RTL'),
+    ];
+    final selectedTextDirectionLabel = textDirectionOptions
+        .firstWhere((option) => option.value == textDirectionOverride)
         .label;
 
     return ExpandedSection(
@@ -83,6 +95,35 @@ class AppSettingDevelopSubGroup extends StatelessWidget {
                 iconAlignment: IconAlignment.end,
                 icon: const Icon(Icons.arrow_drop_down),
                 label: Text(selectedStyleLabel),
+              ),
+            ),
+          ),
+          ListTile(
+            title: const Text('Text direction'),
+            trailing: MenuAnchor(
+              menuChildren: [
+                for (final option in textDirectionOptions)
+                  MenuItemButton(
+                    leadingIcon: Opacity(
+                      opacity: option.value == textDirectionOverride ? 1 : 0,
+                      child: const Icon(Icons.check),
+                    ),
+                    onPressed: onTextDirectionOverrideChanged == null
+                        ? null
+                        : () => onTextDirectionOverrideChanged!(option.value),
+                    child: Text(option.label),
+                  ),
+              ],
+              builder: (context, controller, child) => TextButton.icon(
+                key: const ValueKey('developer-text-direction-control'),
+                onPressed: onTextDirectionOverrideChanged == null
+                    ? null
+                    : () => controller.isOpen
+                          ? controller.close()
+                          : controller.open(),
+                iconAlignment: IconAlignment.end,
+                icon: const Icon(Icons.arrow_drop_down),
+                label: Text(selectedTextDirectionLabel),
               ),
             ),
           ),

--- a/lib/pages/app_settings/page.dart
+++ b/lib/pages/app_settings/page.dart
@@ -463,6 +463,11 @@ class _PageState extends State<_Page> with XShare {
     context.read<AppDeveloperViewModel>().setAdaptiveStyleMode(value);
   }
 
+  void _onTextDirectionOverrideChanged(TextDirection? value) {
+    if (!mounted) return;
+    context.read<AppDeveloperViewModel>().setTextDirectionOverride(value);
+  }
+
   void _onExportDBTilePressed(BuildContext context) async {
     if (!context.mounted) return;
     final dbPath = path.join(
@@ -906,16 +911,25 @@ class _PageState extends State<_Page> with XShare {
     ];
 
     Widget buildDevelopSubGroup(BuildContext context) =>
-        Selector<AppDeveloperViewModel, (bool, bool, AppAdaptiveStyleMode)>(
-          selector: (context, vm) =>
-              (vm.isInDevelopMode, vm.displayDebugMenu, vm.adaptiveStyleMode),
+        Selector<
+          AppDeveloperViewModel,
+          (bool, bool, AppAdaptiveStyleMode, TextDirection?)
+        >(
+          selector: (context, vm) => (
+            vm.isInDevelopMode,
+            vm.displayDebugMenu,
+            vm.adaptiveStyleMode,
+            vm.textDirectionOverride,
+          ),
           shouldRebuild: (previous, next) => previous != next,
           builder: (context, value, child) => AppSettingDevelopSubGroup(
             isInDevelopMode: value.$1,
             isDisplayDebugMenuSelect: value.$2,
             adaptiveStyleMode: value.$3,
+            textDirectionOverride: value.$4,
             onDisplayDebugMenuSelectChanged: _onDisplayDebugMenuSelectChanged,
             onAdaptiveStyleModeChanged: _onAdaptiveStyleModeChanged,
+            onTextDirectionOverrideChanged: _onTextDirectionOverrideChanged,
             onExportDBTilePressed: _onExportDBTilePressed,
             onClearDBTilePressed: _onClearDBTilePressed,
           ),

--- a/lib/pages/habits_display/_widgets/habit_display_appbar.dart
+++ b/lib/pages/habits_display/_widgets/habit_display_appbar.dart
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:flutter/cupertino.dart' show CupertinoNavigationBar;
+import 'package:flutter/cupertino.dart'
+    show CupertinoColors, CupertinoNavigationBar;
 import 'package:flutter/material.dart';
 import 'package:linked_scroll_controller/linked_scroll_controller.dart';
 import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
@@ -313,6 +314,8 @@ class _AppleCalendarBar extends StatelessWidget {
             child: const CupertinoNavigationBar(
               automaticallyImplyLeading: false,
               transitionBetweenRoutes: false,
+              automaticBackgroundVisibility: false,
+              backgroundColor: CupertinoColors.transparent,
               border: null,
             ),
           ),

--- a/lib/pages/habits_display/page_today.dart
+++ b/lib/pages/habits_display/page_today.dart
@@ -169,15 +169,22 @@ class _Appbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = L10n.of(context);
+    final useLargeTitle =
+        WindowSize.of(context).width == WindowSizeClass.compact;
+    final pageBackground = Theme.of(context).colorScheme.surface;
     return AdaptiveSliverAppBar(
       height: toolbarHeight,
-      styles: const AppBarStyles(
-        material: AppBarMaterialStyle(
+      styles: AppBarStyles(
+        material: const AppBarMaterialStyle(
           floating: false,
           snap: false,
           pinned: false,
         ),
-        apple: AppBarAppleStyle(collapsible: true),
+        apple: AppBarAppleStyle(
+          collapsible: useLargeTitle,
+          automaticBackgroundVisibility: false,
+          backgroundColor: pageBackground.withValues(alpha: 0.82),
+        ),
       ),
       title: Text(l10n?.habitToday_appBar_title ?? "Today"),
       actions: const [AppThemeSwitchButton()],

--- a/lib/providers/app_ui/app_developer.dart
+++ b/lib/providers/app_ui/app_developer.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart' show TextDirection;
 import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 
 import '../../models/app_adaptive_style_mode.dart';
@@ -23,6 +24,7 @@ import '../support/global.dart';
 class AppDeveloperViewModel extends ChangeNotifier
     with GlobalLoadedMixin, ProfileHandlerLoadedMixin {
   AdaptiveStyleOverrideProfileHandler? _adaptiveStyleOverride;
+  TextDirection? _textDirectionOverride;
 
   AppDeveloperViewModel({required Global global, ProfileViewModel? profile}) {
     updateGlobal(global);
@@ -67,9 +69,17 @@ class AppDeveloperViewModel extends ChangeNotifier
     AppAdaptiveStyleMode.apple => AdaptiveStyle.apple,
   };
 
+  TextDirection? get textDirectionOverride => _textDirectionOverride;
+
   Future<void> setAdaptiveStyleMode(AppAdaptiveStyleMode mode) async {
     if (adaptiveStyleMode == mode) return;
     await _adaptiveStyleOverride?.set(mode);
+    notifyListeners();
+  }
+
+  void setTextDirectionOverride(TextDirection? textDirection) {
+    if (_textDirectionOverride == textDirection) return;
+    _textDirectionOverride = textDirection;
     notifyListeners();
   }
 }

--- a/lib/theme/app_theme_builder.dart
+++ b/lib/theme/app_theme_builder.dart
@@ -25,6 +25,8 @@ import '../widgets/_widgets/predictive_back_page_transitions_builder.dart';
 import '../widgets/styles.dart';
 import 'color.dart';
 
+// Tuned from composited iOS 26 native navigation screenshots. Apple does not
+// publish equivalent Liquid Glass alpha constants for custom Flutter chrome.
 const _appleGlassBackgroundColor = CupertinoDynamicColor.withBrightness(
   debugLabel: 'mhabitAppleGlassBackground',
   color: Color(0xCCFFFFFF),

--- a/lib/theme/app_theme_builder.dart
+++ b/lib/theme/app_theme_builder.dart
@@ -102,7 +102,7 @@ class AppThemeBuilder {
             barBackgroundColor: _appleGlassBackgroundColor,
             scaffoldBackgroundColor: colorScheme.surface,
           );
-    return ThemeData(
+    final theme = ThemeData(
       fontFamily: getFontFamily(),
       fontFamilyFallback: getFontFamilyFallbacks(),
       pageTransitionsTheme: pageTransitionsTheme,
@@ -116,6 +116,12 @@ class AppThemeBuilder {
       menuTheme: _mobileMenuTheme,
       cupertinoOverrideTheme: cupertinoOverrideTheme,
       extensions: [customColor],
+    );
+    return theme.copyWith(
+      navigationRailTheme: theme.navigationRailTheme.copyWith(
+        backgroundColor: theme.colorScheme.surfaceContainer,
+        elevation: 1.0,
+      ),
     );
   }
 

--- a/lib/theme/app_theme_builder.dart
+++ b/lib/theme/app_theme_builder.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/cupertino.dart'
-    show CupertinoDynamicColor, CupertinoThemeData;
+    show CupertinoDynamicColor, CupertinoTextThemeData, CupertinoThemeData;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -24,6 +24,7 @@ import '../models/app_theme_color.dart';
 import '../widgets/_widgets/predictive_back_page_transitions_builder.dart';
 import '../widgets/styles.dart';
 import 'color.dart';
+import 'linux_bundled_font.dart';
 
 // Tuned from composited iOS 26 native navigation screenshots. Apple does not
 // publish equivalent Liquid Glass alpha constants for custom Flutter chrome.
@@ -32,6 +33,20 @@ const _appleGlassBackgroundColor = CupertinoDynamicColor.withBrightness(
   color: Color(0xCCFFFFFF),
   darkColor: Color(0x0FFFFFFF),
 );
+
+const _linuxFontFamilyFallbacks = [
+  'Ubuntu',
+  'Adwaita Sans',
+  'Cantarell',
+  'DejaVu Sans',
+  'Liberation Sans',
+  'Arial',
+  'Noto Color Emoji',
+  'Noto Sans CJK SC',
+  'Noto Sans CJK TC',
+  'Noto Sans CJK JP',
+  'Noto Sans CJK KR',
+];
 
 /// Assembles the app [ThemeData] from the resolved theme-color inputs.
 ///
@@ -94,17 +109,7 @@ class AppThemeBuilder {
     final colorScheme = mainColor != null
         ? ColorScheme.fromSeed(seedColor: mainColor, brightness: brightness)
         : systemScheme;
-    // Maps the app scheme onto Cupertino components so apple variants follow
-    // the app's dynamic color instead of the Cupertino default blue.
-    final cupertinoOverrideTheme = colorScheme == null
-        ? null
-        : CupertinoThemeData(
-            brightness: colorScheme.brightness,
-            primaryColor: colorScheme.primary,
-            barBackgroundColor: _appleGlassBackgroundColor,
-            scaffoldBackgroundColor: colorScheme.surface,
-          );
-    final theme = ThemeData(
+    final baseTheme = ThemeData(
       fontFamily: getFontFamily(),
       fontFamilyFallback: getFontFamilyFallbacks(),
       pageTransitionsTheme: pageTransitionsTheme,
@@ -116,8 +121,28 @@ class AppThemeBuilder {
         behavior: SnackBarBehavior.floating,
       ),
       menuTheme: _mobileMenuTheme,
-      cupertinoOverrideTheme: cupertinoOverrideTheme,
       extensions: [customColor],
+    );
+    final cupertinoTextTheme = _getCupertinoTextTheme(
+      primaryColor: baseTheme.colorScheme.primary,
+    );
+    // Maps the app scheme onto Cupertino components so apple variants follow
+    // the app's dynamic color instead of the Cupertino default blue. Linux
+    // also keeps a text-only override when using the system Material scheme.
+    final cupertinoOverrideTheme =
+        colorScheme == null && cupertinoTextTheme == null
+        ? null
+        : CupertinoThemeData(
+            brightness: colorScheme?.brightness,
+            primaryColor: colorScheme?.primary,
+            textTheme: cupertinoTextTheme,
+            barBackgroundColor: colorScheme == null
+                ? null
+                : _appleGlassBackgroundColor,
+            scaffoldBackgroundColor: colorScheme?.surface,
+          );
+    final theme = baseTheme.copyWith(
+      cupertinoOverrideTheme: cupertinoOverrideTheme,
     );
     return theme.copyWith(
       navigationRailTheme: theme.navigationRailTheme.copyWith(
@@ -128,40 +153,41 @@ class AppThemeBuilder {
   }
 
   String? getFontFamily() {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.linux:
-        final arch = AppInfo().linuxArchitecture;
-        return switch (arch) {
-          LinuxPlatformArchitecture.aarch64 => 'Roboto',
-          _ => null,
-        };
-      default:
-        return null;
-    }
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.linux => linuxBundledFontFamily,
+      _ => null,
+    };
   }
 
   List<String>? getFontFamilyFallbacks() {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.linux:
-        final arch = AppInfo().linuxArchitecture;
-        return switch (arch) {
-          LinuxPlatformArchitecture.aarch64 => const [
-            'Ubuntu',
-            'Cantarell',
-            'DejaVu Sans',
-            'Liberation Sans',
-            'Arial',
-            'Noto Color Emoji',
-            'Noto Sans CJK SC',
-            'Noto Sans CJK TC',
-            'Noto Sans CJK JP',
-            'Noto Sans CJK KR',
-          ],
-          _ => null,
-        };
-      default:
-        return null;
-    }
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.linux => _linuxFontFamilyFallbacks,
+      _ => null,
+    };
+  }
+
+  CupertinoTextThemeData? _getCupertinoTextTheme({Color? primaryColor}) {
+    if (defaultTargetPlatform != TargetPlatform.linux) return null;
+
+    final defaults = CupertinoTextThemeData(
+      primaryColor: primaryColor ?? const CupertinoThemeData().primaryColor,
+    );
+    TextStyle withLinuxFonts(TextStyle style) => style.copyWith(
+      fontFamily: linuxBundledFontFamily,
+      fontFamilyFallback: _linuxFontFamilyFallbacks,
+    );
+
+    return defaults.copyWith(
+      textStyle: withLinuxFonts(defaults.textStyle),
+      actionTextStyle: withLinuxFonts(defaults.actionTextStyle),
+      actionSmallTextStyle: withLinuxFonts(defaults.actionSmallTextStyle),
+      tabLabelTextStyle: withLinuxFonts(defaults.tabLabelTextStyle),
+      navTitleTextStyle: withLinuxFonts(defaults.navTitleTextStyle),
+      navLargeTitleTextStyle: withLinuxFonts(defaults.navLargeTitleTextStyle),
+      navActionTextStyle: withLinuxFonts(defaults.navActionTextStyle),
+      pickerTextStyle: withLinuxFonts(defaults.pickerTextStyle),
+      dateTimePickerTextStyle: withLinuxFonts(defaults.dateTimePickerTextStyle),
+    );
   }
 
   static MenuThemeData? get _mobileMenuTheme => switch (defaultTargetPlatform) {

--- a/lib/theme/app_theme_builder.dart
+++ b/lib/theme/app_theme_builder.dart
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:flutter/cupertino.dart' show CupertinoThemeData;
+import 'package:flutter/cupertino.dart'
+    show CupertinoDynamicColor, CupertinoThemeData;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -23,6 +24,12 @@ import '../models/app_theme_color.dart';
 import '../widgets/_widgets/predictive_back_page_transitions_builder.dart';
 import '../widgets/styles.dart';
 import 'color.dart';
+
+const _appleGlassBackgroundColor = CupertinoDynamicColor.withBrightness(
+  debugLabel: 'mhabitAppleGlassBackground',
+  color: Color(0xCCFFFFFF),
+  darkColor: Color(0x0FFFFFFF),
+);
 
 /// Assembles the app [ThemeData] from the resolved theme-color inputs.
 ///
@@ -92,11 +99,7 @@ class AppThemeBuilder {
         : CupertinoThemeData(
             brightness: colorScheme.brightness,
             primaryColor: colorScheme.primary,
-            barBackgroundColor:
-                (colorScheme.brightness == Brightness.dark
-                        ? colorScheme.surfaceContainerHigh
-                        : colorScheme.surface)
-                    .withValues(alpha: 0.8),
+            barBackgroundColor: _appleGlassBackgroundColor,
             scaffoldBackgroundColor: colorScheme.surface,
           );
     return ThemeData(

--- a/lib/theme/linux_bundled_font.dart
+++ b/lib/theme/linux_bundled_font.dart
@@ -1,0 +1,52 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+import 'dart:ui' show loadFontFromList;
+
+import 'package:flutter/foundation.dart';
+
+const linuxBundledFontFamily = 'mhabit Noto Sans CJK SC';
+const linuxBundledFontPath = '/app/share/fonts/NotoSansCJKsc-Regular.otf';
+
+typedef LinuxFontRegistrar =
+    Future<void> Function(Uint8List bytes, String family);
+
+/// Registers the Flatpak-bundled font directly with Flutter's font collection.
+///
+/// Flutter's Linux system font manager does not reliably discover app fonts in
+/// every Flatpak environment. Registering the OTF before starting the widget
+/// tree makes the family deterministic while leaving non-Flatpak Linux builds
+/// unchanged when the file is absent.
+Future<bool> loadLinuxBundledFont({
+  TargetPlatform? platform,
+  String path = linuxBundledFontPath,
+  Future<bool> Function(String path)? fileExists,
+  Future<Uint8List> Function(String path)? readFile,
+  LinuxFontRegistrar? registerFont,
+}) async {
+  if ((platform ?? defaultTargetPlatform) != TargetPlatform.linux) return false;
+
+  final exists = fileExists ?? (String path) => File(path).exists();
+  if (!await exists(path)) return false;
+
+  final read = readFile ?? (String path) => File(path).readAsBytes();
+  final register = registerFont ?? _registerFont;
+  await register(await read(path), linuxBundledFontFamily);
+  return true;
+}
+
+Future<void> _registerFont(Uint8List bytes, String family) {
+  return loadFontFromList(bytes, fontFamily: family);
+}

--- a/packages/mhabit_adaptive_ui/lib/src/adaptive/adaptive_sliver_app_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/adaptive/adaptive_sliver_app_bar.dart
@@ -98,6 +98,7 @@ class AppBarAppleStyle {
     this.enableBackgroundFilterBlur = true,
     this.border,
     this.backgroundColor,
+    this.automaticBackgroundVisibility = true,
     this.padding,
     this.stretch = false,
     this.windowControlEdgePadding = cupertinoWindowControlEdgePadding,
@@ -107,6 +108,7 @@ class AppBarAppleStyle {
   final bool enableBackgroundFilterBlur;
   final Border? border;
   final Color? backgroundColor;
+  final bool automaticBackgroundVisibility;
   final EdgeInsetsDirectional? padding;
   final bool stretch;
 
@@ -118,6 +120,7 @@ class AppBarAppleStyle {
     bool? enableBackgroundFilterBlur,
     Border? border,
     Color? backgroundColor,
+    bool? automaticBackgroundVisibility,
     EdgeInsetsDirectional? padding,
     bool? stretch,
     EdgeInsetsDirectional? windowControlEdgePadding,
@@ -127,6 +130,8 @@ class AppBarAppleStyle {
         enableBackgroundFilterBlur ?? this.enableBackgroundFilterBlur,
     border: border ?? this.border,
     backgroundColor: backgroundColor ?? this.backgroundColor,
+    automaticBackgroundVisibility:
+        automaticBackgroundVisibility ?? this.automaticBackgroundVisibility,
     padding: padding ?? this.padding,
     stretch: stretch ?? this.stretch,
     windowControlEdgePadding:
@@ -140,6 +145,7 @@ class AppBarAppleStyle {
       other.enableBackgroundFilterBlur == enableBackgroundFilterBlur &&
       other.border == border &&
       other.backgroundColor == backgroundColor &&
+      other.automaticBackgroundVisibility == automaticBackgroundVisibility &&
       other.padding == padding &&
       other.stretch == stretch &&
       other.windowControlEdgePadding == windowControlEdgePadding;
@@ -150,6 +156,7 @@ class AppBarAppleStyle {
     enableBackgroundFilterBlur,
     border,
     backgroundColor,
+    automaticBackgroundVisibility,
     padding,
     stretch,
     windowControlEdgePadding,
@@ -286,6 +293,7 @@ class AdaptiveSliverAppBar extends StatelessWidget {
     enableBackgroundFilterBlur: config.enableBackgroundFilterBlur,
     border: config.border,
     backgroundColor: config.backgroundColor,
+    automaticBackgroundVisibility: config.automaticBackgroundVisibility,
     padding: config.padding,
     stretch: config.stretch,
     windowControlEdgePadding: config.windowControlEdgePadding,

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_adaptive_navigation_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_adaptive_navigation_bar.dart
@@ -435,11 +435,11 @@ class _NavigationSurfaceContentState extends State<_NavigationSurfaceContent> {
     final activeColor = CupertinoDynamicColor.resolve(
       theme.primaryColor,
       context,
-    );
+    ).withValues(alpha: 1);
     final inactiveColor = CupertinoDynamicColor.resolve(
-      CupertinoColors.inactiveGray,
+      CupertinoColors.label,
       context,
-    );
+    ).withValues(alpha: 1);
     final destinationExtent =
         widget.expandedNavigationWidth / widget.destinations.length;
 

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_shell.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_shell.dart
@@ -19,17 +19,15 @@ import 'cupertino_navigation_sidebar.dart';
 /// ```text
 /// compact          constrained side  expanded side
 /// +----------+     +------------+    +------+-------+
-/// | content  |     |  overlay   |    | side |content|
-/// +----------+     |  Sidebar   |    | bar  |       |
-/// | Tab Bar  |     +------------+    |      |       |
-/// +----------+                       +------+-------+
+/// | content  |     | side |body |    | side |content|
+/// +----------+     | bar  |     |    | bar  |       |
+/// | Tab Bar  |     |      |     |    |      |       |
+/// +----------+     +------+-----+    +------+-------+
 /// ```
 ///
-/// The side-form diagrams show the target Cupertino presentation. The
-/// compatibility rail preserves current behavior until the Sidebar renderer
-/// replaces it. In compact form, route and contextual state control visibility
-/// while scroll direction selects the expanded or minimized Tab Bar
-/// presentation.
+/// Medium and larger widths use the same hideable beside presentation. In
+/// compact form, route and contextual state control visibility while scroll
+/// direction selects the expanded or minimized Tab Bar presentation.
 class CupertinoNavigationShell extends StatelessWidget {
   /// Creates Cupertino navigation chrome around [child].
   const CupertinoNavigationShell({
@@ -43,6 +41,8 @@ class CupertinoNavigationShell extends StatelessWidget {
     required this.primaryAction,
     required this.railExtent,
     required this.appleBarStyle,
+    this.expandNavigationLabel,
+    this.collapseNavigationLabel,
   });
 
   /// Content displayed beside or underneath the navigation chrome.
@@ -66,11 +66,21 @@ class CupertinoNavigationShell extends StatelessWidget {
   /// App-selected primary action for the active branch.
   final CupertinoNavigationPrimaryAction? primaryAction;
 
-  /// Full-width policy shared by the compatibility rail and future sidebar.
+  /// Full-width policy used by the Sidebar panel.
   final NavigationRailExtent railExtent;
 
   /// Geometry and spacing for the compact Apple navigation bar.
   final AppleNavigationBarStyle appleBarStyle;
+
+  /// Localized action label used when the Sidebar can be shown.
+  ///
+  /// Defaults to the closest available Flutter localization.
+  final String? expandNavigationLabel;
+
+  /// Localized action label used when the Sidebar can be hidden.
+  ///
+  /// Defaults to the closest available Flutter localization.
+  final String? collapseNavigationLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -99,12 +109,14 @@ class CupertinoNavigationShell extends StatelessWidget {
           : navigationShellAnimationDuration,
       formResolver: _resolveCupertinoNavigationShellForm,
       bodyBuilder: (context, form, onSelected, child) =>
-          CupertinoNavigationSidebarCompatibility(
+          CupertinoNavigationSidebar(
             form: form,
             selectedIndex: selectedIndex,
             destinations: destinations,
             onDestinationSelected: onSelected,
             railExtent: railExtent,
+            expandNavigationLabel: expandNavigationLabel,
+            collapseNavigationLabel: collapseNavigationLabel,
             child: child,
           ),
       windowControlOwnerResolver: _resolveCupertinoWindowControlOwner,

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_shell.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_shell.dart
@@ -46,6 +46,23 @@ class CupertinoNavigationShell extends StatelessWidget {
     this.collapseNavigationLabel,
   });
 
+  NavigationShellForm _resolveForm(WindowSize windowSize) =>
+      switch (windowSize.width) {
+        WindowSizeClass.compact => NavigationShellForm.compact,
+        WindowSizeClass.medium => NavigationShellForm.constrainedSide,
+        WindowSizeClass.expanded ||
+        WindowSizeClass.large ||
+        WindowSizeClass.extraLarge => NavigationShellForm.expandedSide,
+      };
+
+  WindowControlLayoutOwner _resolveWindowControlOwner(
+    NavigationShellForm form,
+  ) => switch (form) {
+    NavigationShellForm.compact => WindowControlLayoutOwner.appBar,
+    NavigationShellForm.constrainedSide ||
+    NavigationShellForm.expandedSide => WindowControlLayoutOwner.sideNavigation,
+  };
+
   /// Content displayed beside or underneath the navigation chrome.
   final Widget child;
 
@@ -111,7 +128,7 @@ class CupertinoNavigationShell extends StatelessWidget {
       switchDuration: disableAnimations
           ? Duration.zero
           : navigationShellAnimationDuration,
-      formResolver: _resolveCupertinoNavigationShellForm,
+      formResolver: _resolveForm,
       bodyBuilder: (context, form, onSelected, child) =>
           CupertinoNavigationSidebar(
             form: form,
@@ -124,7 +141,7 @@ class CupertinoNavigationShell extends StatelessWidget {
             collapseNavigationLabel: collapseNavigationLabel,
             child: child,
           ),
-      windowControlOwnerResolver: _resolveCupertinoWindowControlOwner,
+      windowControlOwnerResolver: _resolveWindowControlOwner,
       compactNavigationBuilder: _buildCompactNavigation,
       floatingActionButtonBuilder: (context, state) =>
           CupertinoNavigationPrimaryActionHost(
@@ -170,21 +187,3 @@ class CupertinoNavigationShell extends StatelessWidget {
     );
   }
 }
-
-NavigationShellForm _resolveCupertinoNavigationShellForm(
-  WindowSize windowSize,
-) => switch (windowSize.width) {
-  WindowSizeClass.compact => NavigationShellForm.compact,
-  WindowSizeClass.medium => NavigationShellForm.constrainedSide,
-  WindowSizeClass.expanded ||
-  WindowSizeClass.large ||
-  WindowSizeClass.extraLarge => NavigationShellForm.expandedSide,
-};
-
-WindowControlLayoutOwner _resolveCupertinoWindowControlOwner(
-  NavigationShellForm form,
-) => switch (form) {
-  NavigationShellForm.compact => WindowControlLayoutOwner.appBar,
-  NavigationShellForm.constrainedSide ||
-  NavigationShellForm.expandedSide => WindowControlLayoutOwner.sideNavigation,
-};

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_shell.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_shell.dart
@@ -1,15 +1,35 @@
 import 'package:flutter/cupertino.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
+import '../breakpoints/window_size_class.dart';
 import '../material/material_navigation_rail.dart' show NavigationRailExtent;
 import '../shell/navigation_scroll_wish_policy.dart';
 import '../shell/navigation_shell_frame.dart';
+import '../window_control/window_control_layout.dart';
 import 'cupertino_adaptive_navigation_bar.dart';
 import 'cupertino_floating_surface.dart';
 import 'cupertino_navigation_primary_action.dart';
 import 'cupertino_navigation_sidebar.dart';
 
 /// Composes the Cupertino renderers around style-neutral shell mechanics.
+///
+/// Forms are resolved only from Apple width classes; compact height never
+/// downgrades a wider window to constrained side navigation.
+///
+/// ```text
+/// compact          constrained side  expanded side
+/// +----------+     +------------+    +------+-------+
+/// | content  |     |  overlay   |    | side |content|
+/// +----------+     |  Sidebar   |    | bar  |       |
+/// | Tab Bar  |     +------------+    |      |       |
+/// +----------+                       +------+-------+
+/// ```
+///
+/// The side-form diagrams show the target Cupertino presentation. The
+/// compatibility rail preserves current behavior until the Sidebar renderer
+/// replaces it. In compact form, route and contextual state control visibility
+/// while scroll direction selects the expanded or minimized Tab Bar
+/// presentation.
 class CupertinoNavigationShell extends StatelessWidget {
   /// Creates Cupertino navigation chrome around [child].
   const CupertinoNavigationShell({
@@ -46,7 +66,7 @@ class CupertinoNavigationShell extends StatelessWidget {
   /// App-selected primary action for the active branch.
   final CupertinoNavigationPrimaryAction? primaryAction;
 
-  /// Width policy used by the temporary medium-and-wider rail renderer.
+  /// Full-width policy shared by the compatibility rail and future sidebar.
   final NavigationRailExtent railExtent;
 
   /// Geometry and spacing for the compact Apple navigation bar.
@@ -61,7 +81,6 @@ class CupertinoNavigationShell extends StatelessWidget {
     );
     return NavigationShellFrame(
       selectedIndex: selectedIndex,
-      destinations: destinations,
       onDestinationSelected: onDestinationSelected,
       compactRouteVisible: compactRouteVisible,
       contextualChromeSuppressed: contextualChromeSuppressed,
@@ -78,14 +97,17 @@ class CupertinoNavigationShell extends StatelessWidget {
       switchDuration: disableAnimations
           ? Duration.zero
           : navigationShellAnimationDuration,
-      leadingBuilder: (context, form, onSelected) =>
+      formResolver: _resolveCupertinoNavigationShellForm,
+      bodyBuilder: (context, form, onSelected, child) =>
           CupertinoNavigationSidebarCompatibility(
             form: form,
             selectedIndex: selectedIndex,
             destinations: destinations,
             onDestinationSelected: onSelected,
             railExtent: railExtent,
+            child: child,
           ),
+      windowControlOwnerResolver: _resolveCupertinoWindowControlOwner,
       compactNavigationBuilder: _buildCompactNavigation,
       floatingActionButtonBuilder: (context, state) =>
           CupertinoNavigationPrimaryActionHost(
@@ -131,3 +153,21 @@ class CupertinoNavigationShell extends StatelessWidget {
     );
   }
 }
+
+NavigationShellForm _resolveCupertinoNavigationShellForm(
+  WindowSize windowSize,
+) => switch (windowSize.width) {
+  WindowSizeClass.compact => NavigationShellForm.compact,
+  WindowSizeClass.medium => NavigationShellForm.constrainedSide,
+  WindowSizeClass.expanded ||
+  WindowSizeClass.large ||
+  WindowSizeClass.extraLarge => NavigationShellForm.expandedSide,
+};
+
+WindowControlLayoutOwner _resolveCupertinoWindowControlOwner(
+  NavigationShellForm form,
+) => switch (form) {
+  NavigationShellForm.compact => WindowControlLayoutOwner.appBar,
+  NavigationShellForm.constrainedSide ||
+  NavigationShellForm.expandedSide => WindowControlLayoutOwner.sideNavigation,
+};

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_shell.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_shell.dart
@@ -2,9 +2,9 @@ import 'package:flutter/cupertino.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
 import '../breakpoints/window_size_class.dart';
-import '../material/material_navigation_rail.dart' show NavigationRailExtent;
 import '../shell/navigation_scroll_wish_policy.dart';
 import '../shell/navigation_shell_frame.dart';
+import '../shell/side_navigation.dart';
 import '../window_control/window_control_layout.dart';
 import 'cupertino_adaptive_navigation_bar.dart';
 import 'cupertino_floating_surface.dart';
@@ -39,7 +39,8 @@ class CupertinoNavigationShell extends StatelessWidget {
     required this.compactRouteVisible,
     required this.contextualChromeSuppressed,
     required this.primaryAction,
-    required this.railExtent,
+    required this.sideNavigationExtent,
+    required this.dragHandleBuilder,
     required this.appleBarStyle,
     this.expandNavigationLabel,
     this.collapseNavigationLabel,
@@ -67,7 +68,10 @@ class CupertinoNavigationShell extends StatelessWidget {
   final CupertinoNavigationPrimaryAction? primaryAction;
 
   /// Full-width policy used by the Sidebar panel.
-  final NavigationRailExtent railExtent;
+  final SideNavigationExtent sideNavigationExtent;
+
+  /// Optional visual displayed inside the Sidebar resize target.
+  final SideNavigationDragHandleBuilder? dragHandleBuilder;
 
   /// Geometry and spacing for the compact Apple navigation bar.
   final AppleNavigationBarStyle appleBarStyle;
@@ -114,7 +118,8 @@ class CupertinoNavigationShell extends StatelessWidget {
             selectedIndex: selectedIndex,
             destinations: destinations,
             onDestinationSelected: onSelected,
-            railExtent: railExtent,
+            sideNavigationExtent: sideNavigationExtent,
+            dragHandleBuilder: dragHandleBuilder,
             expandNavigationLabel: expandNavigationLabel,
             collapseNavigationLabel: collapseNavigationLabel,
             child: child,

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar.dart
@@ -1,86 +1,391 @@
-import 'package:flutter/material.dart';
+import 'dart:math' as math;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart' show MaterialLocalizations;
 
 import '../adaptive/adaptive_navigation_destination.dart';
-import '../material/material_navigation_rail.dart';
+import '../material/material_navigation_rail.dart' show NavigationRailExtent;
 import '../shell/navigation_shell_frame.dart';
+import '../shell/navigation_sidebar_app_bar_leading.dart';
+import '../window_control/window_control_layout.dart';
+import 'cupertino_navigation_sidebar_button.dart';
+import 'cupertino_navigation_sidebar_panel.dart';
 
-/// Temporary medium+ compatibility renderer.
+/// Cupertino-owned side-navigation body.
 ///
-/// TODO(adaptive-ui::apple-sidebar): Replace the delegated Material rail with
-/// the Phase 3-4 HIG sidebar. This fallback is intentionally Cupertino-owned;
-/// it must not be treated as a common rail or an Apple sidebar implementation.
-class CupertinoNavigationSidebarCompatibility extends StatelessWidget {
-  /// Creates the temporary rail body for the current shell [form].
-  const CupertinoNavigationSidebarCompatibility({
+/// Medium and larger windows use one beside Sidebar presentation. The Sidebar
+/// can be completely hidden, but never collapses to an icon-only rail.
+class CupertinoNavigationSidebar extends StatefulWidget {
+  const CupertinoNavigationSidebar({
     super.key,
     required this.form,
     required this.selectedIndex,
     required this.destinations,
     required this.onDestinationSelected,
     required this.railExtent,
+    this.expandNavigationLabel,
+    this.collapseNavigationLabel,
     required this.child,
   });
 
-  /// Current compact, constrained-side, or expanded-side shell form.
   final NavigationShellForm form;
-
-  /// Zero-based index of the selected destination.
   final int selectedIndex;
-
-  /// Top-level destinations rendered by the compatibility rail.
   final List<AdaptiveNavigationDestination> destinations;
-
-  /// Called with the index of a destination selected by the user.
   final ValueChanged<int> onDestinationSelected;
-
-  /// Automatic and manually resizable rail-width policy.
   final NavigationRailExtent railExtent;
 
-  /// Stable branch content composed beside the compatibility rail.
+  /// Optional override for the localized action label used when showing.
+  final String? expandNavigationLabel;
+
+  /// Optional override for the localized action label used when hiding.
+  final String? collapseNavigationLabel;
   final Widget child;
 
   @override
-  Widget build(BuildContext context) => ColoredBox(
-    color: Theme.of(context).colorScheme.surface,
-    child: Row(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        MaterialNavigationRailRegion(
-          form: form,
-          selectedIndex: selectedIndex,
-          destinations: destinations,
-          onDestinationSelected: onDestinationSelected,
-          railExtent: railExtent,
-        ),
-        Expanded(
-          child: _CupertinoCompatibilityBranch(form: form, child: child),
-        ),
-      ],
-    ),
-  );
+  State<CupertinoNavigationSidebar> createState() =>
+      _CupertinoNavigationSidebarState();
 }
 
-class _CupertinoCompatibilityBranch extends StatelessWidget {
-  const _CupertinoCompatibilityBranch({
-    required this.form,
+class _CupertinoNavigationSidebarState extends State<CupertinoNavigationSidebar>
+    with SingleTickerProviderStateMixin {
+  static const double _surfaceMargin = 12;
+  static const double _contentGap = 12;
+  static const double _edgeGestureWidth = 20;
+  static const double _appBarLeadingPadding = 16;
+  static const double _panelToggleTrailingPadding = 8;
+
+  late final AnimationController _animation = AnimationController(
+    vsync: this,
+    value: 1,
+  );
+  late final Animation<double> _curvedAnimation = CurvedAnimation(
+    parent: _animation,
+    curve: Curves.easeOut,
+    reverseCurve: Curves.easeOut,
+  );
+  final FocusNode _toggleFocusNode = FocusNode(
+    debugLabel: 'cupertino-sidebar-toggle',
+  );
+  bool _visible = true;
+  double? _manualWidth;
+  bool _manualAboveAuto = false;
+  double _dragCurrentWidth = 0;
+  bool _dragging = false;
+  double _edgeDragDistance = 0;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _animation.duration = MediaQuery.disableAnimationsOf(context)
+        ? Duration.zero
+        : navigationShellAnimationDuration;
+  }
+
+  @override
+  void dispose() {
+    _toggleFocusNode.dispose();
+    _animation.dispose();
+    super.dispose();
+  }
+
+  double _automaticWidth(double windowWidth) =>
+      widget.railExtent.resolve(windowWidth);
+
+  double _effectiveWidth(double windowWidth) {
+    final manualWidth = _manualWidth;
+    if (manualWidth == null) return _automaticWidth(windowWidth);
+    final bound = _manualAboveAuto
+        ? widget.railExtent.upperBoundAt(windowWidth)
+        : _automaticWidth(windowWidth);
+    return math.min(manualWidth, bound);
+  }
+
+  void _toggle() {
+    setState(() => _visible = !_visible);
+    if (_visible) {
+      _animation.forward();
+    } else {
+      _animation.reverse();
+    }
+  }
+
+  void _handleResizeStart(double windowWidth) {
+    setState(() {
+      _dragging = true;
+      _dragCurrentWidth = _effectiveWidth(windowWidth);
+    });
+  }
+
+  void _handleResizeUpdate(double logicalDelta, double windowWidth) {
+    setState(() {
+      _dragCurrentWidth = widget.railExtent.clamp(
+        _dragCurrentWidth + logicalDelta,
+        windowWidth: windowWidth,
+      );
+      _manualWidth = _dragCurrentWidth;
+      _manualAboveAuto = _dragCurrentWidth > _automaticWidth(windowWidth);
+    });
+  }
+
+  void _handleResizeEnd() {
+    if (!_dragging) return;
+    setState(() => _dragging = false);
+  }
+
+  void _handleEdgeDragStart() => _edgeDragDistance = 0;
+
+  void _handleEdgeDragUpdate(double logicalDelta) {
+    _edgeDragDistance += logicalDelta;
+  }
+
+  void _handleEdgeDragEnd(double logicalVelocity) {
+    final shouldOpen =
+        _edgeDragDistance >= kTouchSlop || logicalVelocity >= kMinFlingVelocity;
+    _edgeDragDistance = 0;
+    if (!shouldOpen || _visible) return;
+    setState(() => _visible = true);
+    _animation.forward();
+  }
+
+  void _handleEdgeDragCancel() => _edgeDragDistance = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.form == NavigationShellForm.compact) return widget.child;
+
+    final materialLocalizations = Localizations.of<MaterialLocalizations>(
+      context,
+      MaterialLocalizations,
+    );
+    final expandNavigationLabel =
+        widget.expandNavigationLabel ??
+        materialLocalizations?.collapsedIconTapHint ??
+        'Expand';
+    final collapseNavigationLabel =
+        widget.collapseNavigationLabel ??
+        materialLocalizations?.expandedIconTapHint ??
+        'Collapse';
+    final windowWidth = MediaQuery.sizeOf(context).width;
+    final panelWidth = _effectiveWidth(windowWidth);
+    final mediaPadding = MediaQuery.paddingOf(context);
+    final direction = Directionality.of(context);
+    final leadingSafeMargin = math.max(
+      _surfaceMargin,
+      direction == TextDirection.ltr ? mediaPadding.left : mediaPadding.right,
+    );
+    final toolbarTopInset = math.max(0.0, _surfaceMargin - mediaPadding.top);
+    final buttonTop = math.max(_surfaceMargin, mediaPadding.top);
+    final sideNavigationAvoidance =
+        AdaptiveWindowControlLayoutScope.sideNavigationHorizontalAvoidanceOf(
+          context,
+        );
+    final visibleButtonStart =
+        leadingSafeMargin +
+        panelWidth -
+        math.max(sideNavigationAvoidance.end, _panelToggleTrailingPadding) -
+        NavigationSidebarAppBarLeading.buttonExtent;
+    final hiddenButtonStart =
+        sideNavigationAvoidance.start + _appBarLeadingPadding;
+    return AnimatedBuilder(
+      animation: _curvedAnimation,
+      builder: (context, child) {
+        final progress = _curvedAnimation.value;
+        final panelActive = _animation.value > 0;
+        final appBarProgress = 1 - progress;
+        final toolbarAvoidance = EdgeInsetsDirectional.lerp(
+          EdgeInsetsDirectional.zero,
+          sideNavigationAvoidance,
+          appBarProgress,
+        )!;
+        final buttonStart =
+            hiddenButtonStart +
+            (visibleButtonStart - hiddenButtonStart) * progress;
+        final branch = _CupertinoSidebarBranch(
+          occupiedSpan:
+              (leadingSafeMargin + panelWidth + _contentGap) * progress,
+          child: NavigationSidebarAppBarLeading(
+            toolbarAvoidance: toolbarAvoidance,
+            toolbarTopInset: toolbarTopInset,
+            progress: appBarProgress,
+            child: widget.child,
+          ),
+        );
+        final stack = Stack(
+          key: const ValueKey('cupertino-sidebar-beside-host'),
+          fit: StackFit.expand,
+          children: [
+            branch,
+            if (panelActive)
+              _CupertinoSidebarAnimatedPanel(
+                progress: progress,
+                child: CupertinoNavigationSidebarPanel(
+                  width: panelWidth,
+                  contentActive: progress == 1,
+                  selectedIndex: widget.selectedIndex,
+                  destinations: widget.destinations,
+                  onDestinationSelected: widget.onDestinationSelected,
+                  dragging: _dragging,
+                  onResizeStart: () => _handleResizeStart(windowWidth),
+                  onResizeUpdate: (delta) =>
+                      _handleResizeUpdate(delta, windowWidth),
+                  onResizeEnd: _handleResizeEnd,
+                ),
+              ),
+            PositionedDirectional(
+              key: const ValueKey('cupertino-sidebar-toggle-position'),
+              start: buttonStart,
+              top: buttonTop,
+              width: NavigationSidebarAppBarLeading.buttonExtent,
+              height: NavigationSidebarAppBarLeading.buttonExtent,
+              child: CupertinoNavigationSidebarButton(
+                focusNode: _toggleFocusNode,
+                label: _visible
+                    ? collapseNavigationLabel
+                    : expandNavigationLabel,
+                onPressed: _toggle,
+                buttonKey: const ValueKey('cupertino-sidebar-toggle'),
+              ),
+            ),
+          ],
+        );
+        return _CupertinoSidebarEdgeGesture(
+          enabled: !panelActive,
+          edgeWidth: _edgeGestureWidth,
+          onStart: _handleEdgeDragStart,
+          onUpdate: _handleEdgeDragUpdate,
+          onEnd: _handleEdgeDragEnd,
+          onCancel: _handleEdgeDragCancel,
+          child: stack,
+        );
+      },
+    );
+  }
+}
+
+class _CupertinoSidebarEdgeGesture extends StatelessWidget {
+  const _CupertinoSidebarEdgeGesture({
+    required this.enabled,
+    required this.edgeWidth,
+    required this.onStart,
+    required this.onUpdate,
+    required this.onEnd,
+    required this.onCancel,
     required this.child,
   });
 
-  final NavigationShellForm form;
+  final bool enabled;
+  final double edgeWidth;
+  final VoidCallback onStart;
+  final ValueChanged<double> onUpdate;
+  final ValueChanged<double> onEnd;
+  final VoidCallback onCancel;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    if (form == NavigationShellForm.compact) return child;
-
-    // The compatibility rail consumes logical-start padding until the real
-    // Cupertino sidebar replaces this body in Phase 3-4c.
-    final removeLeft = Directionality.of(context) == TextDirection.ltr;
-    return MediaQuery.removePadding(
-      context: context,
-      removeLeft: removeLeft,
-      removeRight: !removeLeft,
+    final direction = Directionality.of(context);
+    final viewWidth = MediaQuery.sizeOf(context).width;
+    return RawGestureDetector(
+      key: const ValueKey('cupertino-sidebar-edge-gesture'),
+      behavior: HitTestBehavior.translucent,
+      gestures: enabled
+          ? <Type, GestureRecognizerFactory>{
+              _CupertinoSidebarEdgeDragRecognizer:
+                  GestureRecognizerFactoryWithHandlers<
+                    _CupertinoSidebarEdgeDragRecognizer
+                  >(_CupertinoSidebarEdgeDragRecognizer.new, (recognizer) {
+                    recognizer
+                      ..edgeWidth = edgeWidth
+                      ..viewWidth = viewWidth
+                      ..textDirection = direction
+                      ..onStart = (_) {
+                        onStart();
+                      }
+                      ..onUpdate = (details) {
+                        final logicalDelta = direction == TextDirection.ltr
+                            ? details.delta.dx
+                            : -details.delta.dx;
+                        onUpdate(logicalDelta);
+                      }
+                      ..onEnd = (details) {
+                        final velocity = details.primaryVelocity ?? 0;
+                        final logicalVelocity = direction == TextDirection.ltr
+                            ? velocity
+                            : -velocity;
+                        onEnd(logicalVelocity);
+                      }
+                      ..onCancel = onCancel;
+                  }),
+            }
+          : const <Type, GestureRecognizerFactory>{},
       child: child,
+    );
+  }
+}
+
+class _CupertinoSidebarEdgeDragRecognizer
+    extends HorizontalDragGestureRecognizer {
+  double edgeWidth = 0;
+  double viewWidth = 0;
+  TextDirection textDirection = TextDirection.ltr;
+
+  @override
+  bool isPointerAllowed(PointerEvent event) {
+    if (!super.isPointerAllowed(event)) return false;
+    return switch (textDirection) {
+      TextDirection.ltr => event.position.dx <= edgeWidth,
+      TextDirection.rtl => event.position.dx >= viewWidth - edgeWidth,
+    };
+  }
+
+  @override
+  String get debugDescription => 'cupertino sidebar edge drag';
+}
+
+class _CupertinoSidebarBranch extends StatelessWidget {
+  const _CupertinoSidebarBranch({
+    required this.occupiedSpan,
+    required this.child,
+  });
+
+  final double occupiedSpan;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      key: const ValueKey('cupertino-sidebar-branch-safe-span'),
+      padding: EdgeInsetsDirectional.only(start: occupiedSpan),
+      child: child,
+    );
+  }
+}
+
+class _CupertinoSidebarAnimatedPanel extends StatelessWidget {
+  const _CupertinoSidebarAnimatedPanel({
+    required this.progress,
+    required this.child,
+  });
+
+  final double progress;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final direction = Directionality.of(context);
+    return SafeArea(
+      minimum: const EdgeInsets.fromLTRB(12, 12, 12, 12),
+      child: Align(
+        alignment: AlignmentDirectional.centerStart,
+        child: FractionalTranslation(
+          translation: Offset(
+            (direction == TextDirection.ltr ? -1 : 1) * (1 - progress),
+            0,
+          ),
+          child: Opacity(opacity: progress, child: child),
+        ),
+      ),
     );
   }
 }

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar.dart
@@ -5,9 +5,9 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' show MaterialLocalizations;
 
 import '../adaptive/adaptive_navigation_destination.dart';
-import '../material/material_navigation_rail.dart' show NavigationRailExtent;
 import '../shell/navigation_shell_frame.dart';
 import '../shell/navigation_sidebar_app_bar_leading.dart';
+import '../shell/side_navigation.dart';
 import '../window_control/window_control_layout.dart';
 import 'cupertino_navigation_sidebar_button.dart';
 import 'cupertino_navigation_sidebar_panel.dart';
@@ -23,7 +23,8 @@ class CupertinoNavigationSidebar extends StatefulWidget {
     required this.selectedIndex,
     required this.destinations,
     required this.onDestinationSelected,
-    required this.railExtent,
+    required this.sideNavigationExtent,
+    required this.dragHandleBuilder,
     this.expandNavigationLabel,
     this.collapseNavigationLabel,
     required this.child,
@@ -33,7 +34,8 @@ class CupertinoNavigationSidebar extends StatefulWidget {
   final int selectedIndex;
   final List<AdaptiveNavigationDestination> destinations;
   final ValueChanged<int> onDestinationSelected;
-  final NavigationRailExtent railExtent;
+  final SideNavigationExtent sideNavigationExtent;
+  final SideNavigationDragHandleBuilder? dragHandleBuilder;
 
   /// Optional override for the localized action label used when showing.
   final String? expandNavigationLabel;
@@ -68,10 +70,7 @@ class _CupertinoNavigationSidebarState extends State<CupertinoNavigationSidebar>
     debugLabel: 'cupertino-sidebar-toggle',
   );
   bool _visible = true;
-  double? _manualWidth;
-  bool _manualAboveAuto = false;
-  double _dragCurrentWidth = 0;
-  bool _dragging = false;
+  final SideNavigationResizeState _resizeState = SideNavigationResizeState();
   double _edgeDragDistance = 0;
 
   @override
@@ -89,18 +88,6 @@ class _CupertinoNavigationSidebarState extends State<CupertinoNavigationSidebar>
     super.dispose();
   }
 
-  double _automaticWidth(double windowWidth) =>
-      widget.railExtent.resolve(windowWidth);
-
-  double _effectiveWidth(double windowWidth) {
-    final manualWidth = _manualWidth;
-    if (manualWidth == null) return _automaticWidth(windowWidth);
-    final bound = _manualAboveAuto
-        ? widget.railExtent.upperBoundAt(windowWidth)
-        : _automaticWidth(windowWidth);
-    return math.min(manualWidth, bound);
-  }
-
   void _toggle() {
     setState(() => _visible = !_visible);
     if (_visible) {
@@ -111,26 +98,27 @@ class _CupertinoNavigationSidebarState extends State<CupertinoNavigationSidebar>
   }
 
   void _handleResizeStart(double windowWidth) {
-    setState(() {
-      _dragging = true;
-      _dragCurrentWidth = _effectiveWidth(windowWidth);
-    });
+    setState(
+      () => _resizeState.startDrag(
+        widget.sideNavigationExtent,
+        windowWidth: windowWidth,
+      ),
+    );
   }
 
   void _handleResizeUpdate(double logicalDelta, double windowWidth) {
-    setState(() {
-      _dragCurrentWidth = widget.railExtent.clamp(
-        _dragCurrentWidth + logicalDelta,
+    setState(
+      () => _resizeState.updateDrag(
+        logicalDelta,
+        widget.sideNavigationExtent,
         windowWidth: windowWidth,
-      );
-      _manualWidth = _dragCurrentWidth;
-      _manualAboveAuto = _dragCurrentWidth > _automaticWidth(windowWidth);
-    });
+      ),
+    );
   }
 
   void _handleResizeEnd() {
-    if (!_dragging) return;
-    setState(() => _dragging = false);
+    if (!_resizeState.dragging) return;
+    setState(_resizeState.endDrag);
   }
 
   void _handleEdgeDragStart() => _edgeDragDistance = 0;
@@ -167,7 +155,10 @@ class _CupertinoNavigationSidebarState extends State<CupertinoNavigationSidebar>
         materialLocalizations?.expandedIconTapHint ??
         'Collapse';
     final windowWidth = MediaQuery.sizeOf(context).width;
-    final panelWidth = _effectiveWidth(windowWidth);
+    final panelWidth = _resizeState.effectiveWidth(
+      widget.sideNavigationExtent,
+      windowWidth: windowWidth,
+    );
     final mediaPadding = MediaQuery.paddingOf(context);
     final direction = Directionality.of(context);
     final leadingSafeMargin = math.max(
@@ -225,7 +216,8 @@ class _CupertinoNavigationSidebarState extends State<CupertinoNavigationSidebar>
                   selectedIndex: widget.selectedIndex,
                   destinations: widget.destinations,
                   onDestinationSelected: widget.onDestinationSelected,
-                  dragging: _dragging,
+                  dragging: _resizeState.dragging,
+                  dragHandleBuilder: widget.dragHandleBuilder,
                   onResizeStart: () => _handleResizeStart(windowWidth),
                   onResizeUpdate: (delta) =>
                       _handleResizeUpdate(delta, windowWidth),

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
 import '../material/material_navigation_rail.dart';
@@ -10,7 +10,7 @@ import '../shell/navigation_shell_frame.dart';
 /// the Phase 3-4 HIG sidebar. This fallback is intentionally Cupertino-owned;
 /// it must not be treated as a common rail or an Apple sidebar implementation.
 class CupertinoNavigationSidebarCompatibility extends StatelessWidget {
-  /// Creates the temporary rail renderer for the current shell [form].
+  /// Creates the temporary rail body for the current shell [form].
   const CupertinoNavigationSidebarCompatibility({
     super.key,
     required this.form,
@@ -18,9 +18,10 @@ class CupertinoNavigationSidebarCompatibility extends StatelessWidget {
     required this.destinations,
     required this.onDestinationSelected,
     required this.railExtent,
+    required this.child,
   });
 
-  /// Current compact, collapsed-rail, or extended-rail shell form.
+  /// Current compact, constrained-side, or expanded-side shell form.
   final NavigationShellForm form;
 
   /// Zero-based index of the selected destination.
@@ -35,12 +36,51 @@ class CupertinoNavigationSidebarCompatibility extends StatelessWidget {
   /// Automatic and manually resizable rail-width policy.
   final NavigationRailExtent railExtent;
 
+  /// Stable branch content composed beside the compatibility rail.
+  final Widget child;
+
   @override
-  Widget build(BuildContext context) => MaterialNavigationRailRegion(
-    form: form,
-    selectedIndex: selectedIndex,
-    destinations: destinations,
-    onDestinationSelected: onDestinationSelected,
-    railExtent: railExtent,
+  Widget build(BuildContext context) => ColoredBox(
+    color: Theme.of(context).colorScheme.surface,
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        MaterialNavigationRailRegion(
+          form: form,
+          selectedIndex: selectedIndex,
+          destinations: destinations,
+          onDestinationSelected: onDestinationSelected,
+          railExtent: railExtent,
+        ),
+        Expanded(
+          child: _CupertinoCompatibilityBranch(form: form, child: child),
+        ),
+      ],
+    ),
   );
+}
+
+class _CupertinoCompatibilityBranch extends StatelessWidget {
+  const _CupertinoCompatibilityBranch({
+    required this.form,
+    required this.child,
+  });
+
+  final NavigationShellForm form;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (form == NavigationShellForm.compact) return child;
+
+    // The compatibility rail consumes logical-start padding until the real
+    // Cupertino sidebar replaces this body in Phase 3-4c.
+    final removeLeft = Directionality.of(context) == TextDirection.ltr;
+    return MediaQuery.removePadding(
+      context: context,
+      removeLeft: removeLeft,
+      removeRight: !removeLeft,
+      child: child,
+    );
+  }
 }

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar_button.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar_button.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart' show Tooltip;
+
+/// Platform-standard button used by the Cupertino Sidebar shell.
+class CupertinoNavigationSidebarButton extends StatelessWidget {
+  const CupertinoNavigationSidebarButton({
+    super.key,
+    required this.focusNode,
+    required this.label,
+    required this.onPressed,
+    required this.buttonKey,
+  });
+
+  final FocusNode focusNode;
+  final String label;
+  final VoidCallback onPressed;
+  final Key buttonKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final direction = Directionality.of(context);
+    return Tooltip(
+      message: label,
+      child: CupertinoButton(
+        key: buttonKey,
+        focusNode: focusNode,
+        minimumSize: const Size.square(44),
+        padding: EdgeInsets.zero,
+        onPressed: onPressed,
+        child: Semantics(
+          button: true,
+          label: label,
+          excludeSemantics: true,
+          child: Icon(
+            direction == TextDirection.ltr
+                ? CupertinoIcons.sidebar_left
+                : CupertinoIcons.sidebar_right,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar_panel.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar_panel.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/cupertino.dart';
+
+import '../adaptive/adaptive_navigation_destination.dart';
+import '../shell/navigation_shell_frame.dart';
+import 'cupertino_floating_surface.dart';
+
+/// Floating surface and destination presentation for a Cupertino Sidebar.
+///
+/// Visibility, animation, width policy, focus transfer, and toggle ownership
+/// remain responsibilities of the Sidebar host.
+class CupertinoNavigationSidebarPanel extends StatelessWidget {
+  static const double _toolbarHeight = 44;
+  static const double _destinationTopGap = 24;
+  static const double _resizeHandleWidth = 16;
+  static const double _resizeHandleCornerInset = 25;
+
+  const CupertinoNavigationSidebarPanel({
+    super.key,
+    required this.width,
+    required this.contentActive,
+    required this.selectedIndex,
+    required this.destinations,
+    required this.onDestinationSelected,
+    required this.dragging,
+    required this.onResizeStart,
+    required this.onResizeUpdate,
+    required this.onResizeEnd,
+  });
+
+  final double width;
+  final bool contentActive;
+  final int selectedIndex;
+  final List<AdaptiveNavigationDestination> destinations;
+  final ValueChanged<int> onDestinationSelected;
+  final bool dragging;
+  final VoidCallback onResizeStart;
+  final ValueChanged<double> onResizeUpdate;
+  final VoidCallback onResizeEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    const toolbarLayer = Positioned(
+      top: 0,
+      left: 0,
+      right: 0,
+      height: _toolbarHeight,
+      child: IgnorePointer(
+        child: CupertinoNavigationBar(
+          automaticallyImplyLeading: false,
+          transitionBetweenRoutes: false,
+          automaticBackgroundVisibility: false,
+          backgroundColor: CupertinoColors.transparent,
+          border: null,
+        ),
+      ),
+    );
+
+    final direction = Directionality.of(context);
+
+    final destinationList = ListView.builder(
+      key: const ValueKey('cupertino-sidebar-destination-list'),
+      padding: const EdgeInsets.only(
+        top: _toolbarHeight + _destinationTopGap,
+        bottom: 8,
+      ),
+      itemCount: destinations.length,
+      itemBuilder: (context, index) => _CupertinoSidebarDestination(
+        key: ValueKey('cupertino-sidebar-destination-$index'),
+        destination: destinations[index],
+        selected: selectedIndex == index,
+        onPressed: () => onDestinationSelected(index),
+      ),
+    );
+    final destinationContent = ExcludeSemantics(
+      excluding: !contentActive,
+      child: destinationList,
+    );
+    final destinationLayer = Positioned.fill(
+      child: IgnorePointer(ignoring: !contentActive, child: destinationContent),
+    );
+
+    final surface = CupertinoFloatingGlassSurface(
+      key: const ValueKey('cupertino-sidebar-surface'),
+      borderRadius: const BorderRadius.all(Radius.circular(25)),
+      child: Stack(
+        fit: StackFit.expand,
+        children: [destinationLayer, toolbarLayer],
+      ),
+    );
+
+    final resizeHandleTarget = GestureDetector(
+      key: const ValueKey('cupertino-sidebar-resize-handle'),
+      behavior: HitTestBehavior.opaque,
+      onHorizontalDragStart: (_) => onResizeStart(),
+      onHorizontalDragUpdate: (details) {
+        final logicalDelta = direction == TextDirection.ltr
+            ? details.delta.dx
+            : -details.delta.dx;
+        onResizeUpdate(logicalDelta);
+      },
+      onHorizontalDragEnd: (_) => onResizeEnd(),
+      onHorizontalDragCancel: onResizeEnd,
+      child: const SizedBox(width: _resizeHandleWidth, height: double.infinity),
+    );
+    final resizeHandle = PositionedDirectional(
+      end: 0,
+      top: _resizeHandleCornerInset,
+      bottom: _resizeHandleCornerInset,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.resizeColumn,
+        child: IgnorePointer(
+          ignoring: !contentActive,
+          child: resizeHandleTarget,
+        ),
+      ),
+    );
+
+    final panel = SizedBox(
+      key: const ValueKey('cupertino-sidebar-panel'),
+      width: width,
+      height: double.infinity,
+      child: Stack(fit: StackFit.expand, children: [surface, resizeHandle]),
+    );
+
+    return AnimatedSize(
+      duration: dragging
+          ? const Duration(milliseconds: 1)
+          : navigationShellAnimationDuration,
+      curve: Curves.easeOut,
+      alignment: AlignmentDirectional.centerStart,
+      child: panel,
+    );
+  }
+}
+
+class _CupertinoSidebarDestination extends StatelessWidget {
+  const _CupertinoSidebarDestination({
+    super.key,
+    required this.destination,
+    required this.selected,
+    required this.onPressed,
+  });
+
+  final AdaptiveNavigationDestination destination;
+  final bool selected;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final primaryColor = CupertinoTheme.of(context).primaryColor;
+    final labelColor = CupertinoDynamicColor.resolve(
+      CupertinoColors.label,
+      context,
+    );
+
+    final foregroundColor = (selected ? primaryColor : labelColor).withValues(
+      alpha: 1,
+    );
+    final icon = selected
+        ? destination.icons.appleSelected
+        : destination.icons.apple;
+
+    final label = Expanded(
+      child: Text(
+        destination.label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+    final button = CupertinoButton(
+      sizeStyle: CupertinoButtonSize.medium,
+      minimumSize: const Size(0, 44),
+      padding: const EdgeInsetsDirectional.symmetric(horizontal: 12),
+      alignment: AlignmentDirectional.centerStart,
+      color: selected ? primaryColor.withValues(alpha: 0.14) : null,
+      foregroundColor: foregroundColor,
+      autofocus: selected,
+      onPressed: onPressed,
+      child: Row(children: [icon, const SizedBox(width: 12), label]),
+    );
+    final paddedButton = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: SizedBox(width: double.infinity, child: button),
+    );
+
+    return Semantics(
+      container: true,
+      button: true,
+      selected: selected,
+      label: destination.effectiveSemanticsLabel,
+      excludeSemantics: true,
+      child: paddedButton,
+    );
+  }
+}

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar_panel.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar_panel.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
 import '../shell/navigation_shell_frame.dart';
+import '../shell/side_navigation.dart';
 import 'cupertino_floating_surface.dart';
 
 /// Floating surface and destination presentation for a Cupertino Sidebar.
@@ -22,6 +23,7 @@ class CupertinoNavigationSidebarPanel extends StatelessWidget {
     required this.destinations,
     required this.onDestinationSelected,
     required this.dragging,
+    required this.dragHandleBuilder,
     required this.onResizeStart,
     required this.onResizeUpdate,
     required this.onResizeEnd,
@@ -33,6 +35,7 @@ class CupertinoNavigationSidebarPanel extends StatelessWidget {
   final List<AdaptiveNavigationDestination> destinations;
   final ValueChanged<int> onDestinationSelected;
   final bool dragging;
+  final SideNavigationDragHandleBuilder? dragHandleBuilder;
   final VoidCallback onResizeStart;
   final ValueChanged<double> onResizeUpdate;
   final VoidCallback onResizeEnd;
@@ -54,8 +57,6 @@ class CupertinoNavigationSidebarPanel extends StatelessWidget {
         ),
       ),
     );
-
-    final direction = Directionality.of(context);
 
     final destinationList = ListView.builder(
       key: const ValueKey('cupertino-sidebar-destination-list'),
@@ -88,31 +89,19 @@ class CupertinoNavigationSidebarPanel extends StatelessWidget {
       ),
     );
 
-    final resizeHandleTarget = GestureDetector(
+    final resizeHandleTarget = SideNavigationResizeHandle(
       key: const ValueKey('cupertino-sidebar-resize-handle'),
-      behavior: HitTestBehavior.opaque,
-      onHorizontalDragStart: (_) => onResizeStart(),
-      onHorizontalDragUpdate: (details) {
-        final logicalDelta = direction == TextDirection.ltr
-            ? details.delta.dx
-            : -details.delta.dx;
-        onResizeUpdate(logicalDelta);
-      },
-      onHorizontalDragEnd: (_) => onResizeEnd(),
-      onHorizontalDragCancel: onResizeEnd,
-      child: const SizedBox(width: _resizeHandleWidth, height: double.infinity),
+      hitExtent: _resizeHandleWidth,
+      dragHandleBuilder: dragHandleBuilder,
+      onResizeStart: onResizeStart,
+      onResizeUpdate: onResizeUpdate,
+      onResizeEnd: onResizeEnd,
     );
     final resizeHandle = PositionedDirectional(
       end: 0,
       top: _resizeHandleCornerInset,
       bottom: _resizeHandleCornerInset,
-      child: MouseRegion(
-        cursor: SystemMouseCursors.resizeColumn,
-        child: IgnorePointer(
-          ignoring: !contentActive,
-          child: resizeHandleTarget,
-        ),
-      ),
+      child: IgnorePointer(ignoring: !contentActive, child: resizeHandleTarget),
     );
 
     final panel = SizedBox(

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_sliver_app_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_sliver_app_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 
 import '../breakpoints/window_size_class.dart';
+import '../shell/navigation_sidebar_app_bar_leading.dart';
 import '../window_control/cupertino_navigation_bar.dart';
 import '../window_control/toolbar_geometry.dart';
 import 'cupertino_toolbar_padding.dart';
@@ -19,6 +20,7 @@ class CupertinoSliverAppBar extends StatelessWidget {
     this.enableBackgroundFilterBlur = true,
     this.border,
     this.backgroundColor,
+    this.automaticBackgroundVisibility = true,
     this.padding,
     this.stretch = false,
     this.windowControlAvoidance,
@@ -33,53 +35,97 @@ class CupertinoSliverAppBar extends StatelessWidget {
   final bool enableBackgroundFilterBlur;
   final Border? border;
   final Color? backgroundColor;
+  final bool automaticBackgroundVisibility;
   final EdgeInsetsDirectional? padding;
   final bool stretch;
   final EdgeInsetsDirectional? windowControlAvoidance;
   final EdgeInsetsDirectional windowControlEdgePadding;
 
-  Widget? get _effectiveLeading =>
-      leading ??
-      (onLeadingPressed == null
-          ? null
-          : CupertinoButton(
-              padding: EdgeInsets.zero,
-              onPressed: onLeadingPressed,
-              child: const Icon(CupertinoIcons.back),
-            ));
-
-  Widget? get _effectiveTrailing => actions.isEmpty
+  Widget? _effectiveTrailing(List<Widget> effectiveActions) =>
+      effectiveActions.isEmpty
       ? null
-      : Row(mainAxisSize: MainAxisSize.min, children: actions);
+      : Row(mainAxisSize: MainAxisSize.min, children: effectiveActions);
 
   @override
   Widget build(BuildContext context) {
+    final sidebarLeading = NavigationSidebarAppBarLeading.maybeOf(context);
+    final hasLeading =
+        sidebarLeading != null || leading != null || onLeadingPressed != null;
+    final effectiveLeading = hasLeading
+        ? _CupertinoSliverAppBarLeading(
+            sidebarLeading: sidebarLeading,
+            leading: leading,
+            onLeadingPressed: onLeadingPressed,
+          )
+        : null;
+    final effectiveTrailing = _effectiveTrailing(actions);
+    final effectiveWindowControlAvoidance =
+        windowControlAvoidance ?? sidebarLeading?.toolbarAvoidance;
     final height = this.height;
     if (height != null) {
       return _FixedCupertinoSliverAppBar(
         title: title,
-        leading: _effectiveLeading,
-        trailing: _effectiveTrailing,
+        leading: effectiveLeading,
+        trailing: effectiveTrailing,
         toolbarHeight: height,
         enableBackgroundFilterBlur: enableBackgroundFilterBlur,
         border: border,
         backgroundColor: backgroundColor,
         padding: padding,
-        windowControlAvoidance: windowControlAvoidance,
+        windowControlAvoidance: effectiveWindowControlAvoidance,
         windowControlEdgePadding: windowControlEdgePadding,
       );
     }
     return _CollapsibleCupertinoSliverAppBar(
       title: title,
-      leading: _effectiveLeading,
-      trailing: _effectiveTrailing,
+      leading: effectiveLeading,
+      trailing: effectiveTrailing,
       enableBackgroundFilterBlur: enableBackgroundFilterBlur,
       border: border,
       backgroundColor: backgroundColor,
+      automaticBackgroundVisibility: automaticBackgroundVisibility,
       padding: padding,
       stretch: stretch,
-      windowControlAvoidance: windowControlAvoidance,
+      windowControlAvoidance: effectiveWindowControlAvoidance,
       windowControlEdgePadding: windowControlEdgePadding,
+    );
+  }
+}
+
+class _CupertinoSliverAppBarLeading extends StatelessWidget {
+  const _CupertinoSliverAppBarLeading({
+    required this.sidebarLeading,
+    required this.leading,
+    required this.onLeadingPressed,
+  });
+
+  final NavigationSidebarAppBarLeading? sidebarLeading;
+  final Widget? leading;
+  final VoidCallback? onLeadingPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final sidebarLeading = this.sidebarLeading;
+    final leading =
+        this.leading ??
+        (onLeadingPressed == null
+            ? null
+            : CupertinoButton(
+                padding: EdgeInsets.zero,
+                onPressed: onLeadingPressed,
+                child: const Icon(CupertinoIcons.back),
+              ));
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (sidebarLeading case final sidebarLeading?)
+          SizedBox(
+            key: const ValueKey('cupertino-sidebar-leading-anchor'),
+            width: sidebarLeading.reservedExtent,
+            height: NavigationSidebarAppBarLeading.buttonExtent,
+          ),
+        ?leading,
+      ],
     );
   }
 }
@@ -111,7 +157,10 @@ class _FixedCupertinoSliverAppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final topPadding = MediaQuery.paddingOf(context).top;
+    final sidebarLeading = NavigationSidebarAppBarLeading.maybeOf(context);
+    final topPadding =
+        MediaQuery.paddingOf(context).top +
+        (sidebarLeading?.toolbarTopInset ?? 0);
     final extent = topPadding + toolbarHeight;
     return SliverPersistentHeader(
       pinned: true,
@@ -125,6 +174,7 @@ class _FixedCupertinoSliverAppBar extends StatelessWidget {
               CupertinoNavigationBar(
                 automaticallyImplyLeading: false,
                 transitionBetweenRoutes: false,
+                automaticBackgroundVisibility: false,
                 enableBackgroundFilterBlur: enableBackgroundFilterBlur,
                 border: border,
                 backgroundColor: backgroundColor,
@@ -212,6 +262,7 @@ class _CollapsibleCupertinoSliverAppBar extends StatelessWidget {
     required this.enableBackgroundFilterBlur,
     required this.border,
     required this.backgroundColor,
+    required this.automaticBackgroundVisibility,
     required this.padding,
     required this.stretch,
     required this.windowControlAvoidance,
@@ -224,6 +275,7 @@ class _CollapsibleCupertinoSliverAppBar extends StatelessWidget {
   final bool enableBackgroundFilterBlur;
   final Border? border;
   final Color? backgroundColor;
+  final bool automaticBackgroundVisibility;
   final EdgeInsetsDirectional? padding;
   final bool stretch;
   final EdgeInsetsDirectional? windowControlAvoidance;
@@ -237,7 +289,7 @@ class _CollapsibleCupertinoSliverAppBar extends StatelessWidget {
         MediaQuery.orientationOf(context) == Orientation.portrait;
     final useLargeTitle =
         isPortrait || WindowSize.of(context).width == WindowSizeClass.compact;
-    return WindowControlCupertinoSliverNavigationBar(
+    final navigationBar = WindowControlCupertinoSliverNavigationBar(
       middle: useLargeTitle ? null : title,
       largeTitle: useLargeTitle ? title : null,
       leading: leading,
@@ -245,6 +297,7 @@ class _CollapsibleCupertinoSliverAppBar extends StatelessWidget {
       enableBackgroundFilterBlur: enableBackgroundFilterBlur,
       border: border,
       backgroundColor: backgroundColor,
+      automaticBackgroundVisibility: automaticBackgroundVisibility,
       padding: CupertinoToolbarPadding.resolveDirectional(
         context,
         contentPadding: padding,
@@ -254,6 +307,14 @@ class _CollapsibleCupertinoSliverAppBar extends StatelessWidget {
       windowControlAvoidance: windowControlAvoidance,
       windowControlEdgePadding: EdgeInsetsDirectional.zero,
     );
+    final toolbarTopInset =
+        NavigationSidebarAppBarLeading.maybeOf(context)?.toolbarTopInset ?? 0;
+    return toolbarTopInset == 0
+        ? navigationBar
+        : SliverPadding(
+            padding: EdgeInsets.only(top: toolbarTopInset),
+            sliver: navigationBar,
+          );
   }
 }
 

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_sliver_search_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_sliver_search_bar.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart' show Easing;
 
 import '../breakpoints/breakpoints.dart';
 import '../breakpoints/window_size_class.dart';
+import '../shell/navigation_sidebar_app_bar_leading.dart';
 import '../window_control/toolbar_geometry.dart';
 import 'cupertino_toolbar_padding.dart';
 
@@ -80,7 +81,7 @@ final class CupertinoSliverSearchBarAction
 /// a large title.
 /// Business state and the text controller stay with the caller.
 class CupertinoSliverSearchBar extends StatefulWidget {
-  static const double toolbarHeight = 52.0;
+  static const double toolbarHeight = 44.0;
 
   const CupertinoSliverSearchBar({
     super.key,
@@ -231,11 +232,14 @@ class _CupertinoSliverSearchBarState extends State<CupertinoSliverSearchBar> {
 
   @override
   Widget build(BuildContext context) {
+    final sidebarLeading = NavigationSidebarAppBarLeading.maybeOf(context);
     final screenWidth = MediaQuery.sizeOf(context).width;
     final widthClass = Breakpoints.of(context).widthClass(screenWidth);
     final isCompact = !(widthClass >= WindowSizeClass.medium);
     final isLarge = widthClass >= WindowSizeClass.large;
-    final topPadding = MediaQuery.paddingOf(context).top;
+    final topPadding =
+        MediaQuery.paddingOf(context).top +
+        (sidebarLeading?.toolbarTopInset ?? 0);
     final extent =
         topPadding +
         CupertinoSliverSearchBar.toolbarHeight +
@@ -254,6 +258,8 @@ class _CupertinoSliverSearchBarState extends State<CupertinoSliverSearchBar> {
               const CupertinoNavigationBar(
                 automaticallyImplyLeading: false,
                 transitionBetweenRoutes: false,
+                automaticBackgroundVisibility: false,
+                backgroundColor: CupertinoColors.transparent,
                 border: null,
               ),
               Positioned(
@@ -268,6 +274,7 @@ class _CupertinoSliverSearchBarState extends State<CupertinoSliverSearchBar> {
                     showTitle: !isLarge,
                     centerTitle: !isCompact && !isLarge,
                     preferPersistentSearch: isLarge,
+                    sidebarLeading: sidebarLeading,
                     leading: widget.leading,
                     actions: widget.actions,
                     fixedActions: widget.fixedActions,
@@ -338,6 +345,7 @@ class _CupertinoSearchToolbar extends StatelessWidget {
     required this.showTitle,
     required this.centerTitle,
     required this.preferPersistentSearch,
+    required this.sidebarLeading,
     required this.leading,
     required this.actions,
     required this.fixedActions,
@@ -359,6 +367,7 @@ class _CupertinoSearchToolbar extends StatelessWidget {
   final bool showTitle;
   final bool centerTitle;
   final bool preferPersistentSearch;
+  final NavigationSidebarAppBarLeading? sidebarLeading;
   final Widget? leading;
   final List<CupertinoSliverSearchBarAction> actions;
   final List<Widget> fixedActions;
@@ -398,8 +407,10 @@ class _CupertinoSearchToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final contentPadding = CupertinoToolbarPadding.resolveDirectional(context);
+    final sidebarLeading = this.sidebarLeading;
     final insets = WindowControlToolbarGeometry.resolve(
       context,
+      avoidance: sidebarLeading?.toolbarAvoidance,
       edgePadding: contentPadding,
     ).cupertinoInsets;
     return Padding(
@@ -409,7 +420,12 @@ class _CupertinoSearchToolbar extends StatelessWidget {
           const itemExtent = _CupertinoSliverSearchBarState._toolbarItemExtent;
           const minimumPersistentSearchWidth = 100.0;
           final preferredTitleExtent = _measureTitleExtent(context);
-          final leadingWidth = leading == null ? 0.0 : itemExtent;
+          final leadingRegion = _CupertinoSearchToolbarLeading(
+            sidebarLeading: sidebarLeading,
+            leading: leading,
+            itemExtent: itemExtent,
+          );
+          final leadingWidth = leadingRegion.width;
           final fixedActionWidth = fixedActions.length * itemExtent;
           final contentWidth = math.max(
             0.0,
@@ -461,12 +477,7 @@ class _CupertinoSearchToolbar extends StatelessWidget {
                 child: Row(
                   children: [
                     SizedBox(width: insets.start),
-                    if (leading case final leading?)
-                      SizedBox(
-                        width: itemExtent,
-                        height: itemExtent,
-                        child: leading,
-                      ),
+                    leadingRegion,
                     Expanded(
                       child: _CupertinoCommandRegion(
                         title: title,
@@ -518,6 +529,40 @@ class _CupertinoSearchToolbar extends StatelessWidget {
           );
         },
       ),
+    );
+  }
+}
+
+class _CupertinoSearchToolbarLeading extends StatelessWidget {
+  const _CupertinoSearchToolbarLeading({
+    required this.sidebarLeading,
+    required this.leading,
+    required this.itemExtent,
+  });
+
+  final NavigationSidebarAppBarLeading? sidebarLeading;
+  final Widget? leading;
+  final double itemExtent;
+
+  double get width =>
+      (sidebarLeading?.reservedExtent ?? 0) +
+      (leading == null ? 0 : itemExtent);
+
+  @override
+  Widget build(BuildContext context) {
+    final sidebarLeading = this.sidebarLeading;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (sidebarLeading case final sidebarLeading?)
+          SizedBox(
+            key: const ValueKey('cupertino-sidebar-leading-anchor'),
+            width: sidebarLeading.reservedExtent,
+            height: itemExtent,
+          ),
+        if (leading case final leading?)
+          SizedBox(width: itemExtent, height: itemExtent, child: leading),
+      ],
     );
   }
 }

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_sliver_select_app_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_sliver_select_app_bar.dart
@@ -53,7 +53,7 @@ final class CupertinoSelectAction {
 /// commands in the bottom toolbar; wider layouts place them through
 /// adaptive_actions without allowing them to overlap the title.
 class CupertinoSliverSelectAppBar extends StatelessWidget {
-  static const double toolbarHeight = 52.0;
+  static const double toolbarHeight = 44.0;
 
   const CupertinoSliverSelectAppBar({
     super.key,
@@ -91,6 +91,7 @@ class CupertinoSliverSelectAppBar extends StatelessWidget {
     return CupertinoSliverAppBar(
       key: const ValueKey('cupertino-sliver-select-app-bar'),
       height: toolbarHeight,
+      backgroundColor: CupertinoColors.transparent,
       border: null,
       title: _viewMode
           ? _CupertinoSelectEntryToolbar(title: title, actions: actions)

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_rail.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_rail.dart
@@ -1,16 +1,19 @@
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/material.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
 import '../shell/navigation_shell_frame.dart';
 import '../shell/side_navigation.dart';
 import '../window_control/window_control_layout.dart';
+import 'material_wide_navigation_rail_button.dart';
 
 /// Material-specific NavigationRail geometry.
 class MaterialNavigationRailStyle {
-  const MaterialNavigationRailStyle({this.collapsedExtent = 72.0})
+  const MaterialNavigationRailStyle({this.collapsedExtent = 96.0})
     : assert(collapsedExtent > 0);
 
-  /// Width of the collapsed icon-only rail.
+  /// Width of a collapsed Material 3 wide navigation rail.
   final double collapsedExtent;
 }
 
@@ -52,25 +55,75 @@ class MaterialAdaptiveNavigationRail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return NavigationRail(
-      selectedIndex: selectedIndex,
-      onDestinationSelected: onDestinationSelected,
+      selectedIndex: null,
       extended: extended,
       minWidth: minWidth,
       minExtendedWidth: minExtendedWidth,
-      leading: leading,
-      destinations: [
-        for (final destination in destinations)
-          NavigationRailDestination(
-            icon: destination.icons.material,
-            selectedIcon: destination.icons.materialSelected,
-            label: destination.semanticsLabel == null
-                ? Text(destination.label)
-                : Semantics(
-                    label: destination.effectiveSemanticsLabel,
-                    excludeSemantics: true,
-                    child: Text(destination.label),
-                  ),
+      // Host the custom content in leading so it shares NavigationRail's
+      // surface and animation. It renders the destinations itself, so the
+      // NavigationRail destinations below intentionally stay empty.
+      leading: _MaterialWideNavigationRailContent(
+        collapsedWidth: minWidth,
+        expandedWidth: minExtendedWidth,
+        leading: leading,
+        destinations: destinations,
+        selectedIndex: selectedIndex,
+        onDestinationSelected: onDestinationSelected,
+      ),
+      destinations: const [],
+    );
+  }
+}
+
+class _MaterialWideNavigationRailContent extends StatelessWidget {
+  const _MaterialWideNavigationRailContent({
+    required this.collapsedWidth,
+    required this.expandedWidth,
+    required this.destinations,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+    this.leading,
+  });
+
+  static const double _headerSpacing = 40.0;
+  static const double _destinationSpacing = 6.0;
+
+  final double collapsedWidth;
+  final double expandedWidth;
+  final Widget? leading;
+  final List<AdaptiveNavigationDestination> destinations;
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final animation = NavigationRail.extendedAnimation(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AnimatedBuilder(
+          animation: animation,
+          builder: (context, child) => SizedBox(
+            width: lerpDouble(collapsedWidth, expandedWidth, animation.value)!,
+            child: child,
           ),
+          child: leading,
+        ),
+        const SizedBox(height: _headerSpacing),
+        for (final (index, destination) in destinations.indexed) ...[
+          MaterialWideNavigationRailButton(
+            slotKey: ValueKey('material-rail-destination-slot-$index'),
+            buttonKey: ValueKey('material-rail-destination-$index'),
+            animation: animation,
+            collapsedRailWidth: collapsedWidth,
+            expandedRailWidth: expandedWidth,
+            destination: destination,
+            selected: selectedIndex == index,
+            onPressed: () => onDestinationSelected(index),
+          ),
+          if (index != destinations.length - 1)
+            const SizedBox(height: _destinationSpacing),
+        ],
       ],
     );
   }
@@ -126,10 +179,12 @@ class MaterialNavigationRailRegion extends StatefulWidget {
 
 class _MaterialNavigationRailRegionState
     extends State<MaterialNavigationRailRegion> {
-  static const double _minimumRailButtonExtent = 44.0;
+  static const double _collapsedDragOpenThreshold = 16.0;
 
   bool _extended = false;
   final SideNavigationResizeState _resizeState = SideNavigationResizeState();
+  double _dragWidth = 0;
+  double _dragOpenWidth = 0;
 
   @override
   void initState() {
@@ -147,28 +202,134 @@ class _MaterialNavigationRailRegionState
   @override
   Widget build(BuildContext context) {
     final windowWidth = MediaQuery.sizeOf(context).width;
+    final resolvedExpandedWidth = _resizeState.effectiveWidth(
+      widget.sideNavigationExtent,
+      windowWidth: windowWidth,
+    );
+    final expandedWidth = resolvedExpandedWidth < widget.style.collapsedExtent
+        ? widget.style.collapsedExtent
+        : resolvedExpandedWidth;
     return AnimatedSize(
       duration: _resizeState.dragging
           ? const Duration(milliseconds: 1)
           : navigationShellAnimationDuration,
       curve: Curves.easeOut,
-      alignment: Alignment.centerLeft,
+      alignment: AlignmentDirectional.centerStart,
       clipBehavior: Clip.hardEdge,
       child: switch (widget.form) {
         NavigationShellForm.compact => const SizedBox(width: 0),
         NavigationShellForm.constrainedSide ||
-        NavigationShellForm.expandedSide => _buildRail(context, windowWidth),
+        NavigationShellForm.expandedSide => _MaterialNavigationRailPanel(
+          selectedIndex: widget.selectedIndex,
+          destinations: widget.destinations,
+          onDestinationSelected: widget.onDestinationSelected,
+          extended: _extended,
+          collapsedWidth: widget.style.collapsedExtent,
+          expandedWidth: expandedWidth,
+          dragHandleBuilder: widget.dragHandleBuilder,
+          expandNavigationLabel: widget.expandNavigationLabel,
+          collapseNavigationLabel: widget.collapseNavigationLabel,
+          onToggle: _toggleExtended,
+          onResizeStart: () => _handleResizeStart(windowWidth),
+          onResizeUpdate: (delta) => _handleResizeUpdate(delta, windowWidth),
+          onResizeEnd: _handleResizeEnd,
+        ),
       },
     );
   }
 
-  Widget _buildRail(BuildContext context, double windowWidth) {
-    final width = _extended
-        ? _resizeState.effectiveWidth(
-            widget.sideNavigationExtent,
-            windowWidth: windowWidth,
-          )
-        : widget.style.collapsedExtent;
+  void _toggleExtended() => setState(() => _extended = !_extended);
+
+  void _handleResizeStart(double windowWidth) {
+    setState(() {
+      final effectiveWidth = _resizeState.effectiveWidth(
+        widget.sideNavigationExtent,
+        windowWidth: windowWidth,
+      );
+      _dragWidth = _extended ? effectiveWidth : widget.style.collapsedExtent;
+      _dragOpenWidth = _extended
+          ? widget.sideNavigationExtent.minimum
+          : widget.style.collapsedExtent + _collapsedDragOpenThreshold;
+      _resizeState.startDrag(
+        widget.sideNavigationExtent,
+        windowWidth: windowWidth,
+      );
+    });
+  }
+
+  void _handleResizeUpdate(double delta, double windowWidth) {
+    setState(() {
+      _dragWidth += delta;
+      if (_dragWidth < widget.style.collapsedExtent) {
+        _dragWidth = widget.style.collapsedExtent;
+      }
+
+      if (_extended) {
+        _resizeState.updateDrag(
+          delta,
+          widget.sideNavigationExtent,
+          windowWidth: windowWidth,
+        );
+        if (_dragWidth >= widget.sideNavigationExtent.minimum) return;
+        _extended = false;
+        _dragOpenWidth = widget.sideNavigationExtent.minimum;
+        return;
+      }
+
+      if (_dragWidth < _dragOpenWidth) return;
+      final effectiveWidth = _resizeState.effectiveWidth(
+        widget.sideNavigationExtent,
+        windowWidth: windowWidth,
+      );
+      _resizeState.updateDrag(
+        widget.sideNavigationExtent.minimum - effectiveWidth,
+        widget.sideNavigationExtent,
+        windowWidth: windowWidth,
+      );
+      _dragWidth = widget.sideNavigationExtent.minimum;
+      _extended = true;
+    });
+  }
+
+  void _handleResizeEnd() => setState(_resizeState.endDrag);
+}
+
+class _MaterialNavigationRailPanel extends StatelessWidget {
+  const _MaterialNavigationRailPanel({
+    required this.selectedIndex,
+    required this.destinations,
+    required this.onDestinationSelected,
+    required this.extended,
+    required this.collapsedWidth,
+    required this.expandedWidth,
+    required this.expandNavigationLabel,
+    required this.collapseNavigationLabel,
+    required this.onToggle,
+    required this.onResizeStart,
+    required this.onResizeUpdate,
+    required this.onResizeEnd,
+    this.dragHandleBuilder,
+  });
+
+  static const double _minimumRailButtonExtent = 44.0;
+
+  final int selectedIndex;
+  final List<AdaptiveNavigationDestination> destinations;
+  final ValueChanged<int> onDestinationSelected;
+  final bool extended;
+  final double collapsedWidth;
+  final double expandedWidth;
+  final SideNavigationDragHandleBuilder? dragHandleBuilder;
+  final String expandNavigationLabel;
+  final String collapseNavigationLabel;
+  final VoidCallback onToggle;
+  final VoidCallback onResizeStart;
+  final ValueChanged<double> onResizeUpdate;
+  final VoidCallback onResizeEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = extended ? expandedWidth : collapsedWidth;
     final horizontalAvoidance =
         AdaptiveWindowControlLayoutScope.sideNavigationHorizontalAvoidanceOf(
           context,
@@ -177,10 +338,10 @@ class _MaterialNavigationRailRegionState
         AdaptiveWindowControlLayoutScope.sideNavigationVerticalAvoidanceOf(
           context,
         );
+    final toggleAnchorWidth = width < collapsedWidth ? width : collapsedWidth;
     final safeWidth =
-        width - horizontalAvoidance.start - horizontalAvoidance.end;
-    final useVerticalFallback =
-        !_extended && safeWidth < _minimumRailButtonExtent;
+        toggleAnchorWidth - horizontalAvoidance.start - horizontalAvoidance.end;
+    final useVerticalFallback = safeWidth < _minimumRailButtonExtent;
     final leadingHorizontalAvoidance = useVerticalFallback
         ? EdgeInsetsDirectional.zero
         : horizontalAvoidance;
@@ -192,78 +353,138 @@ class _MaterialNavigationRailRegionState
       children: [
         MaterialAdaptiveNavigationRail(
           key: const ValueKey('rail-panel'),
-          selectedIndex: widget.selectedIndex,
-          onDestinationSelected: widget.onDestinationSelected,
-          extended: _extended,
-          minWidth: widget.style.collapsedExtent,
-          minExtendedWidth: width,
-          leading: SizedBox(
-            width: width,
-            child: Padding(
-              key: const ValueKey('rail-leading-safe-span'),
-              padding: EdgeInsetsDirectional.only(
-                start: leadingHorizontalAvoidance.start,
-                top: leadingTopAvoidance,
-                end: leadingHorizontalAvoidance.end,
-              ),
-              child: Align(
-                child: IconButton(
-                  key: const ValueKey('rail-toggle-button'),
-                  tooltip: _extended
-                      ? widget.collapseNavigationLabel
-                      : widget.expandNavigationLabel,
-                  icon: Icon(_extended ? Icons.menu_open : Icons.menu),
-                  onPressed: () => setState(() => _extended = !_extended),
+          selectedIndex: selectedIndex,
+          onDestinationSelected: onDestinationSelected,
+          extended: extended,
+          minWidth: collapsedWidth,
+          minExtendedWidth: expandedWidth,
+          leading: Padding(
+            padding: EdgeInsetsDirectional.only(
+              start: leadingHorizontalAvoidance.start,
+              top: leadingTopAvoidance,
+              end: leadingHorizontalAvoidance.end,
+            ),
+            child: const Align(
+              child: SizedBox.square(dimension: kMinInteractiveDimension),
+            ),
+          ),
+          destinations: destinations,
+        ),
+        Positioned.fill(
+          child: SafeArea(
+            left: Directionality.of(context) != TextDirection.rtl,
+            right: Directionality.of(context) == TextDirection.rtl,
+            child: Align(
+              alignment: AlignmentDirectional.topStart,
+              child: SizedBox(
+                width: toggleAnchorWidth,
+                child: Padding(
+                  key: const ValueKey('rail-leading-safe-span'),
+                  padding: EdgeInsetsDirectional.only(
+                    start: leadingHorizontalAvoidance.start,
+                    top: leadingTopAvoidance,
+                    end: leadingHorizontalAvoidance.end,
+                  ),
+                  child: Align(
+                    heightFactor: 1,
+                    child: IconButton(
+                      key: const ValueKey('rail-toggle-button'),
+                      tooltip: extended
+                          ? collapseNavigationLabel
+                          : expandNavigationLabel,
+                      icon: Icon(extended ? Icons.menu_open : Icons.menu),
+                      onPressed: onToggle,
+                    ),
+                  ),
                 ),
               ),
             ),
           ),
-          destinations: widget.destinations,
         ),
-        if (_extended)
-          PositionedDirectional(
-            end: 0,
-            top: 0,
-            bottom: 0,
-            child: _buildResizeHandle(windowWidth),
+        PositionedDirectional(
+          end: 0,
+          top: 0,
+          bottom: 0,
+          child: _MaterialNavigationRailResizeHandle(
+            extended: extended,
+            dragHandleBuilder: dragHandleBuilder,
+            onResizeStart: onResizeStart,
+            onResizeUpdate: onResizeUpdate,
+            onResizeEnd: onResizeEnd,
           ),
+        ),
       ],
-    );
-  }
-
-  Widget _buildResizeHandle(double windowWidth) {
-    return SideNavigationResizeHandle(
-      key: const ValueKey('rail-resize-handle'),
-      hitExtent: 8,
-      dragHandleBuilder: widget.dragHandleBuilder ?? _materialDragHandle,
-      onResizeStart: () => setState(
-        () => _resizeState.startDrag(
-          widget.sideNavigationExtent,
-          windowWidth: windowWidth,
-        ),
-      ),
-      onResizeUpdate: (delta) => setState(
-        () => _resizeState.updateDrag(
-          delta,
-          widget.sideNavigationExtent,
-          windowWidth: windowWidth,
-        ),
-      ),
-      onResizeEnd: () => setState(_resizeState.endDrag),
     );
   }
 }
 
-Widget _materialDragHandle(BuildContext context, Set<WidgetState> _) {
-  return SizedBox(
-    key: const ValueKey('material-side-navigation-drag-bar'),
-    width: 4,
-    height: 32,
-    child: DecoratedBox(
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-        borderRadius: const BorderRadius.all(Radius.circular(2)),
+class _MaterialNavigationRailResizeHandle extends StatelessWidget {
+  const _MaterialNavigationRailResizeHandle({
+    required this.extended,
+    required this.onResizeStart,
+    required this.onResizeUpdate,
+    required this.onResizeEnd,
+    this.dragHandleBuilder,
+  });
+
+  final bool extended;
+  final SideNavigationDragHandleBuilder? dragHandleBuilder;
+  final VoidCallback onResizeStart;
+  final ValueChanged<double> onResizeUpdate;
+  final VoidCallback onResizeEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    return SideNavigationResizeHandle(
+      key: const ValueKey('rail-resize-gesture-handle'),
+      hitExtent: 16,
+      dragHandleBuilder: (context, states) => _MaterialNavigationRailDragHandle(
+        extended: extended,
+        states: states,
+        builder: dragHandleBuilder,
       ),
-    ),
-  );
+      onResizeStart: onResizeStart,
+      onResizeUpdate: onResizeUpdate,
+      onResizeEnd: onResizeEnd,
+    );
+  }
+}
+
+class _MaterialNavigationRailDragHandle extends StatelessWidget {
+  const _MaterialNavigationRailDragHandle({
+    required this.extended,
+    required this.states,
+    this.builder,
+  });
+
+  final bool extended;
+  final Set<WidgetState> states;
+  final SideNavigationDragHandleBuilder? builder;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!extended) {
+      return const SizedBox(
+        key: ValueKey('rail-collapsed-resize-handle'),
+        width: 16,
+        height: 48,
+      );
+    }
+    return KeyedSubtree(
+      key: const ValueKey('rail-resize-handle'),
+      child:
+          builder?.call(context, states) ??
+          SizedBox(
+            key: const ValueKey('material-side-navigation-drag-bar'),
+            width: 4,
+            height: 32,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                borderRadius: const BorderRadius.all(Radius.circular(2)),
+              ),
+            ),
+          ),
+    );
+  }
 }

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_rail.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_rail.dart
@@ -173,7 +173,7 @@ class MaterialNavigationRailRegion extends StatefulWidget {
     required this.railExtent,
   });
 
-  /// Current compact, collapsed-rail, or extended-rail shell form.
+  /// Current compact, constrained-side, or expanded-side shell form.
   final NavigationShellForm form;
 
   /// Zero-based index of the selected destination.
@@ -206,14 +206,14 @@ class _MaterialNavigationRailRegionState
   @override
   void initState() {
     super.initState();
-    _extended = widget.form == NavigationShellForm.railExtended;
+    _extended = widget.form == NavigationShellForm.expandedSide;
   }
 
   @override
   void didUpdateWidget(covariant MaterialNavigationRailRegion oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.form == widget.form) return;
-    _extended = widget.form == NavigationShellForm.railExtended;
+    _extended = widget.form == NavigationShellForm.expandedSide;
   }
 
   double _railAutoWidth(double windowWidth) =>
@@ -239,9 +239,9 @@ class _MaterialNavigationRailRegionState
       alignment: Alignment.centerLeft,
       clipBehavior: Clip.hardEdge,
       child: switch (widget.form) {
-        NavigationShellForm.bar => const SizedBox(width: 0),
-        NavigationShellForm.railCollapsed ||
-        NavigationShellForm.railExtended => Row(
+        NavigationShellForm.compact => const SizedBox(width: 0),
+        NavigationShellForm.constrainedSide ||
+        NavigationShellForm.expandedSide => Row(
           mainAxisSize: MainAxisSize.min,
           children: [
             _buildRail(context, windowWidth),
@@ -257,9 +257,13 @@ class _MaterialNavigationRailRegionState
         ? _effectiveRailWidth(windowWidth)
         : widget.railExtent.collapsed;
     final horizontalAvoidance =
-        AdaptiveWindowControlLayoutScope.railHorizontalAvoidanceOf(context);
+        AdaptiveWindowControlLayoutScope.sideNavigationHorizontalAvoidanceOf(
+          context,
+        );
     final verticalAvoidance =
-        AdaptiveWindowControlLayoutScope.railVerticalAvoidanceOf(context);
+        AdaptiveWindowControlLayoutScope.sideNavigationVerticalAvoidanceOf(
+          context,
+        );
     final safeWidth =
         width - horizontalAvoidance.start - horizontalAvoidance.end;
     final useVerticalFallback =

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_rail.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_rail.dart
@@ -171,6 +171,8 @@ class MaterialNavigationRailRegion extends StatefulWidget {
     required this.destinations,
     required this.onDestinationSelected,
     required this.railExtent,
+    required this.expandNavigationLabel,
+    required this.collapseNavigationLabel,
   });
 
   /// Current compact, constrained-side, or expanded-side shell form.
@@ -187,6 +189,12 @@ class MaterialNavigationRailRegion extends StatefulWidget {
 
   /// Automatic and manually resizable rail-width policy.
   final NavigationRailExtent railExtent;
+
+  /// Localized action label used while the rail is collapsed.
+  final String expandNavigationLabel;
+
+  /// Localized action label used while the rail is expanded.
+  final String collapseNavigationLabel;
 
   @override
   State<MaterialNavigationRailRegion> createState() =>
@@ -297,8 +305,8 @@ class _MaterialNavigationRailRegionState
                 child: IconButton(
                   key: const ValueKey('rail-toggle-button'),
                   tooltip: _extended
-                      ? 'Collapse navigation rail'
-                      : 'Expand navigation rail',
+                      ? widget.collapseNavigationLabel
+                      : widget.expandNavigationLabel,
                   icon: Icon(_extended ? Icons.menu_open : Icons.menu),
                   onPressed: () => setState(() => _extended = !_extended),
                 ),

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_rail.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_rail.dart
@@ -1,102 +1,17 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
 import '../shell/navigation_shell_frame.dart';
+import '../shell/side_navigation.dart';
 import '../window_control/window_control_layout.dart';
 
-/// Extended navigation rail sizing configuration.
-///
-/// [collapsed] controls the icon-only rail. The extended interval grows from
-/// [minimum] to [maximum] as the window moves from [rampStart] to [rampEnd].
-/// The default constructor expresses a fixed logical-pixel target inside that
-/// interval. Use [fromRatio] to express a relative position instead, where 0
-/// selects the minimum and 1 the current upper bound.
-///
-/// ```text
-/// window width  rampStart ------------------------- rampEnd
-/// upper bound   minimum        /------------------- maximum
-/// actual width  clamp(requested, minimum..upper bound)
-/// ```
-class NavigationRailExtent {
-  /// Creates an extent with a fixed preferred extended [width].
-  ///
-  /// The preferred width is clamped to the interval available at runtime.
-  const NavigationRailExtent(
-    double width, {
-    this.collapsed = 72.0,
-    this.minimum = 180.0,
-    this.maximum = 360.0,
-    this.rampStart = 600.0,
-    this.rampEnd = 1600.0,
-  }) : assert(width >= 0),
-       assert(collapsed > 0),
-       assert(minimum > 0),
-       assert(minimum >= collapsed),
-       assert(maximum >= minimum),
-       assert(rampEnd > rampStart),
-       _width = width,
-       _ratio = null;
+/// Material-specific NavigationRail geometry.
+class MaterialNavigationRailStyle {
+  const MaterialNavigationRailStyle({this.collapsedExtent = 72.0})
+    : assert(collapsedExtent > 0);
 
-  /// Creates an extent at [ratio] within the available extended interval.
-  ///
-  /// A ratio of zero selects [minimum], while one selects the current upper
-  /// bound.
-  const NavigationRailExtent.fromRatio(
-    double ratio, {
-    this.collapsed = 72.0,
-    this.minimum = 180.0,
-    this.maximum = 360.0,
-    this.rampStart = 600.0,
-    this.rampEnd = 1600.0,
-  }) : assert(ratio >= 0 && ratio <= 1),
-       assert(collapsed > 0),
-       assert(minimum > 0),
-       assert(minimum >= collapsed),
-       assert(maximum >= minimum),
-       assert(rampEnd > rampStart),
-       _width = null,
-       _ratio = ratio;
-
-  /// Width of the collapsed icon rail.
-  final double collapsed;
-
-  /// Smallest extended rail width.
-  final double minimum;
-
-  /// Largest extended rail width available to manual resizing.
-  final double maximum;
-
-  /// Window width where the available upper bound equals [minimum].
-  final double rampStart;
-
-  /// Window width where the available upper bound reaches [maximum].
-  final double rampEnd;
-
-  final double? _width;
-  final double? _ratio;
-
-  /// Returns the largest rail width available at [windowWidth].
-  double upperBoundAt(double windowWidth) {
-    final t = ((windowWidth - rampStart) / (rampEnd - rampStart)).clamp(
-      0.0,
-      1.0,
-    );
-    return minimum + (maximum - minimum) * t;
-  }
-
-  /// Resolves the automatic rail width at [windowWidth].
-  double resolve(double windowWidth) {
-    final upperBound = upperBoundAt(windowWidth);
-    final width = _width;
-    if (width != null) return width.clamp(minimum, upperBound);
-    return minimum + (upperBound - minimum) * _ratio!;
-  }
-
-  /// Clamps a manually requested [width] to the interval at [windowWidth].
-  double clamp(double width, {required double windowWidth}) =>
-      width.clamp(minimum, upperBoundAt(windowWidth));
+  /// Width of the collapsed icon-only rail.
+  final double collapsedExtent;
 }
 
 /// Renders adaptive destinations with a Material [NavigationRail].
@@ -170,7 +85,9 @@ class MaterialNavigationRailRegion extends StatefulWidget {
     required this.selectedIndex,
     required this.destinations,
     required this.onDestinationSelected,
-    required this.railExtent,
+    required this.sideNavigationExtent,
+    required this.style,
+    required this.dragHandleBuilder,
     required this.expandNavigationLabel,
     required this.collapseNavigationLabel,
   });
@@ -188,7 +105,13 @@ class MaterialNavigationRailRegion extends StatefulWidget {
   final ValueChanged<int> onDestinationSelected;
 
   /// Automatic and manually resizable rail-width policy.
-  final NavigationRailExtent railExtent;
+  final SideNavigationExtent sideNavigationExtent;
+
+  /// Material-specific rail geometry.
+  final MaterialNavigationRailStyle style;
+
+  /// Visual displayed in the rail's resize target.
+  final SideNavigationDragHandleBuilder? dragHandleBuilder;
 
   /// Localized action label used while the rail is collapsed.
   final String expandNavigationLabel;
@@ -206,10 +129,7 @@ class _MaterialNavigationRailRegionState
   static const double _minimumRailButtonExtent = 44.0;
 
   bool _extended = false;
-  double? _manualWidth;
-  bool _manualAboveAuto = false;
-  double _dragCurrentWidth = 0.0;
-  bool _dragging = false;
+  final SideNavigationResizeState _resizeState = SideNavigationResizeState();
 
   @override
   void initState() {
@@ -224,23 +144,11 @@ class _MaterialNavigationRailRegionState
     _extended = widget.form == NavigationShellForm.expandedSide;
   }
 
-  double _railAutoWidth(double windowWidth) =>
-      widget.railExtent.resolve(windowWidth);
-
-  double _effectiveRailWidth(double windowWidth) {
-    final manual = _manualWidth;
-    if (manual == null) return _railAutoWidth(windowWidth);
-    final bound = _manualAboveAuto
-        ? widget.railExtent.upperBoundAt(windowWidth)
-        : _railAutoWidth(windowWidth);
-    return math.min(manual, bound);
-  }
-
   @override
   Widget build(BuildContext context) {
     final windowWidth = MediaQuery.sizeOf(context).width;
     return AnimatedSize(
-      duration: _dragging
+      duration: _resizeState.dragging
           ? const Duration(milliseconds: 1)
           : navigationShellAnimationDuration,
       curve: Curves.easeOut,
@@ -249,21 +157,18 @@ class _MaterialNavigationRailRegionState
       child: switch (widget.form) {
         NavigationShellForm.compact => const SizedBox(width: 0),
         NavigationShellForm.constrainedSide ||
-        NavigationShellForm.expandedSide => Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildRail(context, windowWidth),
-            const VerticalDivider(width: 1),
-          ],
-        ),
+        NavigationShellForm.expandedSide => _buildRail(context, windowWidth),
       },
     );
   }
 
   Widget _buildRail(BuildContext context, double windowWidth) {
     final width = _extended
-        ? _effectiveRailWidth(windowWidth)
-        : widget.railExtent.collapsed;
+        ? _resizeState.effectiveWidth(
+            widget.sideNavigationExtent,
+            windowWidth: windowWidth,
+          )
+        : widget.style.collapsedExtent;
     final horizontalAvoidance =
         AdaptiveWindowControlLayoutScope.sideNavigationHorizontalAvoidanceOf(
           context,
@@ -290,7 +195,7 @@ class _MaterialNavigationRailRegionState
           selectedIndex: widget.selectedIndex,
           onDestinationSelected: widget.onDestinationSelected,
           extended: _extended,
-          minWidth: widget.railExtent.collapsed,
+          minWidth: widget.style.collapsedExtent,
           minExtendedWidth: width,
           leading: SizedBox(
             width: width,
@@ -316,8 +221,8 @@ class _MaterialNavigationRailRegionState
           destinations: widget.destinations,
         ),
         if (_extended)
-          Positioned(
-            right: 0,
+          PositionedDirectional(
+            end: 0,
             top: 0,
             bottom: 0,
             child: _buildResizeHandle(windowWidth),
@@ -327,31 +232,38 @@ class _MaterialNavigationRailRegionState
   }
 
   Widget _buildResizeHandle(double windowWidth) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.resizeColumn,
-      child: GestureDetector(
-        key: const ValueKey('rail-resize-handle'),
-        behavior: HitTestBehavior.opaque,
-        onHorizontalDragStart: (details) {
-          setState(() {
-            _dragging = true;
-            _dragCurrentWidth = _effectiveRailWidth(windowWidth);
-          });
-        },
-        onHorizontalDragUpdate: (details) {
-          setState(() {
-            _dragCurrentWidth = widget.railExtent.clamp(
-              _dragCurrentWidth + details.delta.dx,
-              windowWidth: windowWidth,
-            );
-            _manualWidth = _dragCurrentWidth;
-            _manualAboveAuto = _dragCurrentWidth > _railAutoWidth(windowWidth);
-          });
-        },
-        onHorizontalDragEnd: (_) => setState(() => _dragging = false),
-        onHorizontalDragCancel: () => setState(() => _dragging = false),
-        child: const SizedBox(width: 8, height: double.infinity),
+    return SideNavigationResizeHandle(
+      key: const ValueKey('rail-resize-handle'),
+      hitExtent: 8,
+      dragHandleBuilder: widget.dragHandleBuilder ?? _materialDragHandle,
+      onResizeStart: () => setState(
+        () => _resizeState.startDrag(
+          widget.sideNavigationExtent,
+          windowWidth: windowWidth,
+        ),
       ),
+      onResizeUpdate: (delta) => setState(
+        () => _resizeState.updateDrag(
+          delta,
+          widget.sideNavigationExtent,
+          windowWidth: windowWidth,
+        ),
+      ),
+      onResizeEnd: () => setState(_resizeState.endDrag),
     );
   }
+}
+
+Widget _materialDragHandle(BuildContext context, Set<WidgetState> _) {
+  return SizedBox(
+    key: const ValueKey('material-side-navigation-drag-bar'),
+    width: 4,
+    height: 32,
+    child: DecoratedBox(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+        borderRadius: const BorderRadius.all(Radius.circular(2)),
+      ),
+    ),
+  );
 }

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_shell.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_shell.dart
@@ -1,12 +1,34 @@
 import 'package:flutter/material.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
+import '../breakpoints/window_size_class.dart';
 import '../shell/navigation_scroll_wish_policy.dart';
 import '../shell/navigation_shell_frame.dart';
+import '../window_control/window_control_layout.dart';
 import 'material_navigation_bar.dart';
 import 'material_navigation_rail.dart';
 
 /// Composes the Material renderers around style-neutral shell mechanics.
+///
+/// Compact-width windows use a bottom bar. Medium-width windows and windows
+/// with compact height use a collapsed rail; the remaining wider windows use
+/// an extended rail.
+///
+/// ```text
+/// compact          constrained side  expanded side
+/// +----------+     +--+---------+    +------+-------+
+/// | content  |     |  | content |    | rail |content|
+/// +----------+     |r |         |    |      |       |
+/// | nav bar  |     |a |         |    |      |       |
+/// +----------+     |i |         |    +------+-------+
+///                  |l |         |
+///                  +--+---------+
+/// ```
+///
+/// The extended rail uses [railExtent] for its automatic width and resizable
+/// interval. In compact form, route visibility, contextual chrome, and scroll
+/// direction determine whether navigation is hidden. Side navigation remains
+/// visible.
 class MaterialNavigationShell extends StatelessWidget {
   /// Creates Material navigation chrome around [child].
   const MaterialNavigationShell({
@@ -47,7 +69,6 @@ class MaterialNavigationShell extends StatelessWidget {
   Widget build(BuildContext context) {
     return NavigationShellFrame(
       selectedIndex: selectedIndex,
-      destinations: destinations,
       onDestinationSelected: onDestinationSelected,
       compactRouteVisible: compactRouteVisible,
       contextualChromeSuppressed: contextualChromeSuppressed,
@@ -55,14 +76,17 @@ class MaterialNavigationShell extends StatelessWidget {
       navHeight: _barHeight + MediaQuery.paddingOf(context).bottom,
       keepVisibleOnScroll: false,
       scrollWishPolicy: const NavigationScrollWishPolicy.directional(),
-      leadingBuilder: (context, form, onSelected) =>
-          MaterialNavigationRailRegion(
+      formResolver: _resolveMaterialNavigationShellForm,
+      bodyBuilder: (context, form, onSelected, child) =>
+          _MaterialNavigationShellBody(
             form: form,
             selectedIndex: selectedIndex,
             destinations: destinations,
             onDestinationSelected: onSelected,
             railExtent: railExtent,
+            child: child,
           ),
+      windowControlOwnerResolver: _resolveMaterialWindowControlOwner,
       compactNavigationBuilder: (context, state) =>
           CompactNavigationChromeTransition(
             visibility: state.visible,
@@ -75,6 +99,85 @@ class MaterialNavigationShell extends StatelessWidget {
               labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
             ),
           ),
+      child: child,
+    );
+  }
+}
+
+NavigationShellForm _resolveMaterialNavigationShellForm(
+  WindowSize windowSize,
+) => switch (windowSize.width) {
+  WindowSizeClass.compact => NavigationShellForm.compact,
+  WindowSizeClass.medium => NavigationShellForm.constrainedSide,
+  _ when windowSize.height == WindowSizeClass.compact =>
+    NavigationShellForm.constrainedSide,
+  _ => NavigationShellForm.expandedSide,
+};
+
+WindowControlLayoutOwner _resolveMaterialWindowControlOwner(
+  NavigationShellForm form,
+) => switch (form) {
+  NavigationShellForm.compact => WindowControlLayoutOwner.appBar,
+  NavigationShellForm.constrainedSide ||
+  NavigationShellForm.expandedSide => WindowControlLayoutOwner.sideNavigation,
+};
+
+class _MaterialNavigationShellBody extends StatelessWidget {
+  const _MaterialNavigationShellBody({
+    required this.form,
+    required this.selectedIndex,
+    required this.destinations,
+    required this.onDestinationSelected,
+    required this.railExtent,
+    required this.child,
+  });
+
+  final NavigationShellForm form;
+  final int selectedIndex;
+  final List<AdaptiveNavigationDestination> destinations;
+  final ValueChanged<int> onDestinationSelected;
+  final NavigationRailExtent railExtent;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => ColoredBox(
+    color: Theme.of(context).colorScheme.surface,
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        MaterialNavigationRailRegion(
+          form: form,
+          selectedIndex: selectedIndex,
+          destinations: destinations,
+          onDestinationSelected: onDestinationSelected,
+          railExtent: railExtent,
+        ),
+        Expanded(
+          child: _MaterialNavigationBranch(form: form, child: child),
+        ),
+      ],
+    ),
+  );
+}
+
+class _MaterialNavigationBranch extends StatelessWidget {
+  const _MaterialNavigationBranch({required this.form, required this.child});
+
+  final NavigationShellForm form;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (form == NavigationShellForm.compact) return child;
+
+    // The rail consumes the shell's logical-start system inset. Remove only
+    // that padding from the sibling branch so nested page SafeAreas do not
+    // reserve it again, while keeping the opposite side available to content.
+    final removeLeft = Directionality.of(context) == TextDirection.ltr;
+    return MediaQuery.removePadding(
+      context: context,
+      removeLeft: removeLeft,
+      removeRight: !removeLeft,
       child: child,
     );
   }

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_shell.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_shell.dart
@@ -40,6 +40,8 @@ class MaterialNavigationShell extends StatelessWidget {
     required this.compactRouteVisible,
     required this.contextualChromeSuppressed,
     required this.railExtent,
+    required this.expandNavigationLabel,
+    required this.collapseNavigationLabel,
   });
 
   static const double _barHeight = 80.0;
@@ -65,6 +67,12 @@ class MaterialNavigationShell extends StatelessWidget {
   /// Automatic and manually resizable rail-width policy.
   final NavigationRailExtent railExtent;
 
+  /// Localized action label used when side navigation can expand.
+  final String expandNavigationLabel;
+
+  /// Localized action label used when side navigation can collapse.
+  final String collapseNavigationLabel;
+
   @override
   Widget build(BuildContext context) {
     return NavigationShellFrame(
@@ -84,6 +92,8 @@ class MaterialNavigationShell extends StatelessWidget {
             destinations: destinations,
             onDestinationSelected: onSelected,
             railExtent: railExtent,
+            expandNavigationLabel: expandNavigationLabel,
+            collapseNavigationLabel: collapseNavigationLabel,
             child: child,
           ),
       windowControlOwnerResolver: _resolveMaterialWindowControlOwner,
@@ -129,6 +139,8 @@ class _MaterialNavigationShellBody extends StatelessWidget {
     required this.destinations,
     required this.onDestinationSelected,
     required this.railExtent,
+    required this.expandNavigationLabel,
+    required this.collapseNavigationLabel,
     required this.child,
   });
 
@@ -137,6 +149,8 @@ class _MaterialNavigationShellBody extends StatelessWidget {
   final List<AdaptiveNavigationDestination> destinations;
   final ValueChanged<int> onDestinationSelected;
   final NavigationRailExtent railExtent;
+  final String expandNavigationLabel;
+  final String collapseNavigationLabel;
   final Widget child;
 
   @override
@@ -151,6 +165,8 @@ class _MaterialNavigationShellBody extends StatelessWidget {
           destinations: destinations,
           onDestinationSelected: onDestinationSelected,
           railExtent: railExtent,
+          expandNavigationLabel: expandNavigationLabel,
+          collapseNavigationLabel: collapseNavigationLabel,
         ),
         Expanded(
           child: _MaterialNavigationBranch(form: form, child: child),

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_shell.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_shell.dart
@@ -4,6 +4,7 @@ import '../adaptive/adaptive_navigation_destination.dart';
 import '../breakpoints/window_size_class.dart';
 import '../shell/navigation_scroll_wish_policy.dart';
 import '../shell/navigation_shell_frame.dart';
+import '../shell/side_navigation.dart';
 import '../window_control/window_control_layout.dart';
 import 'material_navigation_bar.dart';
 import 'material_navigation_rail.dart';
@@ -25,7 +26,7 @@ import 'material_navigation_rail.dart';
 ///                  +--+---------+
 /// ```
 ///
-/// The extended rail uses [railExtent] for its automatic width and resizable
+/// The extended rail uses [sideNavigationExtent] for its automatic width and resizable
 /// interval. In compact form, route visibility, contextual chrome, and scroll
 /// direction determine whether navigation is hidden. Side navigation remains
 /// visible.
@@ -39,7 +40,9 @@ class MaterialNavigationShell extends StatelessWidget {
     required this.onDestinationSelected,
     required this.compactRouteVisible,
     required this.contextualChromeSuppressed,
-    required this.railExtent,
+    required this.sideNavigationExtent,
+    required this.railStyle,
+    required this.dragHandleBuilder,
     required this.expandNavigationLabel,
     required this.collapseNavigationLabel,
   });
@@ -65,7 +68,13 @@ class MaterialNavigationShell extends StatelessWidget {
   final bool contextualChromeSuppressed;
 
   /// Automatic and manually resizable rail-width policy.
-  final NavigationRailExtent railExtent;
+  final SideNavigationExtent sideNavigationExtent;
+
+  /// Material-specific rail geometry.
+  final MaterialNavigationRailStyle railStyle;
+
+  /// Visual displayed inside the rail resize target.
+  final SideNavigationDragHandleBuilder? dragHandleBuilder;
 
   /// Localized action label used when side navigation can expand.
   final String expandNavigationLabel;
@@ -91,7 +100,9 @@ class MaterialNavigationShell extends StatelessWidget {
             selectedIndex: selectedIndex,
             destinations: destinations,
             onDestinationSelected: onSelected,
-            railExtent: railExtent,
+            sideNavigationExtent: sideNavigationExtent,
+            railStyle: railStyle,
+            dragHandleBuilder: dragHandleBuilder,
             expandNavigationLabel: expandNavigationLabel,
             collapseNavigationLabel: collapseNavigationLabel,
             child: child,
@@ -138,7 +149,9 @@ class _MaterialNavigationShellBody extends StatelessWidget {
     required this.selectedIndex,
     required this.destinations,
     required this.onDestinationSelected,
-    required this.railExtent,
+    required this.sideNavigationExtent,
+    required this.railStyle,
+    required this.dragHandleBuilder,
     required this.expandNavigationLabel,
     required this.collapseNavigationLabel,
     required this.child,
@@ -148,7 +161,9 @@ class _MaterialNavigationShellBody extends StatelessWidget {
   final int selectedIndex;
   final List<AdaptiveNavigationDestination> destinations;
   final ValueChanged<int> onDestinationSelected;
-  final NavigationRailExtent railExtent;
+  final SideNavigationExtent sideNavigationExtent;
+  final MaterialNavigationRailStyle railStyle;
+  final SideNavigationDragHandleBuilder? dragHandleBuilder;
   final String expandNavigationLabel;
   final String collapseNavigationLabel;
   final Widget child;
@@ -164,7 +179,9 @@ class _MaterialNavigationShellBody extends StatelessWidget {
           selectedIndex: selectedIndex,
           destinations: destinations,
           onDestinationSelected: onDestinationSelected,
-          railExtent: railExtent,
+          sideNavigationExtent: sideNavigationExtent,
+          style: railStyle,
+          dragHandleBuilder: dragHandleBuilder,
           expandNavigationLabel: expandNavigationLabel,
           collapseNavigationLabel: collapseNavigationLabel,
         ),

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_shell.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_shell.dart
@@ -49,6 +49,23 @@ class MaterialNavigationShell extends StatelessWidget {
 
   static const double _barHeight = 80.0;
 
+  NavigationShellForm _resolveForm(WindowSize windowSize) =>
+      switch (windowSize.width) {
+        WindowSizeClass.compact => NavigationShellForm.compact,
+        WindowSizeClass.medium => NavigationShellForm.constrainedSide,
+        _ when windowSize.height == WindowSizeClass.compact =>
+          NavigationShellForm.constrainedSide,
+        _ => NavigationShellForm.expandedSide,
+      };
+
+  WindowControlLayoutOwner _resolveWindowControlOwner(
+    NavigationShellForm form,
+  ) => switch (form) {
+    NavigationShellForm.compact => WindowControlLayoutOwner.appBar,
+    NavigationShellForm.constrainedSide ||
+    NavigationShellForm.expandedSide => WindowControlLayoutOwner.sideNavigation,
+  };
+
   /// Content displayed beside or underneath the navigation chrome.
   final Widget child;
 
@@ -93,7 +110,7 @@ class MaterialNavigationShell extends StatelessWidget {
       navHeight: _barHeight + MediaQuery.paddingOf(context).bottom,
       keepVisibleOnScroll: false,
       scrollWishPolicy: const NavigationScrollWishPolicy.directional(),
-      formResolver: _resolveMaterialNavigationShellForm,
+      formResolver: _resolveForm,
       bodyBuilder: (context, form, onSelected, child) =>
           _MaterialNavigationShellBody(
             form: form,
@@ -107,7 +124,7 @@ class MaterialNavigationShell extends StatelessWidget {
             collapseNavigationLabel: collapseNavigationLabel,
             child: child,
           ),
-      windowControlOwnerResolver: _resolveMaterialWindowControlOwner,
+      windowControlOwnerResolver: _resolveWindowControlOwner,
       compactNavigationBuilder: (context, state) =>
           CompactNavigationChromeTransition(
             visibility: state.visible,
@@ -124,24 +141,6 @@ class MaterialNavigationShell extends StatelessWidget {
     );
   }
 }
-
-NavigationShellForm _resolveMaterialNavigationShellForm(
-  WindowSize windowSize,
-) => switch (windowSize.width) {
-  WindowSizeClass.compact => NavigationShellForm.compact,
-  WindowSizeClass.medium => NavigationShellForm.constrainedSide,
-  _ when windowSize.height == WindowSizeClass.compact =>
-    NavigationShellForm.constrainedSide,
-  _ => NavigationShellForm.expandedSide,
-};
-
-WindowControlLayoutOwner _resolveMaterialWindowControlOwner(
-  NavigationShellForm form,
-) => switch (form) {
-  NavigationShellForm.compact => WindowControlLayoutOwner.appBar,
-  NavigationShellForm.constrainedSide ||
-  NavigationShellForm.expandedSide => WindowControlLayoutOwner.sideNavigation,
-};
 
 class _MaterialNavigationShellBody extends StatelessWidget {
   const _MaterialNavigationShellBody({

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_wide_navigation_rail_button.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_wide_navigation_rail_button.dart
@@ -1,0 +1,310 @@
+import 'dart:ui' show lerpDouble;
+
+import 'package:flutter/material.dart';
+
+import '../adaptive/adaptive_navigation_destination.dart';
+
+/// A Material 3 wide-navigation-rail destination button.
+///
+/// This remains internal to the Material rail renderer until Flutter exposes a
+/// wide rail destination with the same collapsed-to-expanded motion.
+class MaterialWideNavigationRailButton extends StatelessWidget {
+  const MaterialWideNavigationRailButton({
+    super.key,
+    required this.slotKey,
+    required this.buttonKey,
+    required this.animation,
+    required this.collapsedRailWidth,
+    required this.expandedRailWidth,
+    required this.destination,
+    required this.selected,
+    required this.onPressed,
+  });
+
+  static const double _slotHeight = 64.0;
+  static const double _buttonHeight = 56.0;
+  static const double _iconSize = 24.0;
+  static const double _collapsedButtonWidth = 56.0;
+  static const double _collapsedIndicatorHeight = 32.0;
+  static const double _expandedHorizontalMargin = 20.0;
+  static const double _expandedContentInset = 16.0;
+  static const double _expandedIconLabelSpacing = 8.0;
+
+  final Key slotKey;
+  final Key buttonKey;
+  final Animation<double> animation;
+  final double collapsedRailWidth;
+  final double expandedRailWidth;
+  final AdaptiveNavigationDestination destination;
+  final bool selected;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, _) {
+        final progress = animation.value;
+        final slotWidth = lerpDouble(
+          collapsedRailWidth,
+          expandedRailWidth,
+          progress,
+        )!;
+        final buttonWidth = lerpDouble(
+          _collapsedButtonWidth,
+          expandedRailWidth - _expandedHorizontalMargin * 2,
+          progress,
+        )!;
+        final buttonHeight = lerpDouble(
+          _collapsedIndicatorHeight,
+          _buttonHeight,
+          progress,
+        )!;
+        return SizedBox(
+          key: slotKey,
+          width: slotWidth,
+          height: _slotHeight,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              SizedBox(
+                width: buttonWidth,
+                height: buttonHeight,
+                child: _MaterialWideNavigationRailButtonSurface(
+                  buttonKey: buttonKey,
+                  destination: destination,
+                  selected: selected,
+                  progress: progress,
+                  onPressed: onPressed,
+                ),
+              ),
+              PositionedDirectional(
+                start: (slotWidth - _collapsedButtonWidth) / 2,
+                top: 48,
+                width: _collapsedButtonWidth,
+                child: ExcludeSemantics(
+                  child: Opacity(
+                    key: const ValueKey('material-rail-collapsed-label'),
+                    opacity: 1 - progress,
+                    child: _MaterialWideNavigationRailLabel(
+                      destination: destination,
+                      selected: selected,
+                      expanded: false,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _MaterialWideNavigationRailButtonSurface extends StatelessWidget {
+  const _MaterialWideNavigationRailButtonSurface({
+    required this.buttonKey,
+    required this.destination,
+    required this.selected,
+    required this.progress,
+    required this.onPressed,
+  });
+
+  final Key buttonKey;
+  final AdaptiveNavigationDestination destination;
+  final bool selected;
+  final double progress;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final railTheme = NavigationRailTheme.of(context);
+    final colorScheme = theme.colorScheme;
+    final selectedIconTheme =
+        railTheme.selectedIconTheme ??
+        IconThemeData(
+          color: colorScheme.onSecondaryContainer,
+          size: MaterialWideNavigationRailButton._iconSize,
+        );
+    final unselectedIconTheme =
+        railTheme.unselectedIconTheme ??
+        IconThemeData(
+          color: colorScheme.onSurfaceVariant,
+          size: MaterialWideNavigationRailButton._iconSize,
+        );
+    final indicatorColor =
+        railTheme.indicatorColor ?? colorScheme.secondaryContainer;
+    final indicatorShape = railTheme.indicatorShape ?? const StadiumBorder();
+    final iconStart = lerpDouble(
+      (MaterialWideNavigationRailButton._collapsedButtonWidth -
+              MaterialWideNavigationRailButton._iconSize) /
+          2,
+      MaterialWideNavigationRailButton._expandedContentInset,
+      progress,
+    )!;
+    final iconTop = lerpDouble(4, 16, progress)!;
+
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: destination.effectiveSemanticsLabel,
+      excludeSemantics: true,
+      onTap: onPressed,
+      child: TextButton(
+        key: buttonKey,
+        onPressed: onPressed,
+        style: const ButtonStyle(
+          padding: WidgetStatePropertyAll(EdgeInsets.zero),
+          minimumSize: WidgetStatePropertyAll(Size.zero),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          shape: WidgetStatePropertyAll(StadiumBorder()),
+        ),
+        child: Stack(
+          children: [
+            _MaterialWideNavigationRailIndicator(
+              selected: selected,
+              color: indicatorColor,
+              shape: indicatorShape,
+            ),
+            PositionedDirectional(
+              start: iconStart,
+              top: iconTop,
+              width: MaterialWideNavigationRailButton._iconSize,
+              height: MaterialWideNavigationRailButton._iconSize,
+              child: _MaterialWideNavigationRailIcon(
+                destination: destination,
+                selected: selected,
+                selectedTheme: selectedIconTheme,
+                unselectedTheme: unselectedIconTheme,
+              ),
+            ),
+            PositionedDirectional(
+              start:
+                  MaterialWideNavigationRailButton._expandedContentInset +
+                  MaterialWideNavigationRailButton._iconSize +
+                  MaterialWideNavigationRailButton._expandedIconLabelSpacing,
+              end: MaterialWideNavigationRailButton._expandedContentInset,
+              top: 0,
+              bottom: 0,
+              child: Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: Opacity(
+                  key: const ValueKey('material-rail-expanded-label'),
+                  opacity: progress,
+                  child: _MaterialWideNavigationRailLabel(
+                    destination: destination,
+                    selected: selected,
+                    expanded: true,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MaterialWideNavigationRailIndicator extends StatelessWidget {
+  const _MaterialWideNavigationRailIndicator({
+    required this.selected,
+    required this.color,
+    required this.shape,
+  });
+
+  final bool selected;
+  final Color color;
+  final ShapeBorder shape;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: SizedBox(
+        key: const ValueKey('material-rail-indicator'),
+        width: double.infinity,
+        height: double.infinity,
+        child: AnimatedOpacity(
+          opacity: selected ? 1 : 0,
+          duration: kThemeAnimationDuration,
+          curve: Curves.easeInOut,
+          child: DecoratedBox(
+            decoration: ShapeDecoration(color: color, shape: shape),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MaterialWideNavigationRailIcon extends StatelessWidget {
+  const _MaterialWideNavigationRailIcon({
+    required this.destination,
+    required this.selected,
+    required this.selectedTheme,
+    required this.unselectedTheme,
+  });
+
+  final AdaptiveNavigationDestination destination;
+  final bool selected;
+  final IconThemeData selectedTheme;
+  final IconThemeData unselectedTheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: kThemeAnimationDuration,
+      switchInCurve: Curves.easeInOut,
+      switchOutCurve: Curves.easeInOut,
+      child: IconTheme(
+        key: ValueKey(selected),
+        data: selected ? selectedTheme : unselectedTheme,
+        child: selected
+            ? destination.icons.materialSelected
+            : destination.icons.material,
+      ),
+    );
+  }
+}
+
+class _MaterialWideNavigationRailLabel extends StatelessWidget {
+  const _MaterialWideNavigationRailLabel({
+    required this.destination,
+    required this.selected,
+    required this.expanded,
+  });
+
+  final AdaptiveNavigationDestination destination;
+  final bool selected;
+  final bool expanded;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final railTheme = NavigationRailTheme.of(context);
+    final baseStyle = expanded
+        ? theme.textTheme.labelLarge
+        : theme.textTheme.labelMedium;
+    final style = (baseStyle ?? const TextStyle())
+        .merge(
+          selected
+              ? railTheme.selectedLabelTextStyle
+              : railTheme.unselectedLabelTextStyle,
+        )
+        .copyWith(
+          color: selected
+              ? theme.colorScheme.secondary
+              : theme.colorScheme.onSurfaceVariant,
+        );
+    return Text(
+      destination.label,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      textAlign: expanded ? null : TextAlign.center,
+      style: style,
+    );
+  }
+}

--- a/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_nav_scope.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_nav_scope.dart
@@ -10,8 +10,10 @@ import 'adaptive_nav_visibility.dart';
 /// In the compact form, branch pages read [visible] to coordinate FAB /
 /// floating-action animations with the bottom bar and reserve [navHeight].
 /// The shell derives [scrollWish] from active vertical user scrolling;
-/// [reportScrollWish] remains available for explicit non-scroll policy. In
-/// non-compact forms (medium+) navigation is always visible.
+/// [reportScrollWish] remains available for explicit non-scroll policy.
+/// Non-compact forms expose constant-true listenables because this scope only
+/// describes the compact chrome envelope, not renderer-owned side-navigation
+/// visibility.
 class AdaptiveNavScope extends InheritedWidget {
   /// Creates a navigation scope for a shell branch subtree.
   const AdaptiveNavScope({
@@ -52,7 +54,7 @@ class AdaptiveNavScope extends InheritedWidget {
   ///
   /// Normal vertical page scrolling is observed automatically by the shell.
   /// Use this for specialized non-scroll policy. Ignored in non-compact forms,
-  /// where navigation is always visible.
+  /// where side-navigation visibility belongs to the themed renderer.
   void reportScrollWish(bool visible) => _scrollWish?.report(visible);
 
   /// Content height of the bar, excluding the bottom safe-area inset.

--- a/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
@@ -8,10 +8,15 @@ import '../cupertino/cupertino_adaptive_navigation_bar.dart'
 import '../cupertino/cupertino_navigation_primary_action.dart'
     show CupertinoNavigationPrimaryAction;
 import '../cupertino/cupertino_navigation_shell.dart';
-import '../material/material_navigation_rail.dart' show NavigationRailExtent;
+import '../material/material_navigation_rail.dart'
+    show MaterialNavigationRailStyle;
 import '../material/material_navigation_shell.dart';
+import 'side_navigation.dart';
 
-export '../material/material_navigation_rail.dart' show NavigationRailExtent;
+export '../material/material_navigation_rail.dart'
+    show MaterialNavigationRailStyle;
+export 'side_navigation.dart'
+    show SideNavigationDragHandleBuilder, SideNavigationExtent;
 
 /// Adaptive navigation chrome around [child].
 ///
@@ -44,7 +49,9 @@ class AdaptiveNavigationShell extends StatefulWidget {
     this.compactRouteVisible = true,
     this.contextualChromeSuppressed = false,
     this.applePrimaryAction,
-    this.railExtent = const NavigationRailExtent(224.0),
+    this.sideNavigationExtent = const SideNavigationExtent(224.0),
+    this.materialRailStyle = const MaterialNavigationRailStyle(),
+    this.sideNavigationDragHandleBuilder,
     this.appleBarStyle = const AppleNavigationBarStyle(),
   });
 
@@ -79,9 +86,17 @@ class AdaptiveNavigationShell extends StatefulWidget {
 
   /// Full-width side-navigation sizing and manual-resize policy.
   ///
-  /// Material also uses [NavigationRailExtent.collapsed] for its icon rail.
-  /// The Apple sidebar uses only the resolved/clamped full-width interval.
-  final NavigationRailExtent railExtent;
+  /// Both renderers use this policy for their full-width side navigation.
+  final SideNavigationExtent sideNavigationExtent;
+
+  /// Material-specific NavigationRail geometry.
+  final MaterialNavigationRailStyle materialRailStyle;
+
+  /// Optional visual displayed inside the side-navigation resize target.
+  ///
+  /// When null, Material displays its default drag bar while Cupertino keeps
+  /// the target visually empty. An explicit builder is used by both renderers.
+  final SideNavigationDragHandleBuilder? sideNavigationDragHandleBuilder;
 
   /// Apple compact navigation-bar geometry and spacing.
   final AppleNavigationBarStyle appleBarStyle;
@@ -114,7 +129,9 @@ class _AdaptiveNavigationShellState extends State<AdaptiveNavigationShell> {
         onDestinationSelected: widget.onDestinationSelected,
         compactRouteVisible: widget.compactRouteVisible,
         contextualChromeSuppressed: widget.contextualChromeSuppressed,
-        railExtent: widget.railExtent,
+        sideNavigationExtent: widget.sideNavigationExtent,
+        railStyle: widget.materialRailStyle,
+        dragHandleBuilder: widget.sideNavigationDragHandleBuilder,
         expandNavigationLabel: expandNavigationLabel,
         collapseNavigationLabel: collapseNavigationLabel,
         child: child,
@@ -126,7 +143,8 @@ class _AdaptiveNavigationShellState extends State<AdaptiveNavigationShell> {
         compactRouteVisible: widget.compactRouteVisible,
         contextualChromeSuppressed: widget.contextualChromeSuppressed,
         primaryAction: widget.applePrimaryAction,
-        railExtent: widget.railExtent,
+        sideNavigationExtent: widget.sideNavigationExtent,
+        dragHandleBuilder: widget.sideNavigationDragHandleBuilder,
         appleBarStyle: widget.appleBarStyle,
         child: child,
       ),

--- a/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
@@ -49,7 +49,7 @@ class AdaptiveNavigationShell extends StatefulWidget {
     this.compactRouteVisible = true,
     this.contextualChromeSuppressed = false,
     this.applePrimaryAction,
-    this.sideNavigationExtent = const SideNavigationExtent(224.0),
+    this.sideNavigationExtent = const SideNavigationExtent(200.0),
     this.materialRailStyle = const MaterialNavigationRailStyle(),
     this.sideNavigationDragHandleBuilder,
     this.appleBarStyle = const AppleNavigationBarStyle(),

--- a/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
@@ -15,25 +15,22 @@ export '../material/material_navigation_rail.dart' show NavigationRailExtent;
 /// Adaptive navigation chrome around [child].
 ///
 /// The shell resolves the active visual style, while Material and Cupertino
-/// renderers own their platform policy. Compact windows use a bottom bar,
-/// medium windows use a collapsed rail, and wider windows use an extended rail
-/// unless their height is compact.
+/// renderers own their form resolution, body composition, inset policy, and
+/// window-control ownership. Compact windows use bottom navigation. Material
+/// side forms use collapsed or extended rails; Apple medium and large forms
+/// are reserved for overlay and beside sidebars respectively.
 ///
 /// ```text
-/// compact          medium            expanded
-/// +----------+     +--+---------+    +------+-------+
-/// | content  |     |  | content |    | rail |content|
-/// +----------+     |r |         |    |      |       |
-/// | nav bar  |     |a |         |    |      |       |
-/// +----------+     |i |         |    +------+-------+
-///                  |l |         |
-///                  +--+---------+
+/// form              Material              Apple
+/// compact           bottom bar            bottom Tab Bar
+/// constrained side  collapsed rail        medium overlay Sidebar
+/// expanded side     extended rail         large beside Sidebar
 /// ```
 ///
-/// The extended rail uses [railExtent] for its automatic width and resizable
-/// interval. In compact form, route visibility, contextual chrome, and scroll
-/// direction determine whether Material navigation is hidden or Apple
-/// navigation is minimized. Non-compact navigation remains visible.
+/// Until the Apple sidebar renderer lands, Apple side forms preserve the
+/// documented Material-rail compatibility fallback. In compact form, route
+/// visibility, contextual chrome, and scroll direction determine whether
+/// Material navigation is hidden or Apple navigation is minimized.
 class AdaptiveNavigationShell extends StatefulWidget {
   /// Creates adaptive navigation chrome around [child].
   const AdaptiveNavigationShell({
@@ -78,7 +75,10 @@ class AdaptiveNavigationShell extends StatefulWidget {
   /// [CupertinoNavigationPrimaryAction] for placement diagrams.
   final CupertinoNavigationPrimaryAction? applePrimaryAction;
 
-  /// Extended-rail sizing and manual-resize policy.
+  /// Full-width side-navigation sizing and manual-resize policy.
+  ///
+  /// Material also uses [NavigationRailExtent.collapsed] for its icon rail.
+  /// The Apple sidebar uses only the resolved/clamped full-width interval.
   final NavigationRailExtent railExtent;
 
   /// Apple compact navigation-bar geometry and spacing.

--- a/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/adaptive_navigation.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart' show MaterialLocalizations;
 import 'package:flutter/widgets.dart';
 
 import '../adaptive/adaptive_navigation_destination.dart';
@@ -17,20 +18,21 @@ export '../material/material_navigation_rail.dart' show NavigationRailExtent;
 /// The shell resolves the active visual style, while Material and Cupertino
 /// renderers own their form resolution, body composition, inset policy, and
 /// window-control ownership. Compact windows use bottom navigation. Material
-/// side forms use collapsed or extended rails; Apple medium and large forms
-/// are reserved for overlay and beside sidebars respectively.
+/// side forms use collapsed or extended rails; Apple medium and larger forms
+/// use one hideable beside Sidebar.
 ///
 /// ```text
 /// form              Material              Apple
 /// compact           bottom bar            bottom Tab Bar
-/// constrained side  collapsed rail        medium overlay Sidebar
-/// expanded side     extended rail         large beside Sidebar
+/// constrained side  collapsed rail        beside Sidebar
+/// expanded side     extended rail         beside Sidebar
 /// ```
 ///
-/// Until the Apple sidebar renderer lands, Apple side forms preserve the
-/// documented Material-rail compatibility fallback. In compact form, route
-/// visibility, contextual chrome, and scroll direction determine whether
-/// Material navigation is hidden or Apple navigation is minimized.
+/// Apple side forms share the same visibility and width state. Hiding the
+/// Sidebar removes it completely instead of leaving an icon-only rail. In
+/// compact form, route visibility, contextual chrome, and scroll direction
+/// determine whether Material navigation is hidden or Apple navigation is
+/// minimized.
 class AdaptiveNavigationShell extends StatefulWidget {
   /// Creates adaptive navigation chrome around [child].
   const AdaptiveNavigationShell({
@@ -96,6 +98,14 @@ class _AdaptiveNavigationShellState extends State<AdaptiveNavigationShell> {
 
   @override
   Widget build(BuildContext context) {
+    final materialLocalizations = Localizations.of<MaterialLocalizations>(
+      context,
+      MaterialLocalizations,
+    );
+    final expandNavigationLabel =
+        materialLocalizations?.collapsedIconTapHint ?? 'Expand';
+    final collapseNavigationLabel =
+        materialLocalizations?.expandedIconTapHint ?? 'Collapse';
     final child = KeyedSubtree(key: _childKey, child: widget.child);
     return switch (AdaptiveStyle.of(context)) {
       AdaptiveStyle.material => MaterialNavigationShell(
@@ -105,6 +115,8 @@ class _AdaptiveNavigationShellState extends State<AdaptiveNavigationShell> {
         compactRouteVisible: widget.compactRouteVisible,
         contextualChromeSuppressed: widget.contextualChromeSuppressed,
         railExtent: widget.railExtent,
+        expandNavigationLabel: expandNavigationLabel,
+        collapseNavigationLabel: collapseNavigationLabel,
         child: child,
       ),
       AdaptiveStyle.apple => CupertinoNavigationShell(

--- a/packages/mhabit_adaptive_ui/lib/src/shell/navigation_shell_frame.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/navigation_shell_frame.dart
@@ -2,45 +2,52 @@ import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/gestures.dart' show kMinFlingVelocity, kTouchSlop;
 import 'package:flutter/material.dart';
 
-import '../adaptive/adaptive_navigation_destination.dart';
 import '../breakpoints/window_size_class.dart';
 import '../window_control/window_control_layout.dart';
 import 'adaptive_nav_scope.dart';
 import 'adaptive_nav_visibility.dart';
 import 'navigation_scroll_wish_policy.dart';
 
-/// Navigation form selected from the current window size classes.
+/// Style-neutral space available to a navigation renderer.
 ///
 /// ```text
-/// bar              railCollapsed      railExtended
-/// +----------+     +--+----------+    +------+------+
-/// | content  |     |r | content  |    | rail |content|
-/// +----------+     |a |          |    |      |       |
-/// | nav bar  |     |i |          |    |      |       |
-/// +----------+     |l |          |    +------+-------+
-///                  +--+----------+
+/// compact          constrained side   expanded side
+/// +----------+     +-------------+    +-------------+
+/// | content  |     | renderer    |    | renderer    |
+/// +----------+     | composition |    | composition |
+/// | nav      |     +-------------+    +-------------+
+/// +----------+
 /// ```
 enum NavigationShellForm {
   /// Compact bottom navigation below the branch content.
-  bar,
+  compact,
 
-  /// Medium-and-wider side rail initially showing icons only.
-  railCollapsed,
+  /// Side navigation with constrained horizontal space.
+  constrainedSide,
 
-  /// Wide side rail initially showing icons and labels.
-  railExtended,
+  /// Side navigation with expanded horizontal space.
+  expandedSide,
 }
 
 /// Default duration for navigation form and compact-chrome transitions.
 const Duration navigationShellAnimationDuration = Duration(milliseconds: 250);
 
-/// Builds the leading rail region for the current shell form.
-typedef NavigationShellLeadingBuilder =
+/// Resolves style-neutral shell space from the current window classes.
+typedef NavigationShellFormResolver =
+    NavigationShellForm Function(WindowSize windowSize);
+
+/// Composes branch content and navigation chrome for the current form.
+typedef NavigationShellBodyBuilder =
     Widget Function(
       BuildContext context,
       NavigationShellForm form,
       ValueChanged<int> onDestinationSelected,
+      Widget child,
     );
+
+/// Selects the window-control owner for the current shell form.
+typedef NavigationShellWindowControlOwnerResolver =
+    WindowControlLayoutOwner Function(NavigationShellForm form);
 
 /// Builds compact navigation or floating action chrome from shell state.
 typedef NavigationShellChromeBuilder =
@@ -81,7 +88,6 @@ class NavigationShellFrame extends StatefulWidget {
     super.key,
     required this.child,
     required this.selectedIndex,
-    required this.destinations,
     required this.onDestinationSelected,
     required this.compactRouteVisible,
     required this.contextualChromeSuppressed,
@@ -89,7 +95,9 @@ class NavigationShellFrame extends StatefulWidget {
     required this.navHeight,
     required this.keepVisibleOnScroll,
     required this.scrollWishPolicy,
-    required this.leadingBuilder,
+    required this.formResolver,
+    required this.bodyBuilder,
+    required this.windowControlOwnerResolver,
     required this.compactNavigationBuilder,
     this.floatingActionButtonBuilder,
     this.floatingActionButtonLocation,
@@ -101,9 +109,6 @@ class NavigationShellFrame extends StatefulWidget {
 
   /// Zero-based index of the selected destination.
   final int selectedIndex;
-
-  /// Top-level destinations supplied to themed renderers.
-  final List<AdaptiveNavigationDestination> destinations;
 
   /// Called with the index of a destination selected by the user.
   final ValueChanged<int> onDestinationSelected;
@@ -128,8 +133,14 @@ class NavigationShellFrame extends StatefulWidget {
   /// Converts compact vertical scrolling into navigation presentation wishes.
   final NavigationScrollWishPolicy scrollWishPolicy;
 
-  /// Builds the rail region for non-compact shell forms.
-  final NavigationShellLeadingBuilder leadingBuilder;
+  /// Resolves the renderer-neutral form from the current window classes.
+  final NavigationShellFormResolver formResolver;
+
+  /// Owns branch/chrome composition and renderer-local inset policy.
+  final NavigationShellBodyBuilder bodyBuilder;
+
+  /// Selects which chrome consumes platform window-control avoidance.
+  final NavigationShellWindowControlOwnerResolver windowControlOwnerResolver;
 
   /// Builds compact navigation from the current chrome state.
   final NavigationShellChromeBuilder compactNavigationBuilder;
@@ -148,7 +159,7 @@ class NavigationShellFrame extends StatefulWidget {
 }
 
 class _NavigationShellFrameState extends State<NavigationShellFrame> {
-  NavigationShellForm _form = NavigationShellForm.bar;
+  NavigationShellForm _form = NavigationShellForm.compact;
   final AdaptiveNavVisibilityController _navVisibility =
       AdaptiveNavVisibilityController();
   final AdaptiveScrollWishController _scrollWish =
@@ -163,8 +174,8 @@ class _NavigationShellFrameState extends State<NavigationShellFrame> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _form = _formFor(WindowSize.of(context));
-    if (_form == NavigationShellForm.bar) {
+    _form = widget.formResolver(WindowSize.of(context));
+    if (_form == NavigationShellForm.compact) {
       _recomputeVisibility();
     } else {
       _navVisibility.show();
@@ -200,7 +211,7 @@ class _NavigationShellFrameState extends State<NavigationShellFrame> {
   }
 
   void _recomputeVisibility() {
-    if (!mounted || _form != NavigationShellForm.bar) return;
+    if (!mounted || _form != NavigationShellForm.compact) return;
     final visible =
         widget.compactRouteVisible &&
         (widget.keepVisibleOnScroll || _scrollWish.value) &&
@@ -214,20 +225,9 @@ class _NavigationShellFrameState extends State<NavigationShellFrame> {
     widget.onDestinationSelected(index);
   }
 
-  NavigationShellForm _formFor(WindowSize windowSize) {
-    if (windowSize.width == WindowSizeClass.compact) {
-      return NavigationShellForm.bar;
-    }
-    if (windowSize.width == WindowSizeClass.medium ||
-        windowSize.height == WindowSizeClass.compact) {
-      return NavigationShellForm.railCollapsed;
-    }
-    return NavigationShellForm.railExtended;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final compact = _form == NavigationShellForm.bar;
+    final compact = _form == NavigationShellForm.compact;
     final windowControlLayout = AdaptiveWindowControlLayoutScope.maybeOf(
       context,
     );
@@ -253,11 +253,11 @@ class _NavigationShellFrameState extends State<NavigationShellFrame> {
         body: _NavigationScrollWishObserver(
           onVisibilityChanged: _scrollWish.report,
           policy: widget.scrollWishPolicy,
-          child: _NavigationShellBody(
+          child: _NavigationShellBodyHost(
             ambientPadding: padding,
             ambientViewPadding: viewPadding,
             form: _form,
-            leadingBuilder: widget.leadingBuilder,
+            bodyBuilder: widget.bodyBuilder,
             onDestinationSelected: _onDestinationSelected,
             child: widget.child,
           ),
@@ -283,7 +283,7 @@ class _NavigationShellFrameState extends State<NavigationShellFrame> {
     return _withWindowControlOwner(
       context,
       layout: windowControlLayout,
-      railOwnsAvoidance: !compact,
+      owner: widget.windowControlOwnerResolver(_form),
       shell: shell,
     );
   }
@@ -291,13 +291,13 @@ class _NavigationShellFrameState extends State<NavigationShellFrame> {
   Widget _withWindowControlOwner(
     BuildContext context, {
     required AdaptiveWindowControlLayoutScope? layout,
-    required bool railOwnsAvoidance,
+    required WindowControlLayoutOwner owner,
     required Widget shell,
   }) {
     if (layout != null) {
       return _WindowControlLayoutOwner(
         layout: layout,
-        railOwnsAvoidance: railOwnsAvoidance,
+        owner: owner,
         child: shell,
       );
     }
@@ -305,7 +305,7 @@ class _NavigationShellFrameState extends State<NavigationShellFrame> {
       child: Builder(
         builder: (context) => _WindowControlLayoutOwner(
           layout: AdaptiveWindowControlLayoutScope.maybeOf(context)!,
-          railOwnsAvoidance: railOwnsAvoidance,
+          owner: owner,
           child: shell,
         ),
       ),
@@ -448,12 +448,13 @@ class _NavigationScrollWishObserverState
       );
 }
 
-class _NavigationShellBody extends StatelessWidget {
-  const _NavigationShellBody({
+/// Restores shell-entry geometry without imposing renderer composition.
+class _NavigationShellBodyHost extends StatelessWidget {
+  const _NavigationShellBodyHost({
     required this.ambientPadding,
     required this.ambientViewPadding,
     required this.form,
-    required this.leadingBuilder,
+    required this.bodyBuilder,
     required this.onDestinationSelected,
     required this.child,
   });
@@ -461,64 +462,31 @@ class _NavigationShellBody extends StatelessWidget {
   final EdgeInsets ambientPadding;
   final EdgeInsets ambientViewPadding;
   final NavigationShellForm form;
-  final NavigationShellLeadingBuilder leadingBuilder;
+  final NavigationShellBodyBuilder bodyBuilder;
   final ValueChanged<int> onDestinationSelected;
   final Widget child;
 
   @override
-  Widget build(BuildContext context) {
-    return MediaQuery(
-      data: MediaQuery.of(
-        context,
-      ).copyWith(padding: ambientPadding, viewPadding: ambientViewPadding),
-      child: ColoredBox(
-        color: Theme.of(context).colorScheme.surface,
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            leadingBuilder(context, form, onDestinationSelected),
-            Expanded(
-              child: _NavigationShellBranch(form: form, child: child),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _NavigationShellBranch extends StatelessWidget {
-  const _NavigationShellBranch({required this.form, required this.child});
-
-  final NavigationShellForm form;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    if (form == NavigationShellForm.bar) return child;
-
-    // NavigationRail's SafeArea owns the shell's logical-start system inset.
-    // Remove that consumed inset from the sibling branch so page SafeAreas do
-    // not reserve it again. Keep the opposite side available to page content.
-    final removeLeft = Directionality.of(context) == TextDirection.ltr;
-    return MediaQuery.removePadding(
-      context: context,
-      removeLeft: removeLeft,
-      removeRight: !removeLeft,
-      child: child,
-    );
-  }
+  Widget build(BuildContext context) => MediaQuery(
+    data: MediaQuery.of(
+      context,
+    ).copyWith(padding: ambientPadding, viewPadding: ambientViewPadding),
+    child: Builder(
+      builder: (context) =>
+          bodyBuilder(context, form, onDestinationSelected, child),
+    ),
+  );
 }
 
 class _WindowControlLayoutOwner extends StatelessWidget {
   const _WindowControlLayoutOwner({
     required this.layout,
-    required this.railOwnsAvoidance,
+    required this.owner,
     required this.child,
   });
 
   final AdaptiveWindowControlLayoutScope layout;
-  final bool railOwnsAvoidance;
+  final WindowControlLayoutOwner owner;
   final Widget child;
 
   @override
@@ -530,9 +498,7 @@ class _WindowControlLayoutOwner extends StatelessWidget {
       verticalSafeAreaAvoidance: layout.verticalSafeAreaAvoidance,
       effectiveCornerRadii: layout.effectiveCornerRadii,
       usesRectangularDisplay: layout.usesRectangularDisplay,
-      owner: railOwnsAvoidance
-          ? WindowControlLayoutOwner.rail
-          : WindowControlLayoutOwner.appBar,
+      owner: owner,
       child: child,
     );
   }

--- a/packages/mhabit_adaptive_ui/lib/src/shell/navigation_sidebar_app_bar_leading.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/navigation_sidebar_app_bar_leading.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/widgets.dart';
+
+/// Renderer-owned Sidebar command exposed to page app bars.
+///
+/// The navigation renderer owns the actual floating control. Page app bars
+/// consume only this geometry so they reserve space beside existing leading
+/// content without reparenting the control during route changes.
+class NavigationSidebarAppBarLeading extends InheritedWidget {
+  const NavigationSidebarAppBarLeading({
+    super.key,
+    required this.toolbarAvoidance,
+    required this.toolbarTopInset,
+    required this.progress,
+    required super.child,
+  });
+
+  static const double buttonExtent = 44;
+
+  /// Logical toolbar space occupied by platform window controls.
+  final EdgeInsetsDirectional toolbarAvoidance;
+
+  /// Extra top inset used to align a toolbar with floating side navigation.
+  final double toolbarTopInset;
+
+  /// Visibility progress for the AppBar's reserved leading slot.
+  final double progress;
+
+  /// Width reserved before the page-owned leading content.
+  double get reservedExtent => buttonExtent * progress;
+
+  static NavigationSidebarAppBarLeading? maybeOf(BuildContext context) =>
+      context
+          .dependOnInheritedWidgetOfExactType<NavigationSidebarAppBarLeading>();
+
+  @override
+  bool updateShouldNotify(NavigationSidebarAppBarLeading oldWidget) =>
+      toolbarAvoidance != oldWidget.toolbarAvoidance ||
+      toolbarTopInset != oldWidget.toolbarTopInset ||
+      progress != oldWidget.progress;
+}

--- a/packages/mhabit_adaptive_ui/lib/src/shell/side_navigation.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/shell/side_navigation.dart
@@ -1,0 +1,207 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+/// Full-width side-navigation sizing configuration.
+///
+/// The available interval grows from [minimum] to [maximum] as the window
+/// moves from [rampStart] to [rampEnd]. The default constructor expresses a
+/// fixed logical-pixel target inside that interval. Use [fromRatio] to express
+/// a relative position instead, where 0 selects the minimum and 1 the current
+/// upper bound.
+class SideNavigationExtent {
+  /// Creates an extent with a fixed preferred [width].
+  const SideNavigationExtent(
+    double width, {
+    this.minimum = 180.0,
+    this.maximum = 360.0,
+    this.rampStart = 600.0,
+    this.rampEnd = 1600.0,
+  }) : assert(width >= 0),
+       assert(minimum > 0),
+       assert(maximum >= minimum),
+       assert(rampEnd > rampStart),
+       _width = width,
+       _ratio = null;
+
+  /// Creates an extent at [ratio] within the available interval.
+  const SideNavigationExtent.fromRatio(
+    double ratio, {
+    this.minimum = 180.0,
+    this.maximum = 360.0,
+    this.rampStart = 600.0,
+    this.rampEnd = 1600.0,
+  }) : assert(ratio >= 0 && ratio <= 1),
+       assert(minimum > 0),
+       assert(maximum >= minimum),
+       assert(rampEnd > rampStart),
+       _width = null,
+       _ratio = ratio;
+
+  /// Smallest full-width side-navigation extent.
+  final double minimum;
+
+  /// Largest full-width side-navigation extent available to manual resizing.
+  final double maximum;
+
+  /// Window width where the available upper bound equals [minimum].
+  final double rampStart;
+
+  /// Window width where the available upper bound reaches [maximum].
+  final double rampEnd;
+
+  final double? _width;
+  final double? _ratio;
+
+  /// Returns the largest side-navigation extent available at [windowWidth].
+  double upperBoundAt(double windowWidth) {
+    final t = ((windowWidth - rampStart) / (rampEnd - rampStart)).clamp(
+      0.0,
+      1.0,
+    );
+    return minimum + (maximum - minimum) * t;
+  }
+
+  /// Resolves the automatic side-navigation extent at [windowWidth].
+  double resolve(double windowWidth) {
+    final upperBound = upperBoundAt(windowWidth);
+    final width = _width;
+    if (width != null) return width.clamp(minimum, upperBound);
+    return minimum + (upperBound - minimum) * _ratio!;
+  }
+
+  /// Clamps a manually requested [width] to the interval at [windowWidth].
+  double clamp(double width, {required double windowWidth}) =>
+      width.clamp(minimum, upperBoundAt(windowWidth));
+}
+
+/// Builds the optional visual displayed inside a side-navigation resize target.
+typedef SideNavigationDragHandleBuilder =
+    Widget Function(BuildContext context, Set<WidgetState> states);
+
+/// Mutable width state shared by side-navigation renderers.
+///
+/// This type is package-internal. Renderers retain ownership of their widget
+/// lifecycle and call these methods from their own `setState` callbacks.
+class SideNavigationResizeState {
+  double? _manualWidth;
+  bool _manualAboveAuto = false;
+  double _dragCurrentWidth = 0;
+  bool _dragging = false;
+
+  /// Whether a resize drag is active.
+  bool get dragging => _dragging;
+
+  /// Resolves the current width without discarding a remembered manual width.
+  double effectiveWidth(
+    SideNavigationExtent extent, {
+    required double windowWidth,
+  }) {
+    final manualWidth = _manualWidth;
+    if (manualWidth == null) return extent.resolve(windowWidth);
+    final bound = _manualAboveAuto
+        ? extent.upperBoundAt(windowWidth)
+        : extent.resolve(windowWidth);
+    return math.min(manualWidth, bound);
+  }
+
+  /// Starts resizing from the currently effective width.
+  void startDrag(SideNavigationExtent extent, {required double windowWidth}) {
+    _dragging = true;
+    _dragCurrentWidth = effectiveWidth(extent, windowWidth: windowWidth);
+  }
+
+  /// Applies a logical horizontal [delta] and remembers the resulting width.
+  void updateDrag(
+    double delta,
+    SideNavigationExtent extent, {
+    required double windowWidth,
+  }) {
+    assert(_dragging);
+    _dragCurrentWidth = extent.clamp(
+      _dragCurrentWidth + delta,
+      windowWidth: windowWidth,
+    );
+    _manualWidth = _dragCurrentWidth;
+    _manualAboveAuto = _dragCurrentWidth > extent.resolve(windowWidth);
+  }
+
+  /// Ends or cancels the active drag while preserving its last width.
+  void endDrag() => _dragging = false;
+}
+
+/// Direction-aware horizontal resize target for side navigation.
+class SideNavigationResizeHandle extends StatefulWidget {
+  const SideNavigationResizeHandle({
+    super.key,
+    required this.hitExtent,
+    required this.onResizeStart,
+    required this.onResizeUpdate,
+    required this.onResizeEnd,
+    this.dragHandleBuilder,
+  }) : assert(hitExtent > 0);
+
+  /// Width of the interactive target around the optional visual.
+  final double hitExtent;
+
+  /// Optional visual centered inside the interactive target.
+  final SideNavigationDragHandleBuilder? dragHandleBuilder;
+
+  final VoidCallback onResizeStart;
+  final ValueChanged<double> onResizeUpdate;
+  final VoidCallback onResizeEnd;
+
+  @override
+  State<SideNavigationResizeHandle> createState() =>
+      _SideNavigationResizeHandleState();
+}
+
+class _SideNavigationResizeHandleState
+    extends State<SideNavigationResizeHandle> {
+  final Set<WidgetState> _states = <WidgetState>{};
+
+  void _setState(WidgetState state, bool value) {
+    final changed = value ? _states.add(state) : _states.remove(state);
+    if (changed) setState(() {});
+  }
+
+  void _handleResizeEnd() {
+    _setState(WidgetState.dragged, false);
+    widget.onResizeEnd();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final direction = Directionality.of(context);
+    final builder = widget.dragHandleBuilder;
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeColumn,
+      onEnter: (_) => _setState(WidgetState.hovered, true),
+      onExit: (_) => _setState(WidgetState.hovered, false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragStart: (_) {
+          _setState(WidgetState.dragged, true);
+          widget.onResizeStart();
+        },
+        onHorizontalDragUpdate: (details) {
+          final logicalDelta = direction == TextDirection.ltr
+              ? details.delta.dx
+              : -details.delta.dx;
+          widget.onResizeUpdate(logicalDelta);
+        },
+        onHorizontalDragEnd: (_) => _handleResizeEnd(),
+        onHorizontalDragCancel: _handleResizeEnd,
+        child: SizedBox(
+          width: widget.hitExtent,
+          height: double.infinity,
+          child: Center(
+            child: builder == null
+                ? const SizedBox.shrink()
+                : builder(context, Set<WidgetState>.unmodifiable(_states)),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/mhabit_adaptive_ui/lib/src/window_control/material_app_bar.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/window_control/material_app_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../shell/navigation_sidebar_app_bar_leading.dart';
 import 'toolbar_geometry.dart';
 
 /// A Material [AppBar] whose leading and action slots avoid window controls.
@@ -510,19 +511,30 @@ _MaterialToolbarSlots _resolveMaterialToolbarSlots(
   required EdgeInsetsDirectional? avoidance,
   required EdgeInsetsDirectional edgePadding,
 }) {
+  final sidebarLeading = NavigationSidebarAppBarLeading.maybeOf(context);
+  final effectiveEdgePadding = sidebarLeading == null
+      ? edgePadding
+      : EdgeInsetsDirectional.fromSTEB(
+          cupertinoWindowControlEdgePadding.start,
+          edgePadding.top,
+          edgePadding.end,
+          edgePadding.bottom,
+        );
   final geometry = WindowControlToolbarGeometry.resolve(
     context,
-    avoidance: avoidance,
-    edgePadding: edgePadding,
+    avoidance: avoidance ?? sidebarLeading?.toolbarAvoidance,
+    edgePadding: effectiveEdgePadding,
   );
   final startInset = geometry.materialStartInset;
   final endInset = geometry.materialEndInset;
-  final scaffold = startInset > 0 || endInset > 0
+  final scaffold = startInset > 0 || endInset > 0 || sidebarLeading != null
       ? Scaffold.maybeOf(context)
       : null;
   var effectiveLeading = leading;
   var effectiveAutomaticallyImplyLeading = automaticallyImplyLeading;
-  if (startInset > 0 && effectiveLeading == null && automaticallyImplyLeading) {
+  if ((startInset > 0 || sidebarLeading != null) &&
+      effectiveLeading == null &&
+      automaticallyImplyLeading) {
     final route = ModalRoute.of(context);
     if (scaffold?.hasDrawer ?? false) {
       effectiveLeading = const DrawerButton();
@@ -532,7 +544,9 @@ _MaterialToolbarSlots _resolveMaterialToolbarSlots(
           : const BackButton();
     }
   }
-  if (startInset > 0) effectiveAutomaticallyImplyLeading = false;
+  if (startInset > 0 || sidebarLeading != null) {
+    effectiveAutomaticallyImplyLeading = false;
+  }
 
   List<Widget>? effectiveActions = actions;
   var effectiveAutomaticallyImplyActions = automaticallyImplyActions;
@@ -546,7 +560,28 @@ _MaterialToolbarSlots _resolveMaterialToolbarSlots(
 
   Widget? paddedLeading;
   double? effectiveLeadingWidth = leadingWidth;
-  if (startInset > 0 && effectiveLeading != null) {
+  final sidebarExtent = sidebarLeading?.reservedExtent ?? 0;
+  if (sidebarLeading != null) {
+    final baseLeadingWidth = effectiveLeading == null
+        ? 0.0
+        : leadingWidth ??
+              AppBarTheme.of(context).leadingWidth ??
+              kToolbarHeight;
+    paddedLeading = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (startInset > 0) SizedBox(width: startInset),
+        SizedBox(
+          key: const ValueKey('cupertino-sidebar-leading-anchor'),
+          width: sidebarExtent,
+          height: NavigationSidebarAppBarLeading.buttonExtent,
+        ),
+        if (effectiveLeading case final effectiveLeading?)
+          SizedBox(width: baseLeadingWidth, child: effectiveLeading),
+      ],
+    );
+    effectiveLeadingWidth = startInset + sidebarExtent + baseLeadingWidth;
+  } else if (startInset > 0 && effectiveLeading != null) {
     final baseLeadingWidth =
         leadingWidth ?? AppBarTheme.of(context).leadingWidth ?? kToolbarHeight;
     paddedLeading = Padding(
@@ -565,7 +600,7 @@ _MaterialToolbarSlots _resolveMaterialToolbarSlots(
   }
 
   return _MaterialToolbarSlots(
-    leading: startInset > 0 ? paddedLeading : leading,
+    leading: startInset > 0 || sidebarLeading != null ? paddedLeading : leading,
     automaticallyImplyLeading: effectiveAutomaticallyImplyLeading,
     leadingWidth: effectiveLeadingWidth,
     actions: effectiveActions,

--- a/packages/mhabit_adaptive_ui/lib/src/window_control/window_control_layout.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/window_control/window_control_layout.dart
@@ -1,12 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:ios_window_control_layout/ios_window_control_layout.dart';
 
-enum WindowControlLayoutOwner { appBar, rail }
+/// Chrome subtree that consumes platform window-control avoidance.
+enum WindowControlLayoutOwner {
+  /// Page app bars consume the window-control region.
+  appBar,
+
+  /// The active side-navigation renderer consumes the window-control region.
+  sideNavigation,
+}
 
 enum _WindowControlLayoutAspect {
   appBarHorizontalAvoidance,
-  railHorizontalAvoidance,
-  railVerticalAvoidance,
+  sideNavigationHorizontalAvoidance,
+  sideNavigationVerticalAvoidance,
   safeAreaGeometry,
   rectangularDisplay,
 }
@@ -44,7 +51,8 @@ final class AdaptiveWindowSafeAreaGeometry {
 /// Queries iOS window-control layout once above an application's navigators.
 ///
 /// Root routes and overlays default to app-bar ownership. A nested
-/// [AdaptiveNavigationShell] overrides that allocation when a rail is visible.
+/// [AdaptiveNavigationShell] overrides that allocation when side navigation
+/// owns the window controls.
 class AdaptiveWindowControlLayout extends StatelessWidget {
   const AdaptiveWindowControlLayout({
     super.key,
@@ -86,7 +94,8 @@ class AdaptiveWindowControlLayout extends StatelessWidget {
 /// Distributes platform window-control avoidance between chrome consumers.
 ///
 /// The application root defaults to app-bar ownership. A navigation shell
-/// overrides this scope so rail layouts expose avoidance to the rail instead.
+/// overrides this scope so side-navigation layouts expose avoidance to their
+/// renderer instead.
 class AdaptiveWindowControlLayoutScope extends InheritedModel<Object> {
   const AdaptiveWindowControlLayoutScope({
     super.key,
@@ -126,13 +135,15 @@ class AdaptiveWindowControlLayoutScope extends InheritedModel<Object> {
       ? horizontalAvoidance
       : EdgeInsetsDirectional.zero;
 
-  EdgeInsetsDirectional get railHorizontalAvoidance =>
-      owner == WindowControlLayoutOwner.rail
+  /// Horizontal avoidance exposed to the active side-navigation renderer.
+  EdgeInsetsDirectional get sideNavigationHorizontalAvoidance =>
+      owner == WindowControlLayoutOwner.sideNavigation
       ? horizontalAvoidance
       : EdgeInsetsDirectional.zero;
 
-  EdgeInsetsDirectional get railVerticalAvoidance =>
-      owner == WindowControlLayoutOwner.rail
+  /// Vertical avoidance exposed to the active side-navigation renderer.
+  EdgeInsetsDirectional get sideNavigationVerticalAvoidance =>
+      owner == WindowControlLayoutOwner.sideNavigation
       ? verticalAvoidance
       : EdgeInsetsDirectional.zero;
 
@@ -148,20 +159,24 @@ class AdaptiveWindowControlLayoutScope extends InheritedModel<Object> {
       )?.appBarHorizontalAvoidance ??
       EdgeInsetsDirectional.zero;
 
-  static EdgeInsetsDirectional railHorizontalAvoidanceOf(
+  /// Returns horizontal avoidance owned by side navigation.
+  static EdgeInsetsDirectional sideNavigationHorizontalAvoidanceOf(
     BuildContext context,
   ) =>
       InheritedModel.inheritFrom<AdaptiveWindowControlLayoutScope>(
         context,
-        aspect: _WindowControlLayoutAspect.railHorizontalAvoidance,
-      )?.railHorizontalAvoidance ??
+        aspect: _WindowControlLayoutAspect.sideNavigationHorizontalAvoidance,
+      )?.sideNavigationHorizontalAvoidance ??
       EdgeInsetsDirectional.zero;
 
-  static EdgeInsetsDirectional railVerticalAvoidanceOf(BuildContext context) =>
+  /// Returns vertical avoidance owned by side navigation.
+  static EdgeInsetsDirectional sideNavigationVerticalAvoidanceOf(
+    BuildContext context,
+  ) =>
       InheritedModel.inheritFrom<AdaptiveWindowControlLayoutScope>(
         context,
-        aspect: _WindowControlLayoutAspect.railVerticalAvoidance,
-      )?.railVerticalAvoidance ??
+        aspect: _WindowControlLayoutAspect.sideNavigationVerticalAvoidance,
+      )?.sideNavigationVerticalAvoidance ??
       EdgeInsetsDirectional.zero;
 
   /// Whether the current display has rectangular physical corners.
@@ -217,10 +232,12 @@ class AdaptiveWindowControlLayoutScope extends InheritedModel<Object> {
       final changed = switch (aspect) {
         _WindowControlLayoutAspect.appBarHorizontalAvoidance =>
           appBarHorizontalAvoidance != oldWidget.appBarHorizontalAvoidance,
-        _WindowControlLayoutAspect.railHorizontalAvoidance =>
-          railHorizontalAvoidance != oldWidget.railHorizontalAvoidance,
-        _WindowControlLayoutAspect.railVerticalAvoidance =>
-          railVerticalAvoidance != oldWidget.railVerticalAvoidance,
+        _WindowControlLayoutAspect.sideNavigationHorizontalAvoidance =>
+          sideNavigationHorizontalAvoidance !=
+              oldWidget.sideNavigationHorizontalAvoidance,
+        _WindowControlLayoutAspect.sideNavigationVerticalAvoidance =>
+          sideNavigationVerticalAvoidance !=
+              oldWidget.sideNavigationVerticalAvoidance,
         _WindowControlLayoutAspect.safeAreaGeometry =>
           horizontalSafeAreaAvoidance !=
                   oldWidget.horizontalSafeAreaAvoidance ||

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -521,8 +521,10 @@ void main() {
 
     test('material rail style owns its collapsed extent', () {
       const style = MaterialNavigationRailStyle(collapsedExtent: 64);
+      const defaults = MaterialNavigationRailStyle();
 
       expect(style.collapsedExtent, 64);
+      expect(defaults.collapsedExtent, 96);
       expect(
         () => MaterialNavigationRailStyle(collapsedExtent: 0),
         throwsAssertionError,
@@ -2627,7 +2629,7 @@ void main() {
       expect(find.byType(NavigationRail), findsOneWidget);
       // Auto width uses the compact fixed target inside the interval.
       final panel = tester.widget<NavigationRail>(find.byType(NavigationRail));
-      expect(panel.minExtendedWidth, closeTo(224, 0.01));
+      expect(panel.minExtendedWidth, closeTo(200, 0.01));
       expect(find.byIcon(Icons.menu_open), findsOneWidget);
     });
 
@@ -2681,14 +2683,14 @@ void main() {
 
       NavigationRail panel() =>
           tester.widget<NavigationRail>(find.byType(NavigationRail));
-      // The fixed 224dp target fits the current 180-288dp interval.
-      expect(panel().minExtendedWidth, closeTo(224, 0.01));
+      // The compact 200dp target fits the current 180-288dp interval.
+      expect(panel().minExtendedWidth, closeTo(200, 0.01));
 
       tester.view.physicalSize = const Size(840, 800);
       await tester.pumpAndSettle();
 
-      // The interval's 223.2dp upper bound clamps the fixed target.
-      expect(panel().minExtendedWidth, closeTo(223.2, 0.01));
+      // The compact target remains inside the narrower interval.
+      expect(panel().minExtendedWidth, closeTo(200, 0.01));
     });
 
     testWidgets('drag resizes the rail and clamps to the interval', (
@@ -2700,7 +2702,7 @@ void main() {
 
       NavigationRail panel() =>
           tester.widget<NavigationRail>(find.byType(NavigationRail));
-      expect(panel().minExtendedWidth, closeTo(224, 0.01));
+      expect(panel().minExtendedWidth, closeTo(200, 0.01));
       final dragBar = find.byKey(
         const ValueKey('material-side-navigation-drag-bar'),
       );
@@ -2721,20 +2723,17 @@ void main() {
         Theme.of(tester.element(dragBar)).colorScheme.onSurfaceVariant,
       );
 
-      // Drag far left: many small moves accumulate and clamp to the minimum.
-      var gesture = await tester.startGesture(
-        tester.getCenter(find.byKey(const ValueKey('rail-resize-handle'))),
+      // Drag to the minimum without crossing it.
+      await tester.drag(
+        find.byKey(const ValueKey('rail-resize-handle')),
+        const Offset(-20, 0),
       );
-      for (var i = 0; i < 60; i++) {
-        await gesture.moveBy(const Offset(-10, 0));
-        await tester.pump();
-      }
-      await gesture.up();
       await tester.pumpAndSettle();
       expect(panel().minExtendedWidth, 180.0);
+      expect(panel().extended, isTrue);
 
       // Drag far right: clamps to the maximum width.
-      gesture = await tester.startGesture(
+      final gesture = await tester.startGesture(
         tester.getCenter(find.byKey(const ValueKey('rail-resize-handle'))),
       );
       for (var i = 0; i < 60; i++) {
@@ -2765,8 +2764,8 @@ void main() {
         expect(
           tester.getCenter(resizeHandle).dx,
           direction == TextDirection.ltr
-              ? tester.getTopRight(railPanel).dx - 4
-              : tester.getTopLeft(railPanel).dx + 4,
+              ? tester.getTopRight(railPanel).dx - 8
+              : tester.getTopLeft(railPanel).dx + 8,
         );
 
         final logicalDrag = direction == TextDirection.ltr
@@ -2784,7 +2783,7 @@ void main() {
                 ),
               )
               .minExtendedWidth,
-          greaterThan(224),
+          greaterThan(200),
         );
       });
     }
@@ -2824,7 +2823,7 @@ void main() {
       final router = _buildRouter();
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
-      // Drag slightly narrower than the auto width (224) -> 219.
+      // Drag slightly narrower than the auto width (200) -> 195.
       final gesture = await tester.startGesture(
         tester.getCenter(find.byKey(const ValueKey('rail-resize-handle'))),
       );
@@ -2834,20 +2833,20 @@ void main() {
       await tester.pumpAndSettle();
       NavigationRail panel() =>
           tester.widget<NavigationRail>(find.byType(NavigationRail));
-      expect(panel().minExtendedWidth, closeTo(219, 0.01));
+      expect(panel().minExtendedWidth, closeTo(195, 0.01));
 
       // The fixed auto target remains above the manual width, so it holds.
       tester.view.physicalSize = const Size(1400, 800);
       await tester.pumpAndSettle();
-      expect(panel().minExtendedWidth, closeTo(219, 0.01));
+      expect(panel().minExtendedWidth, closeTo(195, 0.01));
 
       // Medium resets to collapsed; expanding it applies the interval-clamped
       // auto width because it has fallen below the remembered manual width.
-      tester.view.physicalSize = const Size(700, 800);
+      tester.view.physicalSize = const Size(680, 800);
       await tester.pumpAndSettle();
       await tester.tap(find.byIcon(Icons.menu));
       await tester.pumpAndSettle();
-      expect(panel().minExtendedWidth, closeTo(198, 0.01));
+      expect(panel().minExtendedWidth, closeTo(194.4, 0.01));
 
       // The auto value keeps following the interval down.
       tester.view.physicalSize = const Size(650, 800);
@@ -2857,7 +2856,203 @@ void main() {
       // Grow back: the remembered manual value resumes.
       tester.view.physicalSize = const Size(1800, 800);
       await tester.pumpAndSettle();
-      expect(panel().minExtendedWidth, closeTo(219, 0.01));
+      expect(panel().minExtendedWidth, closeTo(195, 0.01));
+    });
+
+    testWidgets('material rail uses the M3 collapsed destination layout', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(700, 800));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      final rail = tester.widget<NavigationRail>(find.byType(NavigationRail));
+      final destination = find.byKey(
+        const ValueKey('material-rail-destination-0'),
+      );
+      final destinationSlot = find.byKey(
+        const ValueKey('material-rail-destination-slot-0'),
+      );
+      final indicator = find.descendant(
+        of: destination,
+        matching: find.byKey(const ValueKey('material-rail-indicator')),
+      );
+      final collapsedLabel = find.descendant(
+        of: destinationSlot,
+        matching: find.byKey(const ValueKey('material-rail-collapsed-label')),
+      );
+      final expandedLabel = find.descendant(
+        of: destination,
+        matching: find.byKey(const ValueKey('material-rail-expanded-label')),
+      );
+
+      expect(tester.getSize(destination), const Size(56, 32));
+      expect(rail.minWidth, 96);
+      expect(tester.getSize(indicator), const Size(56, 32));
+      expect(tester.widget<Opacity>(collapsedLabel).opacity, 1);
+      expect(tester.widget<Opacity>(expandedLabel).opacity, 0);
+      expect(
+        tester.getCenter(find.byIcon(Icons.home)).dx,
+        tester.getCenter(destination).dx,
+      );
+      expect(
+        tester.getRect(destination).overlaps(tester.getRect(collapsedLabel)),
+        isFalse,
+      );
+    });
+
+    testWidgets('material rail frames the complete expanded destination', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(1400, 800));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      final destination = find.byKey(
+        const ValueKey('material-rail-destination-0'),
+      );
+      final indicator = find.descendant(
+        of: destination,
+        matching: find.byKey(const ValueKey('material-rail-indicator')),
+      );
+      final expandedLabel = find.descendant(
+        of: destination,
+        matching: find.byKey(const ValueKey('material-rail-expanded-label')),
+      );
+      final indicatorRect = tester.getRect(indicator);
+
+      expect(tester.getSize(destination), const Size(160, 56));
+      expect(tester.getSize(indicator), const Size(160, 56));
+      expect(tester.widget<Opacity>(expandedLabel).opacity, 1);
+      expect(
+        indicatorRect.contains(tester.getCenter(find.byIcon(Icons.home))),
+        isTrue,
+      );
+      expect(indicatorRect.contains(tester.getCenter(expandedLabel)), isTrue);
+      expect(
+        tester.getRect(
+          find.descendant(of: destination, matching: find.byType(InkWell)),
+        ),
+        tester.getRect(destination),
+      );
+    });
+
+    testWidgets('material rail destinations follow the rail animation', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(700, 800));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      final destination = find.byKey(
+        const ValueKey('material-rail-destination-0'),
+      );
+      final destinationSlot = find.byKey(
+        const ValueKey('material-rail-destination-slot-0'),
+      );
+      final indicator = find.descendant(
+        of: destination,
+        matching: find.byKey(const ValueKey('material-rail-indicator')),
+      );
+      final collapsedLabel = find.descendant(
+        of: destinationSlot,
+        matching: find.byKey(const ValueKey('material-rail-collapsed-label')),
+      );
+      final expandedLabel = find.descendant(
+        of: destination,
+        matching: find.byKey(const ValueKey('material-rail-expanded-label')),
+      );
+      final todayDestination = find.byKey(
+        const ValueKey('material-rail-destination-1'),
+      );
+      final collapsedCenterY = tester.getCenter(destination).dy;
+      final collapsedTodayCenterY = tester.getCenter(todayDestination).dy;
+
+      await tester.tap(find.byKey(const ValueKey('rail-toggle-button')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(tester.getSize(destination).width, inExclusiveRange(56, 158));
+      expect(tester.getSize(indicator).width, inExclusiveRange(56, 158));
+      expect(tester.getSize(destination).height, inExclusiveRange(32, 56));
+      expect(tester.getSize(indicator).height, inExclusiveRange(32, 56));
+      expect(tester.getCenter(destination).dy, collapsedCenterY);
+      expect(tester.getCenter(todayDestination).dy, collapsedTodayCenterY);
+      expect(
+        tester.widget<Opacity>(collapsedLabel).opacity,
+        inExclusiveRange(0, 1),
+      );
+      expect(
+        tester.widget<Opacity>(expandedLabel).opacity,
+        inExclusiveRange(0, 1),
+      );
+
+      await tester.pumpAndSettle();
+      expect(tester.getSize(destination).width, closeTo(158, 0.01));
+      expect(tester.getSize(indicator).width, closeTo(158, 0.01));
+      expect(tester.getCenter(destination).dy, collapsedCenterY);
+      expect(tester.getCenter(todayDestination).dy, collapsedTodayCenterY);
+
+      await tester.tap(find.byKey(const ValueKey('rail-toggle-button')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(tester.getSize(destination).width, inExclusiveRange(56, 158));
+      expect(tester.getSize(indicator).width, inExclusiveRange(56, 158));
+      expect(tester.getSize(destination).height, inExclusiveRange(32, 56));
+      expect(tester.getSize(indicator).height, inExclusiveRange(32, 56));
+      expect(tester.getCenter(destination).dy, collapsedCenterY);
+      expect(tester.getCenter(todayDestination).dy, collapsedTodayCenterY);
+      expect(
+        tester.widget<Opacity>(collapsedLabel).opacity,
+        inExclusiveRange(0, 1),
+      );
+      expect(
+        tester.widget<Opacity>(expandedLabel).opacity,
+        inExclusiveRange(0, 1),
+      );
+
+      await tester.pumpAndSettle();
+      expect(tester.getSize(destination), const Size(56, 32));
+      expect(tester.getSize(indicator), const Size(56, 32));
+      expect(tester.getCenter(destination).dy, collapsedCenterY);
+      expect(tester.getCenter(todayDestination).dy, collapsedTodayCenterY);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('material rail tap target matches each destination button', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(700, 800));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      final todayButton = find.byKey(
+        const ValueKey('material-rail-destination-1'),
+      );
+      final todaySlot = find.byKey(
+        const ValueKey('material-rail-destination-slot-1'),
+      );
+      final todayLabel = find.descendant(
+        of: todaySlot,
+        matching: find.byKey(const ValueKey('material-rail-collapsed-label')),
+      );
+      final buttonRect = tester.getRect(todayButton);
+      await tester.tapAt(Offset(buttonRect.right + 4, buttonRect.center.dy));
+      await tester.pumpAndSettle();
+      expect(find.text('habits page'), findsOneWidget);
+
+      await tester.tapAt(tester.getCenter(todayLabel));
+      await tester.pumpAndSettle();
+      expect(find.text('habits page'), findsOneWidget);
+
+      await tester.tap(todayButton);
+      await tester.pumpAndSettle();
+      expect(find.text('today page'), findsOneWidget);
     });
 
     testWidgets('drag while the panel animation is running does not crash', (
@@ -2889,16 +3084,194 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    for (final direction in TextDirection.values) {
+      testWidgets(
+        'material rail toggle keeps its logical-start anchor in $direction',
+        (tester) async {
+          _setSurfaceSize(tester, const Size(1800, 800));
+          final router = _buildRouter();
+          await tester.pumpWidget(
+            MaterialApp.router(
+              routerConfig: router,
+              builder: (context, child) =>
+                  Directionality(textDirection: direction, child: child!),
+            ),
+          );
+
+          final toggle = find.byKey(const ValueKey('rail-toggle-button'));
+          final expandedCenter = tester.getCenter(toggle);
+          final expandedTop = tester.getTopLeft(toggle).dy;
+          expect(expandedTop, 0);
+
+          await tester.tap(toggle);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+          expect(tester.getCenter(toggle).dx, closeTo(expandedCenter.dx, 0.01));
+          expect(tester.getTopLeft(toggle).dy, expandedTop);
+
+          await tester.pumpAndSettle();
+          expect(tester.getCenter(toggle).dx, closeTo(expandedCenter.dx, 0.01));
+          expect(tester.getTopLeft(toggle).dy, expandedTop);
+        },
+      );
+    }
+
+    testWidgets('material rail toggle keeps the iPad window-control fallback', (
+      tester,
+    ) async {
+      _mockWindowControlLayout();
+      try {
+        _setSurfaceSize(tester, const Size(700, 800));
+        final router = _buildRouter();
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerConfig: router,
+            builder: (context, child) => AdaptiveStyleScope(
+              override: AdaptiveStyle.material,
+              child: child!,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final toggle = find.byKey(const ValueKey('rail-toggle-button'));
+        Padding safeSpan() => tester.widget<Padding>(
+          find.byKey(const ValueKey('rail-leading-safe-span')),
+        );
+        final collapsedCenter = tester.getCenter(toggle);
+        expect(tester.getTopLeft(toggle).dy, 0);
+        expect(
+          safeSpan().padding,
+          const EdgeInsetsDirectional.only(start: 40, end: 12),
+        );
+
+        await tester.tap(toggle);
+        await tester.pumpAndSettle();
+
+        expect(tester.getCenter(toggle).dx, closeTo(collapsedCenter.dx, 0.01));
+        expect(tester.getTopLeft(toggle).dy, 0);
+        expect(
+          safeSpan().padding,
+          const EdgeInsetsDirectional.only(start: 40, end: 12),
+        );
+      } finally {
+        _resetWindowControlLayoutMock();
+      }
+    });
+
     testWidgets('collapsed rail hides the resize handle', (tester) async {
       _setSurfaceSize(tester, const Size(700, 600));
       final router = _buildRouter();
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
       expect(find.byKey(const ValueKey('rail-resize-handle')), findsNothing);
+      expect(
+        find.byKey(const ValueKey('rail-collapsed-resize-handle')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('material-side-navigation-drag-bar')),
+        findsNothing,
+      );
 
       await tester.tap(find.byIcon(Icons.menu));
       await tester.pumpAndSettle();
       expect(find.byKey(const ValueKey('rail-resize-handle')), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('rail-collapsed-resize-handle')),
+        findsNothing,
+      );
+    });
+
+    for (final direction in TextDirection.values) {
+      testWidgets(
+        'material rail collapses and reopens by dragging in $direction',
+        (tester) async {
+          _setSurfaceSize(tester, const Size(1800, 800));
+          final router = _buildRouter();
+          await tester.pumpWidget(
+            MaterialApp.router(
+              routerConfig: router,
+              builder: (context, child) =>
+                  Directionality(textDirection: direction, child: child!),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final collapseOffset = direction == TextDirection.ltr
+              ? const Offset(-100, 0)
+              : const Offset(100, 0);
+          await tester.drag(
+            find.byKey(const ValueKey('rail-resize-handle')),
+            collapseOffset,
+          );
+          await tester.pumpAndSettle();
+
+          NavigationRail rail() =>
+              tester.widget<NavigationRail>(find.byType(NavigationRail));
+          expect(rail().extended, isFalse);
+          expect(
+            find.byKey(const ValueKey('rail-resize-handle')),
+            findsNothing,
+          );
+          expect(
+            find.byKey(const ValueKey('material-side-navigation-drag-bar')),
+            findsNothing,
+          );
+
+          final expandOffset = direction == TextDirection.ltr
+              ? const Offset(24, 0)
+              : const Offset(-24, 0);
+          await tester.drag(
+            find.byKey(const ValueKey('rail-resize-gesture-handle')),
+            expandOffset,
+          );
+          await tester.pumpAndSettle();
+
+          expect(rail().extended, isTrue);
+          expect(
+            find.byKey(const ValueKey('rail-resize-handle')),
+            findsOneWidget,
+          );
+          expect(
+            find.byKey(const ValueKey('material-side-navigation-drag-bar')),
+            findsOneWidget,
+          );
+        },
+      );
+    }
+
+    testWidgets('material rail keeps one drag active across collapse', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(1800, 800));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      NavigationRail rail() =>
+          tester.widget<NavigationRail>(find.byType(NavigationRail));
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(const ValueKey('rail-resize-handle'))),
+      );
+
+      await gesture.moveBy(const Offset(-100, 0));
+      await tester.pumpAndSettle();
+      expect(rail().extended, isFalse);
+      expect(
+        find.byKey(const ValueKey('rail-collapsed-resize-handle')),
+        findsOneWidget,
+      );
+
+      // The pointer is still down. Reversing the same gesture must reopen the
+      // rail without requiring the user to release and grab it again.
+      await gesture.moveBy(const Offset(100, 0));
+      await tester.pumpAndSettle();
+      expect(rail().extended, isTrue);
+      expect(find.byKey(const ValueKey('rail-resize-handle')), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('apple boundaries use beside Sidebar from medium upward', (
@@ -3570,7 +3943,7 @@ void main() {
         Size panelSize() => tester.getSize(
           find.byKey(const ValueKey('cupertino-sidebar-panel')),
         );
-        expect(panelSize().width, 224);
+        expect(panelSize().width, 200);
         final resizeHandle = find.byKey(
           const ValueKey('cupertino-sidebar-resize-handle'),
         );
@@ -3607,7 +3980,7 @@ void main() {
         await tester.drag(resizeHandle, logicalDrag);
         await tester.pumpAndSettle();
         final resizedWidth = panelSize().width;
-        expect(resizedWidth, greaterThan(224));
+        expect(resizedWidth, greaterThan(200));
 
         await tester.tap(
           find.byKey(const ValueKey('cupertino-sidebar-toggle')),
@@ -4011,12 +4384,12 @@ void main() {
       final router = _buildRouter();
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
-      // Drag slightly narrower than the auto width (224) -> 194.
+      // Drag wider than the auto width (200) -> 230.
       final gesture = await tester.startGesture(
         tester.getCenter(find.byKey(const ValueKey('rail-resize-handle'))),
       );
       for (var i = 0; i < 3; i++) {
-        await gesture.moveBy(const Offset(-10, 0));
+        await gesture.moveBy(const Offset(10, 0));
         await tester.pump();
       }
       await gesture.up();
@@ -4032,7 +4405,7 @@ void main() {
       tester.view.physicalSize = const Size(1800, 800);
       await tester.pumpAndSettle();
       final rail = tester.widget<NavigationRail>(find.byType(NavigationRail));
-      expect(rail.minExtendedWidth, closeTo(194, 0.01));
+      expect(rail.minExtendedWidth, closeTo(230, 0.01));
     });
   });
 

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -1,5 +1,12 @@
+import 'dart:ui' show PointerDeviceKind, Tristate;
+
 import 'package:flutter/cupertino.dart'
     show
+        CupertinoButton,
+        CupertinoButtonSize,
+        CupertinoColors,
+        CupertinoIcons,
+        CupertinoNavigationBar,
         CupertinoPageScaffoldBackgroundColor,
         CupertinoSliverNavigationBar,
         CupertinoThemeData;
@@ -226,27 +233,41 @@ class _StubPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final bottomPadding = MediaQuery.paddingOf(context).bottom;
     return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(text),
-            SizedBox(
-              key: const ValueKey('branch-bottom-padding'),
-              height: bottomPadding,
+      body: CustomScrollView(
+        slivers: [
+          const AdaptiveSliverAppBar(
+            title: Text('Test page'),
+            leading: Icon(
+              Icons.article_outlined,
+              key: ValueKey('test-page-leading'),
             ),
-            TextButton(
-              key: const ValueKey('show-snackbar'),
-              onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  behavior: SnackBarBehavior.floating,
-                  content: Text('saved'),
-                ),
+          ),
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(text),
+                  SizedBox(
+                    key: const ValueKey('branch-bottom-padding'),
+                    height: bottomPadding,
+                  ),
+                  TextButton(
+                    key: const ValueKey('show-snackbar'),
+                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        behavior: SnackBarBehavior.floating,
+                        content: Text('saved'),
+                      ),
+                    ),
+                    child: const Text('Show Snackbar'),
+                  ),
+                ],
               ),
-              child: const Text('Show Snackbar'),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -260,6 +281,7 @@ class _BranchInsetsProbe extends StatelessWidget {
     final padding = MediaQuery.paddingOf(context);
     final viewPadding = MediaQuery.viewPaddingOf(context);
     return Column(
+      key: const ValueKey('branch-layout-probe'),
       children: [
         SizedBox(
           key: const ValueKey('branch-horizontal-padding'),
@@ -1418,30 +1440,43 @@ void main() {
           const BorderRadius.all(Radius.circular(62)),
         );
 
-        final safeSpan = find.byKey(const ValueKey('rail-leading-safe-span'));
-        final toggle = find.byKey(const ValueKey('rail-toggle-button'));
         expect(
-          tester.getTopLeft(toggle).dy - tester.getTopLeft(safeSpan).dy,
-          64,
+          tester
+              .getTopLeft(
+                find.byKey(
+                  const ValueKey('cupertino-sidebar-destination-list'),
+                ),
+              )
+              .dx,
+          12,
         );
 
+        final toggle = find.byKey(const ValueKey('cupertino-sidebar-toggle'));
+        expect(
+          tester.getTopRight(toggle).dx,
+          tester
+                  .getTopRight(
+                    find.byKey(const ValueKey('cupertino-sidebar-surface')),
+                  )
+                  .dx -
+              12,
+        );
+        expect(tester.getTopLeft(toggle).dy, 12);
         await tester.tap(toggle);
         await tester.pumpAndSettle();
-
-        final rail = find.byKey(const ValueKey('rail-panel'));
         expect(
-          tester.getCenter(toggle).dx,
-          moreOrLessEquals(
-            tester.getTopLeft(rail).dx + tester.getSize(rail).width / 2 + 14,
-            epsilon: 0.01,
-          ),
+          find.byKey(const ValueKey('cupertino-sidebar-panel')),
+          findsNothing,
         );
+        expect(tester.getTopLeft(toggle).dx, 56);
       } finally {
         _resetWindowControlLayoutMock();
       }
     });
 
-    testWidgets('extended rail centers in the RTL safe span', (tester) async {
+    testWidgets('apple beside Sidebar uses the RTL side-navigation safe span', (
+      tester,
+    ) async {
       _mockWindowControlLayout();
       try {
         _setSurfaceSize(tester, const Size(1000, 800));
@@ -1470,14 +1505,16 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final rail = find.byKey(const ValueKey('rail-panel'));
-        final toggle = find.byKey(const ValueKey('rail-toggle-button'));
+        expect(find.byType(NavigationRail), findsNothing);
         expect(
-          tester.getCenter(toggle).dx,
-          moreOrLessEquals(
-            tester.getTopLeft(rail).dx + tester.getSize(rail).width / 2 - 14,
-            epsilon: 0.01,
-          ),
+          tester
+              .getTopRight(
+                find.byKey(
+                  const ValueKey('cupertino-sidebar-destination-list'),
+                ),
+              )
+              .dx,
+          988,
         );
       } finally {
         _resetWindowControlLayoutMock();
@@ -2359,7 +2396,7 @@ void main() {
       );
     });
 
-    testWidgets('apple large ignores compact height for its side form', (
+    testWidgets('apple large ignores compact height and uses beside Sidebar', (
       tester,
     ) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
@@ -2367,9 +2404,14 @@ void main() {
       final router = _buildRouter();
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
+      expect(find.byType(NavigationRail), findsNothing);
       expect(
-        tester.widget<NavigationRail>(find.byType(NavigationRail)).extended,
-        isTrue,
+        find.byKey(const ValueKey('cupertino-sidebar-beside-host')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsOneWidget,
       );
       debugDefaultTargetPlatformOverride = null;
     });
@@ -2441,18 +2483,26 @@ void main() {
 
     testWidgets('macOS classifies with apple tiers', (tester) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
       _setSurfaceSize(tester, const Size(700, 600));
       final router = _buildRouter();
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
-      // macOS resolves the three-tier apple system, so 700dp classifies as
-      // medium: a rail collapsed by default.
-      expect(find.byType(NavigationRail), findsOneWidget);
+      // macOS resolves the three-tier Apple system, so 700dp classifies as
+      // medium and uses the same visible beside Sidebar as larger windows.
+      expect(find.byType(NavigationRail), findsNothing);
       expect(
-        tester.widget<NavigationRail>(find.byType(NavigationRail)).extended,
-        isFalse,
+        find.byKey(const ValueKey('cupertino-sidebar-beside-host')),
+        findsOneWidget,
       );
-      expect(find.byIcon(Icons.menu), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-toggle')),
+        findsOneWidget,
+      );
       debugDefaultTargetPlatformOverride = null;
     });
 
@@ -2702,48 +2752,965 @@ void main() {
       expect(find.byKey(const ValueKey('rail-resize-handle')), findsOneWidget);
     });
 
+    testWidgets('apple boundaries use beside Sidebar from medium upward', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _setSurfaceSize(tester, const Size(599, 479));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      expect(
+        find.byKey(const ValueKey('cupertino-adaptive-navigation-bar')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-beside-host')),
+        findsNothing,
+      );
+
+      for (final width in [600.0, 905.0, 906.0, 1400.0]) {
+        tester.view.physicalSize = Size(width, 479);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(NavigationRail), findsNothing);
+        expect(find.byType(NavigationDrawer), findsNothing);
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-beside-host')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-panel')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-resize-handle')),
+          findsOneWidget,
+        );
+        final sidebarSurface = find.byKey(
+          const ValueKey('cupertino-sidebar-surface'),
+        );
+        final sidebarNavigationBar = find.descendant(
+          of: sidebarSurface,
+          matching: find.byType(CupertinoNavigationBar),
+        );
+        expect(sidebarNavigationBar, findsOneWidget);
+        final navigationBar = tester.widget<CupertinoNavigationBar>(
+          sidebarNavigationBar,
+        );
+        expect(navigationBar.enableBackgroundFilterBlur, isTrue);
+        expect(navigationBar.backgroundColor, CupertinoColors.transparent);
+        final destinationList = find.byKey(
+          const ValueKey('cupertino-sidebar-destination-list'),
+        );
+        expect(
+          tester.getTopLeft(destinationList).dy -
+              tester.getTopLeft(sidebarSurface).dy,
+          0,
+        );
+        final firstDestination = find.byKey(
+          const ValueKey('cupertino-sidebar-destination-0'),
+        );
+        expect(
+          tester.getTopLeft(firstDestination).dy -
+              tester.getTopLeft(sidebarSurface).dy,
+          greaterThanOrEqualTo(68),
+        );
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-scrim')),
+          findsNothing,
+        );
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-edge-gesture')),
+          findsOneWidget,
+        );
+      }
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('apple Sidebar spaces destinations below toolbar blur', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _setSurfaceSize(tester, const Size(700, 160));
+      final router = _buildRouter(
+        destinations: List<AdaptiveNavigationDestination>.generate(
+          6,
+          (index) => AdaptiveNavigationDestination(
+            label: 'Destination $index',
+            icons: const NavigationDestinationIcons(
+              material: Icon(Icons.circle_outlined),
+              materialSelected: Icon(Icons.circle),
+              apple: Icon(CupertinoIcons.circle),
+              appleSelected: Icon(CupertinoIcons.circle_fill),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      final surface = find.byKey(const ValueKey('cupertino-sidebar-surface'));
+      final list = find.byKey(
+        const ValueKey('cupertino-sidebar-destination-list'),
+      );
+      final secondDestination = find.byKey(
+        const ValueKey('cupertino-sidebar-destination-1'),
+      );
+      final surfaceTop = tester.getTopLeft(surface).dy;
+
+      expect(tester.getTopLeft(list).dy, surfaceTop);
+      expect(
+        tester.getTopLeft(secondDestination).dy,
+        greaterThan(surfaceTop + 44),
+      );
+
+      await tester.drag(list, const Offset(0, -100));
+      await tester.pumpAndSettle();
+
+      final scrolledTop = tester.getTopLeft(secondDestination).dy;
+      expect(scrolledTop, greaterThan(surfaceTop));
+      expect(scrolledTop, lessThan(surfaceTop + 44));
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('apple Sidebar visibility survives width-class round trips', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _setSurfaceSize(tester, const Size(700, 600));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byKey(const ValueKey('cupertino-sidebar-toggle')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-resize-handle')),
+        findsNothing,
+      );
+
+      tester.view.physicalSize = const Size(906, 600);
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsNothing,
+      );
+
+      tester.view.physicalSize = const Size(599, 600);
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('cupertino-adaptive-navigation-bar')),
+        findsOneWidget,
+      );
+
+      tester.view.physicalSize = const Size(700, 600);
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsNothing,
+      );
+
+      await tester.tap(find.byKey(const ValueKey('cupertino-sidebar-toggle')));
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsOneWidget,
+      );
+      debugDefaultTargetPlatformOverride = null;
+    });
+
     testWidgets(
-      'apple boundaries use the documented rail compatibility fallback',
+      'apple detail routes retain the hidden Sidebar command and avoidance',
+      (tester) async {
+        _mockWindowControlLayout();
+        try {
+          _setSurfaceSize(tester, const Size(700, 600));
+          final router = _buildRouter();
+          await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+          await tester.pumpAndSettle();
+
+          final toggle = find.byKey(const ValueKey('cupertino-sidebar-toggle'));
+          final toggleElement = tester.element(toggle);
+          await tester.tap(toggle);
+          await tester.pumpAndSettle();
+          router.push('/habits/detail');
+          await tester.pumpAndSettle();
+
+          final pageLeading = find.byKey(const ValueKey('test-page-leading'));
+          expect(find.text('detail page'), findsOneWidget);
+          expect(toggle.hitTestable(), findsOneWidget);
+          expect(tester.element(toggle), same(toggleElement));
+          expect(tester.getTopLeft(toggle).dx, 56);
+          expect(
+            tester.getTopLeft(pageLeading).dx,
+            greaterThanOrEqualTo(tester.getTopRight(toggle).dx),
+          );
+        } finally {
+          _resetWindowControlLayoutMock();
+        }
+      },
+    );
+
+    for (final sliver in [false, true]) {
+      testWidgets(
+        'apple Sidebar command precedes existing ${sliver ? 'sliver ' : ''}app bar leading',
+        (tester) async {
+          _mockWindowControlLayout();
+          try {
+            _setSurfaceSize(tester, const Size(700, 600));
+            await tester.pumpWidget(
+              MaterialApp(
+                home: AdaptiveNavigationShell(
+                  selectedIndex: 0,
+                  destinations: const [
+                    AdaptiveNavigationDestination(
+                      label: 'Habits',
+                      icons: NavigationDestinationIcons(
+                        material: Icon(Icons.home_outlined),
+                        materialSelected: Icon(Icons.home),
+                        apple: Icon(CupertinoIcons.home),
+                        appleSelected: Icon(CupertinoIcons.house_fill),
+                      ),
+                    ),
+                  ],
+                  onDestinationSelected: (_) {},
+                  child: Scaffold(
+                    appBar: sliver
+                        ? null
+                        : const WindowControlAppBar(
+                            leading: BackButton(
+                              key: ValueKey('test-existing-leading'),
+                            ),
+                          ),
+                    body: sliver
+                        ? const CustomScrollView(
+                            slivers: [
+                              WindowControlSliverAppBar(
+                                leading: BackButton(
+                                  key: ValueKey('test-existing-leading'),
+                                ),
+                              ),
+                              SliverFillRemaining(child: SizedBox.shrink()),
+                            ],
+                          )
+                        : const SizedBox.shrink(),
+                  ),
+                ),
+              ),
+            );
+            await tester.pumpAndSettle();
+
+            await tester.tap(
+              find.byKey(const ValueKey('cupertino-sidebar-toggle')),
+            );
+            await tester.pumpAndSettle();
+
+            final toggle = find.byKey(
+              const ValueKey('cupertino-sidebar-toggle'),
+            );
+            final existingLeading = find.byKey(
+              const ValueKey('test-existing-leading'),
+            );
+            expect(toggle.hitTestable(), findsOneWidget);
+            expect(tester.getTopLeft(toggle).dx, 56);
+            expect(
+              tester.getTopLeft(existingLeading).dx,
+              greaterThanOrEqualTo(tester.getTopRight(toggle).dx),
+            );
+          } finally {
+            _resetWindowControlLayoutMock();
+          }
+        },
+      );
+    }
+
+    for (final direction in TextDirection.values) {
+      testWidgets('apple hidden Sidebar opens from its edge in $direction', (
+        tester,
+      ) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        _setSurfaceSize(tester, const Size(700, 600));
+        final router = _buildRouter();
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerConfig: router,
+            builder: (context, child) =>
+                Directionality(textDirection: direction, child: child!),
+          ),
+        );
+
+        await tester.tap(
+          find.byKey(const ValueKey('cupertino-sidebar-toggle')),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-panel')),
+          findsNothing,
+        );
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-edge-gesture')),
+          findsOneWidget,
+        );
+
+        final edgeStart = direction == TextDirection.ltr
+            ? const Offset(5, 300)
+            : const Offset(695, 300);
+        final outsideStart = direction == TextDirection.ltr
+            ? const Offset(25, 300)
+            : const Offset(675, 300);
+        final openingDelta = direction == TextDirection.ltr
+            ? const Offset(40, 0)
+            : const Offset(-40, 0);
+
+        await tester.dragFrom(edgeStart, -openingDelta);
+        await tester.pumpAndSettle();
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-panel')),
+          findsNothing,
+        );
+
+        await tester.dragFrom(outsideStart, openingDelta);
+        await tester.pumpAndSettle();
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-panel')),
+          findsNothing,
+        );
+
+        await tester.dragFrom(edgeStart, openingDelta);
+        await tester.pumpAndSettle();
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-panel')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('cupertino-sidebar-edge-gesture')),
+          findsOneWidget,
+        );
+        debugDefaultTargetPlatformOverride = null;
+      });
+    }
+
+    testWidgets('apple Sidebar switches branch without closing', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _setSurfaceSize(tester, const Size(700, 600));
+      final selected = <int>[];
+      final router = _buildRouter(onBranchChanged: selected.add);
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final destinationButtons = find.descendant(
+        of: find.byKey(const ValueKey('cupertino-sidebar-destination-list')),
+        matching: find.byType(CupertinoButton),
+      );
+      expect(destinationButtons, findsNWidgets(2));
+      for (final button in tester.widgetList<CupertinoButton>(
+        destinationButtons,
+      )) {
+        expect(button.sizeStyle, CupertinoButtonSize.medium);
+        expect(button.minimumSize, const Size(0, 44));
+        expect(button.pressedOpacity, 0.4);
+      }
+      await tester.tap(
+        find.byKey(const ValueKey('cupertino-sidebar-destination-1')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(selected, [1]);
+      expect(find.text('today page'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsOneWidget,
+      );
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets(
+      'apple Sidebar keeps one tooltip-enabled toggle across hosts and routes',
       (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-        _setSurfaceSize(tester, const Size(599, 479));
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        tester.view.padding = const FakeViewPadding(top: 12);
+        tester.view.viewPadding = const FakeViewPadding(top: 12);
+        _setSurfaceSize(tester, const Size(700, 600));
         final router = _buildRouter();
         await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
-        expect(
-          find.byKey(const ValueKey('cupertino-adaptive-navigation-bar')),
-          findsOneWidget,
+        final toggle = find.byKey(const ValueKey('cupertino-sidebar-toggle'));
+        final anchor = find.byKey(
+          const ValueKey('cupertino-sidebar-leading-anchor'),
         );
-        expect(find.byType(NavigationRail), findsNothing);
+        final localizations = MaterialLocalizations.of(tester.element(toggle));
+        final toggleElement = tester.element(toggle);
 
-        tester.view.physicalSize = const Size(600, 479);
+        expect(toggle, findsOneWidget);
+        expect(toggle.hitTestable(), findsOneWidget);
+        expect(tester.getSize(toggle), const Size.square(44));
+        expect(
+          tester
+                  .getTopRight(
+                    find.byKey(const ValueKey('cupertino-sidebar-surface')),
+                  )
+                  .dx -
+              tester.getTopRight(toggle).dx,
+          8,
+        );
+        expect(tester.getSize(anchor).width, 0);
+        expect(
+          tester
+              .widget<Tooltip>(
+                find.ancestor(of: toggle, matching: find.byType(Tooltip)),
+              )
+              .message,
+          localizations.expandedIconTapHint,
+        );
+
+        await tester.tap(toggle);
         await tester.pumpAndSettle();
 
-        expect(find.byType(NavigationRail), findsOneWidget);
+        expect(toggle, findsOneWidget);
+        expect(tester.element(toggle), same(toggleElement));
+        expect(tester.getSize(anchor), const Size.square(44));
+        expect(tester.getTopLeft(toggle), tester.getTopLeft(anchor));
         expect(
-          tester.widget<NavigationRail>(find.byType(NavigationRail)).extended,
-          isFalse,
+          tester
+              .widget<Tooltip>(
+                find.ancestor(of: toggle, matching: find.byType(Tooltip)),
+              )
+              .message,
+          localizations.collapsedIconTapHint,
         );
 
-        tester.view.physicalSize = const Size(905, 479);
+        final hiddenPosition = tester.getTopLeft(toggle);
+        router.push('/habits/detail');
         await tester.pumpAndSettle();
-        expect(
-          tester.widget<NavigationRail>(find.byType(NavigationRail)).extended,
-          isFalse,
-        );
-
-        tester.view.physicalSize = const Size(906, 479);
-        await tester.pumpAndSettle();
-
-        expect(
-          tester.widget<NavigationRail>(find.byType(NavigationRail)).extended,
-          isTrue,
-        );
-        expect(find.byType(NavigationDrawer), findsNothing);
-        expect(find.byIcon(Icons.menu_open), findsOneWidget);
+        expect(tester.element(toggle), same(toggleElement));
+        expect(tester.getTopLeft(toggle), hiddenPosition);
         debugDefaultTargetPlatformOverride = null;
       },
     );
+
+    testWidgets('apple Sidebar preserves one interactive toggle and focus', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _setSurfaceSize(tester, const Size(700, 600));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final toggle = find.byKey(const ValueKey('cupertino-sidebar-toggle'));
+      final localizations = MaterialLocalizations.of(tester.element(toggle));
+      final toggleElement = tester.element(toggle);
+      final button = tester.widget<CupertinoButton>(toggle);
+      button.focusNode!.requestFocus();
+      await tester.pump();
+      expect(button.focusNode!.hasFocus, isTrue);
+
+      await tester.tap(toggle);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 125));
+
+      expect(toggle, findsOneWidget);
+      expect(tester.element(toggle), same(toggleElement));
+      expect(
+        tester.widget<CupertinoButton>(toggle).focusNode!.hasFocus,
+        isTrue,
+      );
+      expect(
+        find
+                .bySemanticsLabel(localizations.expandedIconTapHint)
+                .evaluate()
+                .length +
+            find
+                .bySemanticsLabel(localizations.collapsedIconTapHint)
+                .evaluate()
+                .length,
+        1,
+      );
+
+      await tester.pumpAndSettle();
+      expect(tester.element(toggle), same(toggleElement));
+      expect(
+        tester.widget<CupertinoButton>(toggle).focusNode!.hasFocus,
+        isTrue,
+      );
+
+      await tester.tap(toggle);
+      await tester.pumpAndSettle();
+      expect(tester.element(toggle), same(toggleElement));
+      expect(
+        tester.widget<CupertinoButton>(toggle).focusNode!.hasFocus,
+        isTrue,
+      );
+      semantics.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('apple macOS Sidebar keeps a compact inset toolbar', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _setSurfaceSize(tester, const Size(700, 600));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final toggle = find.byKey(const ValueKey('cupertino-sidebar-toggle'));
+      final tooltip = find.ancestor(of: toggle, matching: find.byType(Tooltip));
+      expect(
+        tester.getCenter(toggle).dy,
+        tester.getCenter(find.byKey(const ValueKey('test-page-leading'))).dy,
+      );
+      expect(
+        tester
+            .getTopLeft(find.byKey(const ValueKey('cupertino-sidebar-surface')))
+            .dy,
+        12,
+      );
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(mouse.removePointer);
+      await mouse.addPointer(location: Offset.zero);
+      await mouse.moveTo(tester.getCenter(toggle));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(tooltip, findsOneWidget);
+      expect(
+        find.text(tester.widget<Tooltip>(tooltip).message!),
+        findsOneWidget,
+      );
+
+      await mouse.down(tester.getCenter(toggle));
+      await mouse.up();
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsNothing,
+      );
+      expect(tester.takeException(), isNull);
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets(
+      'apple hidden Sidebar toggle anchors to the search command bar',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        _setSurfaceSize(tester, const Size(700, 600));
+        final controller = TextEditingController();
+        final focusNode = FocusNode();
+        addTearDown(controller.dispose);
+        addTearDown(focusNode.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AdaptiveNavigationShell(
+              selectedIndex: 0,
+              destinations: const [
+                AdaptiveNavigationDestination(
+                  label: 'Habits',
+                  icons: NavigationDestinationIcons(
+                    material: Icon(Icons.home_outlined),
+                    materialSelected: Icon(Icons.home),
+                    apple: Icon(Icons.home_outlined),
+                    appleSelected: Icon(Icons.home),
+                  ),
+                ),
+                AdaptiveNavigationDestination(
+                  label: 'Today',
+                  icons: NavigationDestinationIcons(
+                    material: Icon(Icons.calendar_today_outlined),
+                    materialSelected: Icon(Icons.calendar_today),
+                    apple: Icon(Icons.calendar_today_outlined),
+                    appleSelected: Icon(Icons.calendar_today),
+                  ),
+                ),
+              ],
+              onDestinationSelected: (_) {},
+              child: Scaffold(
+                body: CustomScrollView(
+                  slivers: [
+                    AdaptiveSliverSearchBar.apple(
+                      title: const Text('Habits'),
+                      leading: const Icon(
+                        Icons.article_outlined,
+                        key: ValueKey('test-search-leading'),
+                      ),
+                      controller: controller,
+                      focusNode: focusNode,
+                      isSearchActive: false,
+                      keyword: '',
+                      onChanged: (_) {},
+                      onSearchActivated: () {},
+                      onSearchDismissed: () {},
+                    ),
+                    const SliverFillRemaining(child: SizedBox.shrink()),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final toggle = find.byKey(const ValueKey('cupertino-sidebar-toggle'));
+        final anchor = find.byKey(
+          const ValueKey('cupertino-sidebar-leading-anchor'),
+        );
+        final header = tester.widget<SliverPersistentHeader>(
+          find.byType(SliverPersistentHeader),
+        );
+
+        expect(header.delegate.minExtent, 56);
+        expect(header.delegate.maxExtent, 56);
+        final toggleElement = tester.element(toggle);
+        expect(toggle, findsOneWidget);
+        expect(toggle.hitTestable(), findsOneWidget);
+        expect(tester.getSize(anchor).width, 0);
+
+        await tester.tap(toggle);
+        await tester.pumpAndSettle();
+
+        expect(toggle.hitTestable(), findsOneWidget);
+        expect(tester.element(toggle), same(toggleElement));
+        expect(tester.getSize(anchor), const Size.square(44));
+        expect(tester.getTopLeft(anchor).dy, 12);
+        expect(tester.getTopLeft(toggle), tester.getTopLeft(anchor));
+        expect(
+          tester
+              .getTopLeft(find.byKey(const ValueKey('test-search-leading')))
+              .dx,
+          greaterThan(tester.getTopLeft(toggle).dx),
+        );
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
+
+    for (final direction in TextDirection.values) {
+      testWidgets('apple Sidebar resizes and remembers width in $direction', (
+        tester,
+      ) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        _setSurfaceSize(tester, const Size(1000, 600));
+        final router = _buildRouter();
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerConfig: router,
+            builder: (context, child) =>
+                Directionality(textDirection: direction, child: child!),
+          ),
+        );
+
+        Size panelSize() => tester.getSize(
+          find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        );
+        expect(panelSize().width, 224);
+        final resizeHandle = find.byKey(
+          const ValueKey('cupertino-sidebar-resize-handle'),
+        );
+        expect(tester.getSize(resizeHandle).width, 16);
+        expect(tester.getSize(resizeHandle).height, panelSize().height - 50);
+        expect(
+          tester.getCenter(resizeHandle).dx,
+          direction == TextDirection.ltr
+              ? tester
+                        .getTopRight(
+                          find.byKey(
+                            const ValueKey('cupertino-sidebar-surface'),
+                          ),
+                        )
+                        .dx -
+                    8
+              : tester
+                        .getTopLeft(
+                          find.byKey(
+                            const ValueKey('cupertino-sidebar-surface'),
+                          ),
+                        )
+                        .dx +
+                    8,
+        );
+
+        final logicalDrag = direction == TextDirection.ltr
+            ? const Offset(30, 0)
+            : const Offset(-30, 0);
+        await tester.drag(resizeHandle, logicalDrag);
+        await tester.pumpAndSettle();
+        final resizedWidth = panelSize().width;
+        expect(resizedWidth, greaterThan(224));
+
+        await tester.tap(
+          find.byKey(const ValueKey('cupertino-sidebar-toggle')),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('cupertino-sidebar-toggle')),
+        );
+        await tester.pumpAndSettle();
+        expect(panelSize().width, resizedWidth);
+
+        tester.view.physicalSize = const Size(599, 600);
+        await tester.pumpAndSettle();
+        tester.view.physicalSize = const Size(1000, 600);
+        await tester.pumpAndSettle();
+        expect(panelSize().width, resizedWidth);
+        debugDefaultTargetPlatformOverride = null;
+      });
+    }
+
+    testWidgets(
+      'apple beside span constrains the branch without changing media',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        tester.view.padding = const FakeViewPadding(left: 44, right: 20);
+        tester.view.viewPadding = const FakeViewPadding(left: 50, right: 30);
+        _setSurfaceSize(tester, const Size(700, 600));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AdaptiveNavigationShell(
+              selectedIndex: 0,
+              destinations: const [
+                AdaptiveNavigationDestination(
+                  label: 'Habits',
+                  icons: NavigationDestinationIcons(
+                    material: Icon(Icons.home_outlined),
+                    materialSelected: Icon(Icons.home),
+                    apple: Icon(CupertinoIcons.home),
+                    appleSelected: Icon(CupertinoIcons.house_fill),
+                  ),
+                ),
+              ],
+              onDestinationSelected: (_) {},
+              child: const _BranchInsetsProbe(),
+            ),
+          ),
+        );
+
+        Size branchPadding() => tester.getSize(
+          find.byKey(const ValueKey('branch-horizontal-padding')),
+        );
+        Size branchViewPadding() => tester.getSize(
+          find.byKey(const ValueKey('branch-horizontal-view-padding')),
+        );
+        final branch = find.byKey(const ValueKey('branch-layout-probe'));
+        final surface = find.byKey(const ValueKey('cupertino-sidebar-surface'));
+        final surfaceWidget = tester.widget<CupertinoFloatingGlassSurface>(
+          surface,
+        );
+
+        expect(branchPadding().width, 64);
+        expect(branchViewPadding().width, 80);
+        expect(tester.getTopLeft(branch).dx, 254);
+        expect(tester.getTopLeft(surface), const Offset(44, 12));
+        expect(tester.getSize(surface), const Size(198, 576));
+        expect(
+          surfaceWidget.borderRadius,
+          const BorderRadius.all(Radius.circular(25)),
+        );
+        expect(surfaceWidget.blurSigma, 10);
+
+        await tester.tap(
+          find.byKey(const ValueKey('cupertino-sidebar-toggle')),
+        );
+        await tester.pumpAndSettle();
+        expect(branchPadding().width, 64);
+        expect(branchViewPadding().width, 80);
+        expect(tester.getTopLeft(branch).dx, 0);
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
+
+    testWidgets('apple Sidebar disables visibility animation immediately', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _setSurfaceSize(tester, const Size(700, 600));
+      final router = _buildRouter();
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: router,
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(disableAnimations: true),
+            child: child!,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('cupertino-sidebar-toggle')));
+      await tester.pump();
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsNothing,
+      );
+
+      await tester.tap(find.byKey(const ValueKey('cupertino-sidebar-toggle')));
+      await tester.pump();
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsOneWidget,
+      );
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('apple Sidebar exposes selected destination semantics', (
+      tester,
+    ) async {
+      final semanticsHandle = tester.ensureSemantics();
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _setSurfaceSize(tester, const Size(700, 600));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final destinationSemantics = tester.getSemantics(
+        find.byKey(const ValueKey('cupertino-sidebar-destination-0')),
+      );
+      expect(destinationSemantics.label, 'Habits');
+      expect(destinationSemantics.flagsCollection.isSelected, Tristate.isTrue);
+      expect(destinationSemantics.flagsCollection.isButton, isTrue);
+      expect(find.bySemanticsLabel('Show Snackbar'), findsOneWidget);
+      semanticsHandle.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('apple Sidebar destination foregrounds stay opaque', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _setSurfaceSize(tester, const Size(700, 600));
+      final router = _buildRouter();
+      await tester.pumpWidget(
+        MaterialApp.router(
+          theme: ThemeData(
+            cupertinoOverrideTheme: const CupertinoThemeData(
+              primaryColor: Color(0x80336699),
+            ),
+          ),
+          routerConfig: router,
+        ),
+      );
+
+      CupertinoButton destinationButton(int index) =>
+          tester.widget<CupertinoButton>(
+            find.descendant(
+              of: find.byKey(ValueKey('cupertino-sidebar-destination-$index')),
+              matching: find.byType(CupertinoButton),
+            ),
+          );
+
+      expect(destinationButton(0).foregroundColor!.a, 1);
+      expect(destinationButton(1).foregroundColor!.a, 1);
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets(
+      'apple Sidebar resolves the Cupertino bar surface in dark mode',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        _setSurfaceSize(tester, const Size(700, 600));
+        const barBackground = Color(0xCC112233);
+        final router = _buildRouter();
+        await tester.pumpWidget(
+          MaterialApp.router(
+            theme: ThemeData.dark().copyWith(
+              cupertinoOverrideTheme: const CupertinoThemeData(
+                barBackgroundColor: barBackground,
+              ),
+            ),
+            routerConfig: router,
+          ),
+        );
+
+        final surfaceFinder = find.byKey(
+          const ValueKey('cupertino-sidebar-surface'),
+        );
+        final surface = tester.widget<CupertinoFloatingGlassSurface>(
+          surfaceFinder,
+        );
+        final coloredSurfaces = tester.widgetList<ColoredBox>(
+          find.descendant(of: surfaceFinder, matching: find.byType(ColoredBox)),
+        );
+        expect(
+          surface.borderRadius,
+          const BorderRadius.all(Radius.circular(25)),
+        );
+        expect(surface.blurSigma, 10);
+        expect(
+          coloredSurfaces.any((surface) => surface.color == barBackground),
+          isTrue,
+        );
+        expect(
+          find.descendant(
+            of: surfaceFinder,
+            matching: find.byType(BackdropFilter),
+          ),
+          findsNWidgets(2),
+        );
+        expect(find.byType(NavigationRail), findsNothing);
+        debugDefaultTargetPlatformOverride = null;
+      },
+    );
+
+    testWidgets('navigation toggles use Flutter localization labels', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      _setSurfaceSize(tester, const Size(700, 600));
+      var router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      final materialContext = tester.element(
+        find.byKey(const ValueKey('rail-toggle-button')),
+      );
+      final localizations = MaterialLocalizations.of(materialContext);
+      expect(
+        tester
+            .widget<IconButton>(
+              find.byKey(const ValueKey('rail-toggle-button')),
+            )
+            .tooltip,
+        localizations.collapsedIconTapHint,
+      );
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      expect(
+        find.bySemanticsLabel(localizations.expandedIconTapHint),
+        findsOneWidget,
+      );
+      await tester.tap(find.byKey(const ValueKey('cupertino-sidebar-toggle')));
+      await tester.pumpAndSettle();
+      expect(
+        find.bySemanticsLabel(localizations.collapsedIconTapHint),
+        findsOneWidget,
+      );
+      semantics.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    });
 
     testWidgets('switches forms when crossing the compact/medium boundary', (
       tester,

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -19,6 +19,7 @@ import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 import 'package:mhabit_adaptive_ui/src/cupertino/cupertino_navigation_primary_action.dart';
 import 'package:mhabit_adaptive_ui/src/shell/navigation_scroll_wish_policy.dart';
 import 'package:mhabit_adaptive_ui/src/shell/navigation_shell_frame.dart';
+import 'package:mhabit_adaptive_ui/src/shell/side_navigation.dart';
 
 _TestRouter _buildRouter({
   List<AdaptiveNavigationDestination>? destinations,
@@ -482,42 +483,128 @@ void _resetWindowControlLayoutMock() {
 }
 
 void main() {
-  group('NavigationRailExtent', () {
+  group('SideNavigationExtent', () {
     test('fixed target clamps to the available interval', () {
-      const extent = NavigationRailExtent(224);
+      const extent = SideNavigationExtent(224);
 
       expect(extent.resolve(1600), 224);
       expect(extent.resolve(800), 216);
     });
 
     test('ratio resolves between the available bounds', () {
-      const extent = NavigationRailExtent.fromRatio(0.5);
+      const extent = SideNavigationExtent.fromRatio(0.5);
 
       expect(extent.resolve(1600), 270);
       expect(extent.resolve(800), 198);
     });
 
     test('owns interval growth and manual clamping', () {
-      const extent = NavigationRailExtent(
+      const extent = SideNavigationExtent(
         240,
-        collapsed: 64,
         minimum: 200,
         maximum: 320,
         rampStart: 800,
         rampEnd: 1400,
       );
 
-      expect(extent.collapsed, 64);
       expect(extent.upperBoundAt(1100), 260);
       expect(extent.resolve(1100), 240);
       expect(extent.clamp(300, windowWidth: 1100), 260);
     });
 
-    test('requires the extended minimum to fit the collapsed rail', () {
+    test('requires a valid full-width interval', () {
       expect(
-        () => NavigationRailExtent(100, collapsed: 200),
+        () => SideNavigationExtent(100, minimum: 200, maximum: 100),
         throwsAssertionError,
       );
+    });
+
+    test('material rail style owns its collapsed extent', () {
+      const style = MaterialNavigationRailStyle(collapsedExtent: 64);
+
+      expect(style.collapsedExtent, 64);
+      expect(
+        () => MaterialNavigationRailStyle(collapsedExtent: 0),
+        throwsAssertionError,
+      );
+    });
+  });
+
+  group('SideNavigationResizeState', () {
+    const extent = SideNavigationExtent(224);
+
+    test('clamps and hands a wider manual width to the available interval', () {
+      final state = SideNavigationResizeState();
+
+      expect(state.effectiveWidth(extent, windowWidth: 1800), 224);
+      state.startDrag(extent, windowWidth: 1800);
+      expect(state.dragging, isTrue);
+      state.updateDrag(500, extent, windowWidth: 1800);
+      state.endDrag();
+
+      expect(state.dragging, isFalse);
+      expect(state.effectiveWidth(extent, windowWidth: 1800), 360);
+      expect(state.effectiveWidth(extent, windowWidth: 900), 234);
+      expect(state.effectiveWidth(extent, windowWidth: 1800), 360);
+    });
+
+    test('hands a narrower manual width to auto and restores it later', () {
+      final state = SideNavigationResizeState();
+
+      state.startDrag(extent, windowWidth: 1800);
+      state.updateDrag(-5, extent, windowWidth: 1800);
+      state.endDrag();
+
+      expect(state.effectiveWidth(extent, windowWidth: 1400), 219);
+      expect(state.effectiveWidth(extent, windowWidth: 700), 198);
+      expect(state.effectiveWidth(extent, windowWidth: 1800), 219);
+    });
+
+    testWidgets('handle clears dragged state when a gesture is cancelled', (
+      tester,
+    ) async {
+      final observedStates = <Set<WidgetState>>[];
+      final logicalDeltas = <double>[];
+      var starts = 0;
+      var ends = 0;
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.rtl,
+          child: Center(
+            child: SizedBox(
+              height: 100,
+              child: SideNavigationResizeHandle(
+                hitExtent: 16,
+                dragHandleBuilder: (context, states) {
+                  observedStates.add(Set<WidgetState>.of(states));
+                  return const SizedBox.shrink();
+                },
+                onResizeStart: () => starts += 1,
+                onResizeUpdate: logicalDeltas.add,
+                onResizeEnd: () => ends += 1,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(SideNavigationResizeHandle)),
+      );
+      await gesture.moveBy(const Offset(-30, 0));
+      await tester.pump();
+      expect(starts, 1);
+      expect(logicalDeltas, isNotEmpty);
+      expect(logicalDeltas, everyElement(greaterThan(0)));
+      expect(
+        observedStates.any((states) => states.contains(WidgetState.dragged)),
+        isTrue,
+      );
+
+      await gesture.cancel();
+      await tester.pump();
+      expect(ends, 1);
+      expect(observedStates.last.contains(WidgetState.dragged), isFalse);
     });
   });
 
@@ -2571,9 +2658,9 @@ void main() {
               ),
             ],
             onDestinationSelected: (_) {},
-            railExtent: const NavigationRailExtent.fromRatio(
-              0.5,
-              collapsed: 64,
+            sideNavigationExtent: const SideNavigationExtent.fromRatio(0.5),
+            materialRailStyle: const MaterialNavigationRailStyle(
+              collapsedExtent: 64,
             ),
             child: const SizedBox(),
           ),
@@ -2614,6 +2701,25 @@ void main() {
       NavigationRail panel() =>
           tester.widget<NavigationRail>(find.byType(NavigationRail));
       expect(panel().minExtendedWidth, closeTo(224, 0.01));
+      final dragBar = find.byKey(
+        const ValueKey('material-side-navigation-drag-bar'),
+      );
+      expect(dragBar, findsOneWidget);
+      expect(tester.getSize(dragBar), const Size(4, 32));
+      final decoration =
+          tester
+                  .widget<DecoratedBox>(
+                    find.descendant(
+                      of: dragBar,
+                      matching: find.byType(DecoratedBox),
+                    ),
+                  )
+                  .decoration
+              as BoxDecoration;
+      expect(
+        decoration.color,
+        Theme.of(tester.element(dragBar)).colorScheme.onSurfaceVariant,
+      );
 
       // Drag far left: many small moves accumulate and clamp to the minimum.
       var gesture = await tester.startGesture(
@@ -2639,6 +2745,49 @@ void main() {
       await tester.pumpAndSettle();
       expect(panel().minExtendedWidth, 360.0);
     });
+
+    for (final direction in TextDirection.values) {
+      testWidgets('material rail resizes from its logical end in $direction', (
+        tester,
+      ) async {
+        _setSurfaceSize(tester, const Size(1000, 600));
+        final router = _buildRouter();
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerConfig: router,
+            builder: (context, child) =>
+                Directionality(textDirection: direction, child: child!),
+          ),
+        );
+
+        final railPanel = find.byKey(const ValueKey('rail-panel'));
+        final resizeHandle = find.byKey(const ValueKey('rail-resize-handle'));
+        expect(
+          tester.getCenter(resizeHandle).dx,
+          direction == TextDirection.ltr
+              ? tester.getTopRight(railPanel).dx - 4
+              : tester.getTopLeft(railPanel).dx + 4,
+        );
+
+        final logicalDrag = direction == TextDirection.ltr
+            ? const Offset(30, 0)
+            : const Offset(-30, 0);
+        await tester.drag(resizeHandle, logicalDrag);
+        await tester.pumpAndSettle();
+
+        expect(
+          tester
+              .widget<NavigationRail>(
+                find.descendant(
+                  of: railPanel,
+                  matching: find.byType(NavigationRail),
+                ),
+              )
+              .minExtendedWidth,
+          greaterThan(224),
+        );
+      });
+    }
 
     testWidgets('manual width above auto hands off along the interval', (
       tester,
@@ -3425,6 +3574,10 @@ void main() {
         final resizeHandle = find.byKey(
           const ValueKey('cupertino-sidebar-resize-handle'),
         );
+        expect(
+          find.byKey(const ValueKey('material-side-navigation-drag-bar')),
+          findsNothing,
+        );
         expect(tester.getSize(resizeHandle).width, 16);
         expect(tester.getSize(resizeHandle).height, panelSize().height - 50);
         expect(
@@ -3471,6 +3624,84 @@ void main() {
         tester.view.physicalSize = const Size(1000, 600);
         await tester.pumpAndSettle();
         expect(panelSize().width, resizedWidth);
+        debugDefaultTargetPlatformOverride = null;
+      });
+    }
+
+    for (final platform in <TargetPlatform>[
+      TargetPlatform.android,
+      TargetPlatform.iOS,
+    ]) {
+      testWidgets('custom drag handle builder is adaptive on $platform', (
+        tester,
+      ) async {
+        debugDefaultTargetPlatformOverride = platform;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        _setSurfaceSize(tester, const Size(1000, 600));
+        final observedStates = <Set<WidgetState>>[];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AdaptiveNavigationShell(
+              selectedIndex: 0,
+              destinations: const [
+                AdaptiveNavigationDestination(
+                  label: 'Habits',
+                  icons: NavigationDestinationIcons(
+                    material: Icon(Icons.home_outlined),
+                    materialSelected: Icon(Icons.home),
+                    apple: Icon(CupertinoIcons.home),
+                    appleSelected: Icon(CupertinoIcons.house_fill),
+                  ),
+                ),
+              ],
+              onDestinationSelected: (_) {},
+              sideNavigationDragHandleBuilder: (context, states) {
+                observedStates.add(Set<WidgetState>.of(states));
+                return const SizedBox(
+                  key: ValueKey('custom-side-navigation-drag-bar'),
+                  width: 3,
+                  height: 24,
+                );
+              },
+              child: const Scaffold(body: SizedBox.expand()),
+            ),
+          ),
+        );
+
+        final customBar = find.byKey(
+          const ValueKey('custom-side-navigation-drag-bar'),
+        );
+        final resizeHandle = find.byKey(
+          ValueKey(
+            platform == TargetPlatform.iOS
+                ? 'cupertino-sidebar-resize-handle'
+                : 'rail-resize-handle',
+          ),
+        );
+        expect(customBar, findsOneWidget);
+        expect(tester.getSize(customBar), const Size(3, 24));
+
+        final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        addTearDown(mouse.removePointer);
+        await mouse.addPointer(location: Offset.zero);
+        await mouse.moveTo(tester.getCenter(resizeHandle));
+        await tester.pump();
+        expect(
+          observedStates.any((states) => states.contains(WidgetState.hovered)),
+          isTrue,
+        );
+
+        await mouse.down(tester.getCenter(resizeHandle));
+        await mouse.moveBy(const Offset(10, 0));
+        await tester.pump();
+        expect(
+          observedStates.any((states) => states.contains(WidgetState.dragged)),
+          isTrue,
+        );
+        await mouse.up();
+        await tester.pumpAndSettle();
+        expect(observedStates.last.contains(WidgetState.dragged), isFalse);
         debugDefaultTargetPlatformOverride = null;
       });
     }

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -281,6 +281,7 @@ class _BranchInsetsProbe extends StatelessWidget {
   Widget build(BuildContext context) {
     final padding = MediaQuery.paddingOf(context);
     final viewPadding = MediaQuery.viewPaddingOf(context);
+    final viewInsets = MediaQuery.viewInsetsOf(context);
     return Column(
       key: const ValueKey('branch-layout-probe'),
       children: [
@@ -289,8 +290,21 @@ class _BranchInsetsProbe extends StatelessWidget {
           width: padding.left + padding.right,
         ),
         SizedBox(
+          key: const ValueKey('branch-vertical-padding'),
+          height: padding.top + padding.bottom,
+        ),
+        SizedBox(
           key: const ValueKey('branch-horizontal-view-padding'),
           width: viewPadding.left + viewPadding.right,
+        ),
+        SizedBox(
+          key: const ValueKey('branch-vertical-view-padding'),
+          height: viewPadding.top + viewPadding.bottom,
+        ),
+        SizedBox(
+          key: const ValueKey('branch-view-insets'),
+          width: viewInsets.left + viewInsets.right,
+          height: viewInsets.top + viewInsets.bottom,
         ),
       ],
     );
@@ -4143,6 +4157,85 @@ void main() {
       },
     );
 
+    testWidgets('apple Sidebar preserves all branch media insets', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      tester.view.padding = const FakeViewPadding(
+        left: 11,
+        top: 22,
+        right: 33,
+        bottom: 44,
+      );
+      tester.view.viewPadding = const FakeViewPadding(
+        left: 15,
+        top: 26,
+        right: 37,
+        bottom: 48,
+      );
+      tester.view.viewInsets = const FakeViewPadding(
+        left: 3,
+        top: 5,
+        right: 7,
+        bottom: 90,
+      );
+      _setSurfaceSize(tester, const Size(700, 600));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AdaptiveNavigationShell(
+            selectedIndex: 0,
+            destinations: const [
+              AdaptiveNavigationDestination(
+                label: 'Habits',
+                icons: NavigationDestinationIcons(
+                  material: Icon(Icons.home_outlined),
+                  materialSelected: Icon(Icons.home),
+                  apple: Icon(CupertinoIcons.home),
+                  appleSelected: Icon(CupertinoIcons.house_fill),
+                ),
+              ),
+            ],
+            onDestinationSelected: (_) {},
+            child: const _BranchInsetsProbe(),
+          ),
+        ),
+      );
+
+      expect(
+        tester
+            .getSize(find.byKey(const ValueKey('branch-horizontal-padding')))
+            .width,
+        44,
+      );
+      expect(
+        tester
+            .getSize(find.byKey(const ValueKey('branch-vertical-padding')))
+            .height,
+        66,
+      );
+      expect(
+        tester
+            .getSize(
+              find.byKey(const ValueKey('branch-horizontal-view-padding')),
+            )
+            .width,
+        52,
+      );
+      expect(
+        tester
+            .getSize(find.byKey(const ValueKey('branch-vertical-view-padding')))
+            .height,
+        74,
+      );
+      expect(
+        tester.getSize(find.byKey(const ValueKey('branch-view-insets'))),
+        const Size(10, 95),
+      );
+      debugDefaultTargetPlatformOverride = null;
+    });
+
     testWidgets('apple Sidebar disables visibility animation immediately', (
       tester,
     ) async {
@@ -4194,6 +4287,92 @@ void main() {
       expect(destinationSemantics.flagsCollection.isButton, isTrue);
       expect(find.bySemanticsLabel('Show Snackbar'), findsOneWidget);
       semanticsHandle.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('apple Sidebar supports keyboard activation', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      _setSurfaceSize(tester, const Size(700, 600));
+      final selected = <int>[];
+      final router = _buildRouter(onBranchChanged: selected.add);
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      final selectedButton = tester.widget<CupertinoButton>(
+        find.descendant(
+          of: find.byKey(const ValueKey('cupertino-sidebar-destination-0')),
+          matching: find.byType(CupertinoButton),
+        ),
+      );
+      expect(selectedButton.autofocus, isTrue);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.pumpAndSettle();
+
+      expect(selected, [1]);
+      expect(find.text('today page'), findsOneWidget);
+
+      final toggle = find.byKey(const ValueKey('cupertino-sidebar-toggle'));
+      final toggleButton = tester.widget<CupertinoButton>(toggle);
+      toggleButton.focusNode!.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-panel')),
+        findsNothing,
+      );
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('apple Sidebar remains usable at large text scale', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      tester.platformDispatcher.textScaleFactorTestValue = 3;
+      addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+      _setSurfaceSize(tester, const Size(700, 240));
+      final router = _buildRouter(
+        destinations: const [
+          AdaptiveNavigationDestination(
+            label: 'A very long habits destination label',
+            icons: NavigationDestinationIcons(
+              material: Icon(Icons.home_outlined),
+              materialSelected: Icon(Icons.home),
+              apple: Icon(CupertinoIcons.home),
+              appleSelected: Icon(CupertinoIcons.house_fill),
+            ),
+          ),
+          AdaptiveNavigationDestination(
+            label: 'Today',
+            icons: NavigationDestinationIcons(
+              material: Icon(Icons.calendar_today_outlined),
+              materialSelected: Icon(Icons.calendar_today),
+              apple: Icon(CupertinoIcons.calendar),
+              appleSelected: Icon(CupertinoIcons.calendar_today),
+            ),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      final destinationButtons = tester.widgetList<CupertinoButton>(
+        find.descendant(
+          of: find.byKey(const ValueKey('cupertino-sidebar-destination-list')),
+          matching: find.byType(CupertinoButton),
+        ),
+      );
+      expect(destinationButtons, hasLength(2));
+      expect(
+        find.byKey(const ValueKey('cupertino-sidebar-resize-handle')),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
       debugDefaultTargetPlatformOverride = null;
     });
 

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -10,6 +10,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 import 'package:mhabit_adaptive_ui/src/cupertino/cupertino_navigation_primary_action.dart';
+import 'package:mhabit_adaptive_ui/src/shell/navigation_scroll_wish_policy.dart';
+import 'package:mhabit_adaptive_ui/src/shell/navigation_shell_frame.dart';
 
 _TestRouter _buildRouter({
   List<AdaptiveNavigationDestination>? destinations,
@@ -530,6 +532,77 @@ void main() {
   });
 
   group('AdaptiveNavigationShell', () {
+    testWidgets(
+      'frame delegates body composition with restored ambient geometry',
+      (tester) async {
+        tester.view.padding = const FakeViewPadding(left: 44, right: 20);
+        tester.view.viewPadding = const FakeViewPadding(left: 50, right: 30);
+        _setSurfaceSize(tester, const Size(700, 800));
+        final selected = <int>[];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: NavigationShellFrame(
+              selectedIndex: 0,
+              onDestinationSelected: selected.add,
+              compactRouteVisible: true,
+              contextualChromeSuppressed: false,
+              barHeight: 80,
+              navHeight: 80,
+              keepVisibleOnScroll: false,
+              scrollWishPolicy: const NavigationScrollWishPolicy.directional(),
+              formResolver: (_) => NavigationShellForm.constrainedSide,
+              bodyBuilder: (context, form, onSelected, child) {
+                final padding = MediaQuery.paddingOf(context);
+                final viewPadding = MediaQuery.viewPaddingOf(context);
+                final owner = AdaptiveWindowControlLayoutScope.maybeOf(
+                  context,
+                )!.owner;
+                return Stack(
+                  key: const ValueKey('custom-shell-body'),
+                  children: [
+                    child,
+                    SizedBox(
+                      key: const ValueKey('custom-shell-geometry'),
+                      width: padding.left + padding.right,
+                      height: viewPadding.left + viewPadding.right,
+                    ),
+                    TextButton(
+                      key: const ValueKey('custom-shell-destination'),
+                      onPressed: () => onSelected(1),
+                      child: Text('${form.name}:${owner.name}'),
+                    ),
+                  ],
+                );
+              },
+              windowControlOwnerResolver: (_) =>
+                  WindowControlLayoutOwner.sideNavigation,
+              compactNavigationBuilder: (_, _) => const SizedBox.shrink(),
+              child: const Text('branch'),
+            ),
+          ),
+        );
+
+        expect(
+          find.descendant(
+            of: find.byKey(const ValueKey('custom-shell-body')),
+            matching: find.byType(Row),
+          ),
+          findsNothing,
+        );
+        expect(
+          tester.getSize(find.byKey(const ValueKey('custom-shell-geometry'))),
+          const Size(64, 80),
+        );
+        expect(find.text('constrainedSide:sideNavigation'), findsOneWidget);
+
+        await tester.tap(
+          find.byKey(const ValueKey('custom-shell-destination')),
+        );
+        expect(selected, [1]);
+      },
+    );
+
     testWidgets('style switching preserves branch content state', (
       tester,
     ) async {
@@ -575,14 +648,43 @@ void main() {
       await tester.tap(find.text('branch count 0'));
       await tester.pump();
       expect(find.text('branch count 1'), findsOneWidget);
+      final branchState = tester.state<_StatefulBranchProbeState>(
+        find.byType(_StatefulBranchProbe),
+      );
 
       style.value = AdaptiveStyle.apple;
       await tester.pumpAndSettle();
 
       expect(find.text('branch count 1'), findsOneWidget);
       expect(
+        tester.state<_StatefulBranchProbeState>(
+          find.byType(_StatefulBranchProbe),
+        ),
+        same(branchState),
+      );
+      expect(
         find.byKey(const ValueKey('cupertino-adaptive-navigation-bar')),
         findsOneWidget,
+      );
+
+      tester.view.physicalSize = const Size(700, 800);
+      await tester.pumpAndSettle();
+      expect(find.text('branch count 1'), findsOneWidget);
+      expect(
+        tester.state<_StatefulBranchProbeState>(
+          find.byType(_StatefulBranchProbe),
+        ),
+        same(branchState),
+      );
+
+      tester.view.physicalSize = const Size(1000, 479);
+      await tester.pumpAndSettle();
+      expect(find.text('branch count 1'), findsOneWidget);
+      expect(
+        tester.state<_StatefulBranchProbeState>(
+          find.byType(_StatefulBranchProbe),
+        ),
+        same(branchState),
       );
     });
 
@@ -1256,7 +1358,7 @@ void main() {
       expect(layout.usesRectangularDisplay, isTrue);
     });
 
-    testWidgets('assigns avoidance to app bar or rail without overlap', (
+    testWidgets('assigns avoidance to app bar or side navigation', (
       tester,
     ) async {
       _mockWindowControlLayout();
@@ -1268,12 +1370,19 @@ void main() {
 
         var context = tester.element(find.text('habits page'));
         var layout = AdaptiveWindowControlLayoutScope.maybeOf(context)!;
+        expect(layout.owner, WindowControlLayoutOwner.appBar);
         expect(
           layout.appBarHorizontalAvoidance,
           const EdgeInsetsDirectional.only(start: 40, end: 12),
         );
-        expect(layout.railHorizontalAvoidance, EdgeInsetsDirectional.zero);
-        expect(layout.railVerticalAvoidance, EdgeInsetsDirectional.zero);
+        expect(
+          layout.sideNavigationHorizontalAvoidance,
+          EdgeInsetsDirectional.zero,
+        );
+        expect(
+          layout.sideNavigationVerticalAvoidance,
+          EdgeInsetsDirectional.zero,
+        );
         expect(
           layout.horizontalSafeAreaAvoidance,
           const EdgeInsetsDirectional.fromSTEB(24, 0, 18, 0),
@@ -1289,13 +1398,14 @@ void main() {
 
         context = tester.element(find.text('habits page'));
         layout = AdaptiveWindowControlLayoutScope.maybeOf(context)!;
+        expect(layout.owner, WindowControlLayoutOwner.sideNavigation);
         expect(layout.appBarHorizontalAvoidance, EdgeInsetsDirectional.zero);
         expect(
-          layout.railHorizontalAvoidance,
+          layout.sideNavigationHorizontalAvoidance,
           const EdgeInsetsDirectional.only(start: 40, end: 12),
         );
         expect(
-          layout.railVerticalAvoidance,
+          layout.sideNavigationVerticalAvoidance,
           const EdgeInsetsDirectional.only(top: 64),
         );
         expect(
@@ -1855,6 +1965,21 @@ void main() {
       );
     });
 
+    testWidgets('side form snackbar remains owned by the root scaffold', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(700, 800));
+      final router = _buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      await tester.tap(find.byKey(const ValueKey('show-snackbar')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.byType(NavigationRail), findsOneWidget);
+      expect(find.byType(NavigationBar), findsNothing);
+    });
+
     testWidgets('floating snackbar follows the collapsing navigation bar', (
       tester,
     ) async {
@@ -2234,7 +2359,7 @@ void main() {
       );
     });
 
-    testWidgets('apple large compact-height defaults to a collapsed rail', (
+    testWidgets('apple large ignores compact height for its side form', (
       tester,
     ) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
@@ -2244,7 +2369,7 @@ void main() {
 
       expect(
         tester.widget<NavigationRail>(find.byType(NavigationRail)).extended,
-        isFalse,
+        isTrue,
       );
       debugDefaultTargetPlatformOverride = null;
     });
@@ -2578,25 +2703,38 @@ void main() {
     });
 
     testWidgets(
-      'apple medium+ uses the documented rail compatibility fallback',
+      'apple boundaries use the documented rail compatibility fallback',
       (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-        _setSurfaceSize(tester, const Size(700, 600));
+        _setSurfaceSize(tester, const Size(599, 479));
         final router = _buildRouter();
         await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
-        // Apple medium maps to the collapsible rail, collapsed by default.
+        expect(
+          find.byKey(const ValueKey('cupertino-adaptive-navigation-bar')),
+          findsOneWidget,
+        );
+        expect(find.byType(NavigationRail), findsNothing);
+
+        tester.view.physicalSize = const Size(600, 479);
+        await tester.pumpAndSettle();
+
         expect(find.byType(NavigationRail), findsOneWidget);
         expect(
           tester.widget<NavigationRail>(find.byType(NavigationRail)).extended,
           isFalse,
         );
 
-        tester.view.physicalSize = const Size(1300, 800);
+        tester.view.physicalSize = const Size(905, 479);
+        await tester.pumpAndSettle();
+        expect(
+          tester.widget<NavigationRail>(find.byType(NavigationRail)).extended,
+          isFalse,
+        );
+
+        tester.view.physicalSize = const Size(906, 479);
         await tester.pumpAndSettle();
 
-        // Apple large maps to the collapsible rail, extended by default; no
-        // drawer tier exists on Apple platforms.
         expect(
           tester.widget<NavigationRail>(find.byType(NavigationRail)).extended,
           isTrue,

--- a/packages/mhabit_adaptive_ui/test/cupertino/cupertino_adaptive_navigation_bar_test.dart
+++ b/packages/mhabit_adaptive_ui/test/cupertino/cupertino_adaptive_navigation_bar_test.dart
@@ -321,6 +321,46 @@ void main() {
       expect(selected, [2]);
     });
 
+    testWidgets('keeps selected and unselected foregrounds opaque', (
+      tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(400, 800);
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        _wrap(
+          presentation: AdaptiveNavigationBarPresentation.expanded,
+          onDestinationSelected: (_) {},
+          onExpandRequested: () {},
+          theme: const CupertinoThemeData(primaryColor: Color(0x80336699)),
+        ),
+      );
+
+      final selectedIcon = find.byKey(const ValueKey('today-apple-selected'));
+      final unselectedIcon = find.byKey(const ValueKey('habits-apple'));
+      final selectedIconColor = IconTheme.of(
+        tester.element(selectedIcon),
+      ).color!;
+      final unselectedIconColor = IconTheme.of(
+        tester.element(unselectedIcon),
+      ).color!;
+      final selectedLabelColor = tester
+          .widget<Text>(find.text('Today'))
+          .style!
+          .color!;
+      final unselectedLabelColor = tester
+          .widget<Text>(find.text('Habits'))
+          .style!
+          .color!;
+
+      expect(selectedIconColor.a, 1);
+      expect(unselectedIconColor.a, 1);
+      expect(selectedLabelColor, selectedIconColor);
+      expect(unselectedLabelColor, unselectedIconColor);
+      expect(unselectedIconColor, CupertinoColors.black);
+    });
+
     testWidgets('aligns dark surfaces with shared elevation treatment', (
       tester,
     ) async {

--- a/packages/mhabit_adaptive_ui/test/cupertino/cupertino_sliver_search_bar_test.dart
+++ b/packages/mhabit_adaptive_ui/test/cupertino/cupertino_sliver_search_bar_test.dart
@@ -9,9 +9,10 @@ Widget _host(
   TextDirection textDirection = TextDirection.ltr,
   double? contentWidth,
   EdgeInsetsDirectional appBarAvoidance = EdgeInsetsDirectional.zero,
-}) => MaterialApp(
-  theme: ThemeData(platform: TargetPlatform.iOS),
-  home: Directionality(
+  Color? pageBackground,
+  Brightness brightness = Brightness.light,
+}) {
+  final content = Directionality(
     textDirection: textDirection,
     child: AdaptiveWindowControlLayoutScope(
       horizontalAvoidance: appBarAvoidance,
@@ -27,8 +28,17 @@ Widget _host(
         ),
       ),
     ),
-  ),
-);
+  );
+  return MaterialApp(
+    theme: ThemeData(platform: TargetPlatform.iOS, brightness: brightness),
+    home: pageBackground == null
+        ? content
+        : CupertinoPageScaffoldBackgroundColor(
+            color: pageBackground,
+            child: content,
+          ),
+  );
+}
 
 void main() {
   late TextEditingController controller;
@@ -208,18 +218,18 @@ void main() {
           .border,
       isNull,
     );
-    expect(tester.getSize(find.byType(CupertinoNavigationBar)).height, 52);
+    expect(tester.getSize(find.byType(CupertinoNavigationBar)).height, 44);
     final header = tester.widget<SliverPersistentHeader>(
       find.byType(SliverPersistentHeader),
     );
     expect(header.pinned, isTrue);
-    expect(header.delegate.minExtent, 52);
-    expect(header.delegate.maxExtent, 52);
+    expect(header.delegate.minExtent, 44);
+    expect(header.delegate.maxExtent, 44);
     expect(
       tester
           .getCenter(find.byKey(const ValueKey('activate-cupertino-search')))
           .dy,
-      26,
+      22,
     );
   });
 
@@ -294,16 +304,28 @@ void main() {
     final header = tester.widget<SliverPersistentHeader>(
       find.byType(SliverPersistentHeader),
     );
-    expect(header.delegate.minExtent, 100);
-    expect(header.delegate.maxExtent, 100);
-    expect(tester.getSize(find.byType(CupertinoNavigationBar)).height, 100);
+    expect(header.delegate.minExtent, 92);
+    expect(header.delegate.maxExtent, 92);
+    expect(tester.getSize(find.byType(CupertinoNavigationBar)).height, 92);
     expect(
       tester
           .getTopLeft(find.byKey(const ValueKey('cupertino-search-bottom')))
           .dy,
-      52,
+      44,
     );
-    expect(find.byType(BackdropFilter), findsOneWidget);
+    final navigationBar = tester.widget<CupertinoNavigationBar>(
+      find.byType(CupertinoNavigationBar),
+    );
+    expect(navigationBar.enableBackgroundFilterBlur, isTrue);
+    expect(navigationBar.automaticBackgroundVisibility, isFalse);
+    expect(navigationBar.backgroundColor, CupertinoColors.transparent);
+    expect(navigationBar.border, isNull);
+    expect(
+      tester
+          .widgetList<BackdropFilter>(find.byType(BackdropFilter))
+          .where((filter) => filter.enabled),
+      hasLength(1),
+    );
   });
 
   testWidgets('supports a primary cascading action menu', (tester) async {

--- a/packages/mhabit_adaptive_ui/test/window_control_layout_test.dart
+++ b/packages/mhabit_adaptive_ui/test/window_control_layout_test.dart
@@ -91,7 +91,7 @@ void main() {
     expect(wrappedGeometry, stockGeometry);
   });
 
-  testWidgets('Material explicit zero and rail owner disable avoidance', (
+  testWidgets('Material explicit zero and side owner disable avoidance', (
     tester,
   ) async {
     tester.view.devicePixelRatio = 1;
@@ -116,7 +116,10 @@ void main() {
     }
 
     expect(await leadingLeft(explicitAvoidance: EdgeInsetsDirectional.zero), 0);
-    expect(await leadingLeft(owner: WindowControlLayoutOwner.rail), 0);
+    expect(
+      await leadingLeft(owner: WindowControlLayoutOwner.sideNavigation),
+      0,
+    );
   });
 
   testWidgets('Material edge padding is configurable and directional', (

--- a/test/feature/habits_display/habit_display_page_test.dart
+++ b/test/feature/habits_display/habit_display_page_test.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart'
     show
         CupertinoButton,
+        CupertinoColors,
         CupertinoMenuItem,
         CupertinoNavigationBar,
         CupertinoPopupSurface,
@@ -597,6 +598,41 @@ void main() {
     );
   });
 
+  testWidgets('Today medium uses the fixed native blurred toolbar surface', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(700, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final profile = await _loadProfile();
+    final access = _LoadedHabitsDisplayAccess();
+    final sync = _FakeAppSyncWorkflowAccess();
+    addTearDown(() {
+      sync.dispose();
+      profile.dispose();
+    });
+
+    await _pumpTodayTabPage(
+      tester,
+      profile: profile,
+      access: access,
+      sync: sync,
+      platform: TargetPlatform.iOS,
+    );
+
+    expect(find.byType(CupertinoSliverNavigationBar), findsNothing);
+    final navigationBar = tester.widget<CupertinoNavigationBar>(
+      find.byType(CupertinoNavigationBar),
+    );
+    expect(navigationBar.enableBackgroundFilterBlur, isTrue);
+    expect(navigationBar.automaticBackgroundVisibility, isFalse);
+    final header = tester.widget<SliverPersistentHeader>(
+      find.byType(SliverPersistentHeader),
+    );
+    expect(header.delegate.minExtent, 44);
+    expect(header.delegate.maxExtent, 44);
+  });
+
   testWidgets('framework dismiss intent does not collide with page shortcuts', (
     tester,
   ) async {
@@ -908,8 +944,8 @@ void main() {
       searchHeaderFinder,
     );
     expect(searchHeader.pinned, isTrue);
-    expect(searchHeader.delegate.minExtent, 100);
-    expect(searchHeader.delegate.maxExtent, 100);
+    expect(searchHeader.delegate.minExtent, 92);
+    expect(searchHeader.delegate.maxExtent, 92);
     expect(
       find.ancestor(of: calendar, matching: find.byType(SliverAppBar)),
       findsNothing,
@@ -921,12 +957,25 @@ void main() {
       ),
       findsOneWidget,
     );
-    expect(
+    final habitsNavigationBar = tester.widget<CupertinoNavigationBar>(
       find.descendant(
         of: searchHeaderFinder,
-        matching: find.byType(BackdropFilter),
+        matching: find.byType(CupertinoNavigationBar),
       ),
-      findsOneWidget,
+    );
+    expect(habitsNavigationBar.enableBackgroundFilterBlur, isTrue);
+    expect(habitsNavigationBar.automaticBackgroundVisibility, isFalse);
+    expect(habitsNavigationBar.backgroundColor, CupertinoColors.transparent);
+    expect(
+      tester
+          .widgetList<BackdropFilter>(
+            find.descendant(
+              of: searchHeaderFinder,
+              matching: find.byType(BackdropFilter),
+            ),
+          )
+          .where((filter) => filter.enabled),
+      hasLength(1),
     );
     expect(find.byType(PinnedHeaderSliver), findsNothing);
   });
@@ -1115,7 +1164,10 @@ void main() {
 
     tester.view.physicalSize = const Size(700, 800);
     await tester.pump();
-    expect(find.byType(NavigationRail), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('cupertino-sidebar-panel')),
+      findsOneWidget,
+    );
     expect(find.byType(NavigationBar), findsNothing);
 
     tester.view.physicalSize = const Size(390, 800);
@@ -1232,7 +1284,10 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 350));
 
-    expect(find.byType(NavigationRail), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('cupertino-sidebar-panel')),
+      findsOneWidget,
+    );
     expect(compactButton, findsOneWidget);
     expect(tester.element(compactButton), same(compactButtonElement));
     expect(find.byType(ScrollingFAB), findsNothing);

--- a/test/unit/entries/app_root_view_test.dart
+++ b/test/unit/entries/app_root_view_test.dart
@@ -81,6 +81,20 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('text direction override reaches the app content', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const AppRootView(
+          themeMode: ThemeMode.system,
+          textDirectionOverride: TextDirection.rtl,
+          child: _TextDirectionProbe(),
+        ),
+      );
+
+      expect(find.text('rtl'), findsOneWidget);
+    });
+
     testWidgets(
       'router path: no navigatorKey/navigatorObservers on MaterialApp',
       (tester) async {
@@ -188,4 +202,11 @@ void main() {
       }
     });
   });
+}
+
+class _TextDirectionProbe extends StatelessWidget {
+  const _TextDirectionProbe();
+
+  @override
+  Widget build(BuildContext context) => Text(Directionality.of(context).name);
 }

--- a/test/unit/pages/app_settings/app_setting_develop_subgroup_test.dart
+++ b/test/unit/pages/app_settings/app_setting_develop_subgroup_test.dart
@@ -42,8 +42,10 @@ Widget _host(AppDeveloperViewModel viewModel) =>
                 isInDevelopMode: value.isInDevelopMode,
                 isDisplayDebugMenuSelect: value.displayDebugMenu,
                 adaptiveStyleMode: value.adaptiveStyleMode,
+                textDirectionOverride: value.textDirectionOverride,
                 onDisplayDebugMenuSelectChanged: value.switchDisplayDebugMenu,
                 onAdaptiveStyleModeChanged: value.setAdaptiveStyleMode,
+                onTextDirectionOverrideChanged: value.setTextDirectionOverride,
               ),
             ),
           ),
@@ -87,7 +89,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final control = find.byKey(const ValueKey('developer-ui-style-control'));
-    expect(find.byType(MenuAnchor), findsOneWidget);
+    expect(find.byType(MenuAnchor), findsNWidgets(2));
     final tile = find.ancestor(of: control, matching: find.byType(ListTile));
     expect(
       tester.getCenter(control).dx,
@@ -110,5 +112,42 @@ void main() {
     await tester.tap(find.text('Apple'));
     await tester.pumpAndSettle();
     expect(viewModel.adaptiveStyleMode, AppAdaptiveStyleMode.apple);
+  });
+
+  testWidgets('text direction control switches three in-memory states', (
+    tester,
+  ) async {
+    final (profile, viewModel) = await _loadViewModel();
+    addTearDown(profile.dispose);
+    addTearDown(viewModel.dispose);
+
+    await tester.pumpWidget(_host(viewModel));
+    await tester.pumpAndSettle();
+
+    final control = find.byKey(
+      const ValueKey('developer-text-direction-control'),
+    );
+    expect(
+      find.descendant(of: control, matching: find.text('Auto')),
+      findsOneWidget,
+    );
+
+    await tester.tap(control);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('LTR'));
+    await tester.pumpAndSettle();
+    expect(viewModel.textDirectionOverride, TextDirection.ltr);
+
+    await tester.tap(control);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('RTL'));
+    await tester.pumpAndSettle();
+    expect(viewModel.textDirectionOverride, TextDirection.rtl);
+
+    await tester.tap(control);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Auto'));
+    await tester.pumpAndSettle();
+    expect(viewModel.textDirectionOverride, isNull);
   });
 }

--- a/test/unit/providers/app_ui/app_developer_test.dart
+++ b/test/unit/providers/app_ui/app_developer_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:flutter/widgets.dart' show TextDirection;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mhabit/models/app_adaptive_style_mode.dart';
 import 'package:mhabit/providers/app_ui/app_developer.dart';
@@ -142,5 +143,26 @@ void main() {
         profile.dispose();
       },
     );
+  });
+
+  test('text direction override is in-memory only', () async {
+    final profile = await _loadProfile();
+    final firstViewModel = AppDeveloperViewModel(
+      global: Global(),
+      profile: profile,
+    );
+
+    firstViewModel.setTextDirectionOverride(TextDirection.rtl);
+    expect(firstViewModel.textDirectionOverride, TextDirection.rtl);
+    firstViewModel.dispose();
+
+    final secondViewModel = AppDeveloperViewModel(
+      global: Global(),
+      profile: profile,
+    );
+    expect(secondViewModel.textDirectionOverride, isNull);
+
+    secondViewModel.dispose();
+    profile.dispose();
   });
 }

--- a/test/unit/theme/app_theme_builder_test.dart
+++ b/test/unit/theme/app_theme_builder_test.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/cupertino.dart' show CupertinoDynamicColor;
+import 'package:flutter/cupertino.dart'
+    show CupertinoDynamicColor, CupertinoTextThemeData;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,6 +9,7 @@ import 'package:mhabit/models/app_theme_color.dart';
 import 'package:mhabit/models/habit_color_type.dart';
 import 'package:mhabit/theme/app_theme_builder.dart';
 import 'package:mhabit/theme/color.dart';
+import 'package:mhabit/theme/linux_bundled_font.dart';
 import 'package:mhabit/widgets/styles.dart';
 
 void _withPlatform(TargetPlatform platform, void Function() body) {
@@ -57,11 +59,7 @@ void main() {
     });
 
     test('system path keeps the explicit brightness with a null scheme', () {
-      for (final platform in [
-        TargetPlatform.windows,
-        TargetPlatform.linux,
-        TargetPlatform.fuchsia,
-      ]) {
+      for (final platform in [TargetPlatform.windows, TargetPlatform.fuchsia]) {
         _withPlatform(platform, () {
           final theme = builder.buildLight(
             themeColor: const SystemAppThemeColor(),
@@ -72,6 +70,27 @@ void main() {
           _expectMaterialRailSurface(theme);
         });
       }
+    });
+
+    test('linux system path retains the Cupertino font override', () {
+      _withPlatform(TargetPlatform.linux, () {
+        final theme = builder.buildLight(
+          themeColor: const SystemAppThemeColor(),
+          themeMainColor: fallbackMainColor,
+        );
+        expect(theme.brightness, Brightness.light);
+        expect(theme.cupertinoOverrideTheme?.textTheme, isNotNull);
+        expect(
+          theme.cupertinoOverrideTheme!.textTheme!.actionTextStyle.color,
+          theme.colorScheme.primary,
+        );
+        expect(theme.textTheme.bodyMedium!.fontFamily, linuxBundledFontFamily);
+        expect(
+          theme.textTheme.bodyMedium!.fontFamilyFallback,
+          contains('Noto Sans CJK SC'),
+        );
+        _expectMaterialRailSurface(theme);
+      });
     });
   });
 
@@ -170,13 +189,57 @@ void main() {
         });
       },
     );
+
+    test('uses Linux fonts for every Cupertino text role', () {
+      _withPlatform(TargetPlatform.linux, () {
+        final theme = builder.buildLight(
+          themeColor: const PrimaryAppThemeColor(),
+          themeMainColor: fallbackMainColor,
+        );
+        final CupertinoTextThemeData textTheme =
+            theme.cupertinoOverrideTheme!.textTheme!;
+        final styles = <TextStyle>[
+          textTheme.textStyle,
+          textTheme.actionTextStyle,
+          textTheme.actionSmallTextStyle,
+          textTheme.tabLabelTextStyle,
+          textTheme.navTitleTextStyle,
+          textTheme.navLargeTitleTextStyle,
+          textTheme.navActionTextStyle,
+          textTheme.pickerTextStyle,
+          textTheme.dateTimePickerTextStyle,
+        ];
+
+        for (final style in styles) {
+          expect(style.fontFamily, linuxBundledFontFamily);
+          expect(style.fontFamilyFallback, contains('Noto Sans CJK SC'));
+        }
+      });
+    });
+
+    test('does not override Cupertino typography outside Linux', () {
+      _withPlatform(TargetPlatform.macOS, () {
+        final theme = builder.buildLight(
+          themeColor: const PrimaryAppThemeColor(),
+          themeMainColor: fallbackMainColor,
+        );
+        expect(theme.cupertinoOverrideTheme!.textTheme, isNull);
+      });
+    });
   });
 
   group('AppThemeBuilder.getThemeColor', () {
-    test('font family stays null off the linux aarch64 path', () {
+    test('font family stays null outside Linux', () {
       _withPlatform(TargetPlatform.macOS, () {
         expect(builder.getFontFamily(), isNull);
         expect(builder.getFontFamilyFallbacks(), isNull);
+      });
+    });
+
+    test('font family and CJK fallbacks apply to every Linux architecture', () {
+      _withPlatform(TargetPlatform.linux, () {
+        expect(builder.getFontFamily(), linuxBundledFontFamily);
+        expect(builder.getFontFamilyFallbacks(), contains('Noto Sans CJK SC'));
       });
     });
 

--- a/test/unit/theme/app_theme_builder_test.dart
+++ b/test/unit/theme/app_theme_builder_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart' show CupertinoDynamicColor;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -112,7 +113,7 @@ void main() {
   });
 
   group('AppThemeBuilder cupertino mapping', () {
-    test('follows the resolved scheme colors', () {
+    test('maps scheme chrome and uses the neutral apple glass tint', () {
       _withPlatform(TargetPlatform.macOS, () {
         final theme = builder.buildLight(
           themeColor: const SystemAppThemeColor(),
@@ -125,32 +126,39 @@ void main() {
         expect(override.primaryColor, scheme.primary);
         expect(
           override.barBackgroundColor,
-          scheme.surface.withValues(alpha: 0.8),
+          const CupertinoDynamicColor.withBrightness(
+            debugLabel: 'mhabitAppleGlassBackground',
+            color: Color(0xCCFFFFFF),
+            darkColor: Color(0x0FFFFFFF),
+          ),
         );
         expect(override.scaffoldBackgroundColor, scheme.surface);
       });
     });
 
-    test('uses a distinct elevated bar surface in dark mode', () {
-      _withPlatform(TargetPlatform.macOS, () {
-        final theme = builder.buildDark(
-          themeColor: const SystemAppThemeColor(),
-          themeMainColor: fallbackMainColor,
-        );
-        final scheme = theme.colorScheme;
-        final override = theme.cupertinoOverrideTheme;
-        expect(override, isNotNull);
-        expect(
-          override!.barBackgroundColor,
-          scheme.surfaceContainerHigh.withValues(alpha: 0.8),
-        );
-        expect(
-          override.barBackgroundColor,
-          isNot(scheme.surface.withValues(alpha: 0.8)),
-        );
-        expect(override.scaffoldBackgroundColor, scheme.surface);
-      });
-    });
+    test(
+      'keeps dark apple glass independent from elevated scheme surfaces',
+      () {
+        _withPlatform(TargetPlatform.macOS, () {
+          final theme = builder.buildDark(
+            themeColor: const SystemAppThemeColor(),
+            themeMainColor: fallbackMainColor,
+          );
+          final scheme = theme.colorScheme;
+          final override = theme.cupertinoOverrideTheme;
+          expect(override, isNotNull);
+          expect(
+            override!.barBackgroundColor,
+            isNot(scheme.surfaceContainerHigh.withValues(alpha: 0.8)),
+          );
+          expect(
+            override.barBackgroundColor,
+            isNot(scheme.surface.withValues(alpha: 0.8)),
+          );
+          expect(override.scaffoldBackgroundColor, scheme.surface);
+        });
+      },
+    );
   });
 
   group('AppThemeBuilder.getThemeColor', () {

--- a/test/unit/theme/app_theme_builder_test.dart
+++ b/test/unit/theme/app_theme_builder_test.dart
@@ -16,6 +16,15 @@ void _withPlatform(TargetPlatform platform, void Function() body) {
   body();
 }
 
+void _expectMaterialRailSurface(ThemeData theme) {
+  expect(theme.appBarTheme, same(kAppBarTheme));
+  expect(
+    theme.navigationRailTheme.backgroundColor,
+    theme.colorScheme.surfaceContainer,
+  );
+  expect(theme.navigationRailTheme.elevation, 1.0);
+}
+
 void main() {
   const builder = AppThemeBuilder();
   const fallbackMainColor = Color(0xFF112233);
@@ -31,7 +40,7 @@ void main() {
         expect(theme.useMaterial3, isTrue);
         expect(theme.brightness, Brightness.light);
         expect(theme.colorScheme.brightness, Brightness.light);
-        expect(theme.appBarTheme, same(kAppBarTheme));
+        _expectMaterialRailSurface(theme);
         expect(theme.snackBarTheme.behavior, SnackBarBehavior.floating);
         expect(theme.extensions.values.whereType<CustomColors>(), hasLength(1));
       },
@@ -44,6 +53,7 @@ void main() {
       );
       expect(theme.brightness, Brightness.dark);
       expect(theme.colorScheme.brightness, Brightness.dark);
+      _expectMaterialRailSurface(theme);
     });
 
     test('system path keeps the explicit brightness with a null scheme', () {
@@ -59,6 +69,7 @@ void main() {
           );
           expect(theme.brightness, Brightness.light, reason: '$platform');
           expect(theme.cupertinoOverrideTheme, isNull, reason: '$platform');
+          _expectMaterialRailSurface(theme);
         });
       }
     });

--- a/test/unit/theme/linux_bundled_font_test.dart
+++ b/test/unit/theme/linux_bundled_font_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mhabit/theme/linux_bundled_font.dart';
+
+void main() {
+  test('does not inspect the bundled font outside Linux', () async {
+    var inspectedFile = false;
+
+    final loaded = await loadLinuxBundledFont(
+      platform: TargetPlatform.windows,
+      fileExists: (_) async {
+        inspectedFile = true;
+        return true;
+      },
+    );
+
+    expect(loaded, isFalse);
+    expect(inspectedFile, isFalse);
+  });
+
+  test(
+    'leaves a Linux build unchanged when the Flatpak font is absent',
+    () async {
+      final loaded = await loadLinuxBundledFont(
+        platform: TargetPlatform.linux,
+        fileExists: (_) async => false,
+      );
+
+      expect(loaded, isFalse);
+    },
+  );
+
+  test('registers the Flatpak font with Flutter before use', () async {
+    final bytes = Uint8List.fromList([1, 2, 3]);
+    String? registeredFamily;
+    Uint8List? registeredBytes;
+
+    final loaded = await loadLinuxBundledFont(
+      platform: TargetPlatform.linux,
+      fileExists: (path) async => path == linuxBundledFontPath,
+      readFile: (path) async {
+        expect(path, linuxBundledFontPath);
+        return bytes;
+      },
+      registerFont: (fontBytes, family) async {
+        registeredBytes = fontBytes;
+        registeredFamily = family;
+      },
+    );
+
+    expect(loaded, isTrue);
+    expect(registeredBytes, same(bytes));
+    expect(registeredFamily, linuxBundledFontFamily);
+  });
+}


### PR DESCRIPTION
## Summary
This PR updates the app shell to adopt a Material 3 wide navigation rail and an Apple-style beside sidebar on larger screens. It centralizes navigation resizing logic, refines dark-mode chrome and surface treatment, and adds regression coverage for the Apple sidebar layout.

## Type of Change
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] style
- [ ] test
- [ ] chore

## Related Issue
N/A

## Checklist
- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change

---

> _Templates_: [weblate.md](?template=weblate.md)