### PR TITLE
Fix Android modal route and selection notifications

### DIFF
--- a/lib/pages/habits_display/_providers/habit_summary.dart
+++ b/lib/pages/habits_display/_providers/habit_summary.dart
@@ -475,11 +475,15 @@ class HabitSummaryViewModel extends ChangeNotifier
 
   void switchToEditMode({
     bool clearAllSelected = true,
+    HabitUUID? initialSelectedHabitUUID,
     bool listen = true,
   }) async {
     _canBeDragged = false;
     _isInEditMode = true;
     if (clearAllSelected) clearAllSelectHabits();
+    if (initialSelectedHabitUUID != null) {
+      _selectorData.select(initialSelectedHabitUUID);
+    }
     collapseCalendar(listen: false);
     if (!listen) return;
     notifyListeners();
@@ -493,10 +497,6 @@ class HabitSummaryViewModel extends ChangeNotifier
     if (listen) notifyListeners();
   }
 
-  void exitEditModeOnly({bool listen = true}) {
-    _isInEditMode = false;
-    if (listen) notifyListeners();
-  }
   //#endregion
 
   //#region: search mode
@@ -960,7 +960,7 @@ class HabitSummaryViewModel extends ChangeNotifier
     if (movedCache == null) return;
     _applyHabitReorder(index, dropIndex);
     await _writeChangedSortPositionToDB(fromIndex: index, toIndex: dropIndex);
-    exitEditMode(listen: false);
+    exitEditMode();
     _reloadBridge.eventSubs?.pushHabitReordered(movedCache.uuid);
   }
 
@@ -997,9 +997,9 @@ class HabitSummaryViewModel extends ChangeNotifier
     if (oldGroupId != targetGroupUUID) {
       await _access.updateHabitGroupIds([movedUUID], [targetGroupUUID]);
     }
-    await resortData();
+    await resortData(listen: false);
     if (!mounted) return;
-    exitEditMode(listen: false);
+    exitEditMode();
     _reloadBridge.eventSubs?.pushHabitReordered(movedUUID);
   }
 
@@ -1170,9 +1170,9 @@ class HabitSummaryViewModel extends ChangeNotifier
       }
     }
     _groupCollection = await _groupManager.tryLoadGroupCollection();
-    await resortData(listen: listen);
+    await resortData(listen: false);
     if (!mounted) return changedUUIDs.length;
-    exitEditMode(listen: false);
+    exitEditMode(listen: listen);
     _reloadBridge.eventSubs?.pushBatchGroupChanged(changedUUIDs);
 
     return changedUUIDs.length;

--- a/lib/pages/habits_display/page_habits.dart
+++ b/lib/pages/habits_display/page_habits.dart
@@ -824,11 +824,12 @@ class HabitsTabPageState extends State<HabitsTabPage>
       ScaffoldMessenger.of(context)
         ..hideCurrentSnackBar()
         ..clearSnackBars();
-      viewmodel.switchToEditMode();
       final data = viewmodel.getHabitBySortId(index);
-      if (data is HabitSummaryDataSortCache) {
-        viewmodel.selectHabit(data.uuid, listen: false);
-      }
+      viewmodel.switchToEditMode(
+        initialSelectedHabitUUID: data is HabitSummaryDataSortCache
+            ? data.uuid
+            : null,
+      );
     }
 
     final sortOptions = context.read<HabitsSortViewModel>();
@@ -865,7 +866,7 @@ class HabitsTabPageState extends State<HabitsTabPage>
     }
 
     if (index != dropIndex && viewmodel.isInEditMode) {
-      viewmodel.exitEditModeOnly();
+      viewmodel.exitEditMode();
     }
     return true;
   }
@@ -920,8 +921,6 @@ class HabitsTabPageState extends State<HabitsTabPage>
       }
 
       finishReorder(viewmodel.onHabitReorderComplate(index, dropIndex));
-    } else if (!viewmodel.isInEditMode) {
-      viewmodel.exitEditMode(listen: false);
     }
     return true;
   }

--- a/lib/widgets/_widgets/adaptive_content_sheet.dart
+++ b/lib/widgets/_widgets/adaptive_content_sheet.dart
@@ -48,6 +48,12 @@ import 'enhanced_safe_area.dart';
 /// *when* [buildBody] is called — typically inside a [Provider] scope so that
 /// [contentBuilder] and [actionsBuilder] have access to the Provider tree.
 ///
+/// [useRootNavigator] controls whether the adaptive route is pushed onto the
+/// root navigator or the nearest navigator. It defaults to `true` so both the
+/// sheet and dialog variants cover the same application-level navigation
+/// scope. Pass `false` when the content is intentionally local to a nested
+/// navigator.
+///
 /// Mode‑specific parameters use `sheet*` / `dialog*` prefixes.
 Future<T?> showAdaptiveContentSheet<T>({
   required BuildContext context,
@@ -58,6 +64,7 @@ Future<T?> showAdaptiveContentSheet<T>({
   List<Widget>? actions,
   List<Widget> Function(BuildContext context, bool isDialog)? actionsBuilder,
   bool showCloseButton = true,
+  bool useRootNavigator = true,
   bool? sheetShowCloseButton,
   // Sheet scaffold
   double sheetInitialChildSize = 0.6,
@@ -136,12 +143,14 @@ Future<T?> showAdaptiveContentSheet<T>({
   return useDialog
       ? showDialog<T>(
           context: context,
+          useRootNavigator: useRootNavigator,
           builder: (ctx) => resolvedBuilder != null
               ? resolvedBuilder(ctx, buildBody)
               : buildBody(ctx),
         )
       : showModalBottomSheet<T>(
           context: context,
+          useRootNavigator: useRootNavigator,
           isScrollControlled: true,
           useSafeArea: true,
           showDragHandle: sheetShowDragHandle,

--- a/lib/widgets/_widgets/confirm_dialog.dart
+++ b/lib/widgets/_widgets/confirm_dialog.dart
@@ -30,6 +30,7 @@ Future<bool?> showConfirmDialog({
   bool skipInitiallyEnabled = false,
   ValueChanged<bool>? onSkipChanged,
   String? skipLabel,
+  bool useRootNavigator = true,
 }) async {
   final effectiveTitle = titleBuilder?.call(context) ?? title;
   final effectiveSubtitle = subtitleBuilder?.call(context) ?? subtitle;
@@ -39,6 +40,7 @@ Future<bool?> showConfirmDialog({
   if (!skipOnConfirm) {
     return showDialog<bool>(
       context: context,
+      useRootNavigator: useRootNavigator,
       builder: (context) => ConfirmDialog(
         title: effectiveTitle,
         subtitle: effectiveSubtitle,
@@ -51,6 +53,7 @@ Future<bool?> showConfirmDialog({
   final l10n = L10n.of(context);
   return showDialog<bool>(
     context: context,
+    useRootNavigator: useRootNavigator,
     builder: (context) {
       var skipValue = skipInitiallyEnabled;
       return StatefulBuilder(

--- a/test/feature/habits_display/habit_display_page_test.dart
+++ b/test/feature/habits_display/habit_display_page_test.dart
@@ -38,6 +38,7 @@ import 'package:mhabit/models/habit_summary.dart';
 import 'package:mhabit/pages/common/widgets.dart';
 import 'package:mhabit/pages/habits_display/_providers/habit_summary.dart';
 import 'package:mhabit/pages/habits_display/_providers/habits_today.dart';
+import 'package:mhabit/pages/habits_display/helpers.dart';
 import 'package:mhabit/pages/habits_display/navigation_chrome.dart';
 import 'package:mhabit/pages/habits_display/page.dart';
 import 'package:mhabit/pages/habits_display/page_habits.dart';
@@ -1263,6 +1264,44 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.byType(CupertinoSelectBottomToolbar), findsOneWidget);
+  });
+
+  testWidgets('batch group modify notifies only the final selection state', (
+    tester,
+  ) async {
+    final profile = await _loadProfile();
+    final access = _LoadedHabitsDisplayAccess();
+    final sync = _FakeAppSyncWorkflowAccess();
+    addTearDown(() {
+      sync.dispose();
+      profile.dispose();
+    });
+    final vm = await _pumpHabitsTabPage(
+      tester,
+      profile: profile,
+      access: access,
+      sync: sync,
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+    vm.switchToEditMode();
+    final observedEditModes = <bool>[];
+    vm.addListener(() => observedEditModes.add(vm.isInEditMode));
+
+    final count = await vm.executeBatchGroupModify(
+      affectedHabits: const [
+        HabitGroupModifyItem(
+          uuid: '11111111-1111-4111-8111-000000000001',
+          name: 'Geometry regression habit 0',
+          oldGroupId: null,
+        ),
+      ],
+      targetGroupId: 'group-1',
+    );
+
+    expect(count, 1);
+    expect(observedEditModes, [false]);
+    await tester.pump(const Duration(milliseconds: 350));
   });
 
   testWidgets('Apple medium keeps FAB placement with the Cupertino action', (

--- a/test/unit/pages/habits_display/group_modify_test.dart
+++ b/test/unit/pages/habits_display/group_modify_test.dart
@@ -52,6 +52,16 @@ Widget wrapApp(Widget child) {
   return MaterialApp(home: Scaffold(body: child));
 }
 
+final class _DialogCountingObserver extends NavigatorObserver {
+  int dialogPushes = 0;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    if (route is DialogRoute<dynamic>) dialogPushes += 1;
+  }
+}
+
 void main() {
   group('HabitGroupModifyHandler', () {
     group('_buildAffectedHabits', () {
@@ -366,5 +376,46 @@ void main() {
       expect(find.textContaining('Read'), findsOneWidget);
       expect(find.textContaining('Write'), findsOneWidget);
     });
+  });
+
+  testWidgets('group confirmation uses the root navigator by default', (
+    tester,
+  ) async {
+    final rootObserver = _DialogCountingObserver();
+    final branchObserver = _DialogCountingObserver();
+    const affected = [
+      HabitGroupModifyItem(uuid: 'h1', name: 'Read', oldGroupId: null),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorObservers: [rootObserver],
+        home: Navigator(
+          observers: [branchObserver],
+          onGenerateRoute: (_) => MaterialPageRoute<void>(
+            builder: (context) => Scaffold(
+              body: ElevatedButton(
+                onPressed: () => showHabitGroupModifyConfirmDialog(
+                  context: context,
+                  affectedHabits: affected,
+                  targetGroupId: 'g1',
+                  targetGroupName: 'Work',
+                  sourceGroups: const {},
+                  skipFutureEnabled: false,
+                  onSkipFutureChanged: (_) {},
+                ),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(rootObserver.dialogPushes, 1);
+    expect(branchObserver.dialogPushes, 0);
   });
 }

--- a/test/unit/pages/habits_display/habit_summary_reorder_test.dart
+++ b/test/unit/pages/habits_display/habit_summary_reorder_test.dart
@@ -215,6 +215,29 @@ void main() {
       vm.dispose();
     });
 
+    test('flat reorder publishes only the final non-edit state', () async {
+      final a = _h(id: 1, uuid: 'a', sortPostion: 1);
+      final b = _h(id: 2, uuid: 'b', sortPostion: 2);
+      final access = _ReorderTestAccess([a, b]);
+      final vm = HabitSummaryViewModel()
+        ..attachAccess(access)
+        ..attachGroupManager(_ReorderTestGroupManager([]));
+      addTearDown(vm.dispose);
+
+      await vm.loadData(listen: false);
+      vm.updateHabitDisplayFilter(const HabitsDisplayFilter.withDefault());
+      await vm.resortData(listen: false);
+      vm.switchToEditMode(initialSelectedHabitUUID: a.uuid, listen: false);
+      final observedStates = <(bool, int)>[];
+      vm.addListener(
+        () => observedStates.add((vm.isInEditMode, vm.selectedHabitsCount)),
+      );
+
+      await vm.onHabitReorderComplate(0, 1);
+
+      expect(observedStates, [(false, 0)]);
+    });
+
     // ── grouped reorder ──────────────────────────────────────────
     //  before(flat):  [a(pos=1), b(pos=2), c(pos=3)]
     //  before(group): [H(G1), a, b, H(G2), c]
@@ -641,6 +664,34 @@ void main() {
         vm.dispose();
       },
     );
+
+    test('cross-group move publishes only the final non-edit state', () async {
+      final a = _h(id: 1, uuid: 'a', sortPostion: 10, groupId: 'g1');
+      final b = _h(id: 2, uuid: 'b', sortPostion: 20, groupId: 'g2');
+      final access = _ReorderTestAccess([a, b]);
+      final vm = HabitSummaryViewModel()
+        ..attachAccess(access)
+        ..attachGroupManager(
+          _ReorderTestGroupManager([
+            _g(uuid: 'g1', name: 'G1'),
+            _g(uuid: 'g2', name: 'G2'),
+          ]),
+        );
+      addTearDown(vm.dispose);
+
+      await vm.loadData(listen: false);
+      vm.updateGroupingEnabled(true);
+      await vm.resortData(listen: false);
+      vm.switchToEditMode(initialSelectedHabitUUID: a.uuid, listen: false);
+      final observedStates = <(bool, int)>[];
+      vm.addListener(
+        () => observedStates.add((vm.isInEditMode, vm.selectedHabitsCount)),
+      );
+
+      await vm.onCrossGroupHabitMove(1, 3, 'g2');
+
+      expect(observedStates, [(false, 0)]);
+    });
 
     test('cross-group move to uncategorized sets groupId to null', () async {
       final a = _h(id: 1, uuid: 'a', sortPostion: 10, groupId: 'g1');

--- a/test/unit/pages/habits_display/habit_summary_viewmodel_test.dart
+++ b/test/unit/pages/habits_display/habit_summary_viewmodel_test.dart
@@ -20,6 +20,21 @@ import 'package:mhabit/pages/habits_display/_providers/habit_summary.dart';
 import 'package:mhabit/providers/workflow/app_event.dart';
 
 void main() {
+  group('HabitSummaryViewModel:selection notifications', () {
+    test('entering edit mode publishes the initial selection atomically', () {
+      final vm = HabitSummaryViewModel();
+      addTearDown(vm.dispose);
+      final observedStates = <(bool, int)>[];
+      vm.addListener(
+        () => observedStates.add((vm.isInEditMode, vm.selectedHabitsCount)),
+      );
+
+      vm.switchToEditMode(initialSelectedHabitUUID: 'habit-1');
+
+      expect(observedStates, [(true, 1)]);
+    });
+  });
+
   group('HabitSummaryViewModel:event', () {
     test(
       'exits edit mode on external ReloadDataEvent with exiEditMode: true',

--- a/test/unit/widgets/adaptive_content_sheet_test.dart
+++ b/test/unit/widgets/adaptive_content_sheet_test.dart
@@ -1,0 +1,109 @@
+// Copyright 2026 Fries_I23
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mhabit/widgets/widgets.dart';
+
+final class _RouteCountingObserver extends NavigatorObserver {
+  int popupPushes = 0;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    if (route is PopupRoute<dynamic>) popupPushes += 1;
+  }
+}
+
+Widget _buildNestedNavigatorApp({
+  required NavigatorObserver rootObserver,
+  required NavigatorObserver branchObserver,
+  required bool forceDialog,
+  bool? useRootNavigator,
+}) {
+  return MaterialApp(
+    navigatorObservers: [rootObserver],
+    home: Navigator(
+      observers: [branchObserver],
+      onGenerateRoute: (_) => MaterialPageRoute<void>(
+        builder: (context) => Scaffold(
+          body: ElevatedButton(
+            onPressed: () => useRootNavigator == null
+                ? showAdaptiveContentSheet<void>(
+                    context: context,
+                    contentBuilder: (_) => const Text('Content'),
+                    forceDialog: forceDialog,
+                    forceSheet: !forceDialog,
+                  )
+                : showAdaptiveContentSheet<void>(
+                    context: context,
+                    contentBuilder: (_) => const Text('Content'),
+                    forceDialog: forceDialog,
+                    forceSheet: !forceDialog,
+                    useRootNavigator: useRootNavigator,
+                  ),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  for (final forceDialog in [false, true]) {
+    final mode = forceDialog ? 'dialog' : 'sheet';
+
+    testWidgets('$mode uses the root navigator by default', (tester) async {
+      final rootObserver = _RouteCountingObserver();
+      final branchObserver = _RouteCountingObserver();
+
+      await tester.pumpWidget(
+        _buildNestedNavigatorApp(
+          rootObserver: rootObserver,
+          branchObserver: branchObserver,
+          forceDialog: forceDialog,
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(rootObserver.popupPushes, 1);
+      expect(branchObserver.popupPushes, 0);
+    });
+
+    testWidgets('$mode can use the nearest navigator explicitly', (
+      tester,
+    ) async {
+      final rootObserver = _RouteCountingObserver();
+      final branchObserver = _RouteCountingObserver();
+
+      await tester.pumpWidget(
+        _buildNestedNavigatorApp(
+          rootObserver: rootObserver,
+          branchObserver: branchObserver,
+          forceDialog: forceDialog,
+          useRootNavigator: false,
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(rootObserver.popupPushes, 0);
+      expect(branchObserver.popupPushes, 1);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
This PR fixes Android-specific modal routing and selection notification issues in the habits display flow. It aligns the adaptive content sheet behavior with the selected habit rows and ensures selection state updates are emitted consistently when a modal closes or a batch action completes.

## Type of Change
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] style
- [ ] test
- [ ] chore

## Related Issue
Fixes #654

## Checklist
- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change
