### PR TITLE
Add theme mode control and improve adaptive navigation

### DIFF
--- a/lib/entries/app/entry.dart
+++ b/lib/entries/app/entry.dart
@@ -262,6 +262,7 @@ class _AppEntryState extends State<_AppEntry> {
   List<AppNavigationAuxiliaryChrome> _buildAuxiliaryChrome(
     BuildContext context,
   ) => [
+    AppNavigationAuxiliaryChrome.themeMode(context),
     AppNavigationAuxiliaryChrome(
       destination: AppNavigationDestinations.settings(
         label: L10n.of(context)?.appSetting_appbar_titleText ?? 'Settings',

--- a/lib/entries/app/navigation_chrome.dart
+++ b/lib/entries/app/navigation_chrome.dart
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
+import 'package:provider/provider.dart';
 
+import '../../l10n/localizations.dart';
+import '../../providers/app_ui/app_theme.dart';
 import '../../routes/app_navigation_branch.dart';
+import '../../theme/color.dart';
 
 /// Builds the current auxiliary navigation presentations for the app shell.
 typedef AppNavigationAuxiliaryChromeBuilder =
@@ -24,7 +28,7 @@ typedef AppNavigationAuxiliaryChromeBuilder =
 /// Declarative presentation and interaction for one auxiliary destination.
 ///
 /// The shell consumes this contract without knowing the destination's route
-/// or business meaning. The app entry owns those details.
+/// or business meaning. App-layer constructors own those details.
 @immutable
 final class AppNavigationAuxiliaryChrome {
   /// Creates auxiliary navigation chrome.
@@ -33,6 +37,41 @@ final class AppNavigationAuxiliaryChrome {
     required this.selected,
     required this.onSelected,
   });
+
+  /// Builds the app-wide theme command shown by side-navigation forms.
+  static AppNavigationAuxiliaryChrome themeMode(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    final themeType = context.select<AppThemeViewModel, AppThemeType>(
+      (viewModel) => viewModel.themeType,
+    );
+    final label = switch (themeType) {
+      AppThemeType.light => l10n.common_appThemeMode_light,
+      AppThemeType.dark => l10n.common_appThemeMode_dark,
+      AppThemeType.unknown ||
+      AppThemeType.followSystem => l10n.common_appThemeMode_followSystem,
+    };
+    final icon = Icon(switch (themeType) {
+      AppThemeType.light => Icons.light_mode_rounded,
+      AppThemeType.dark => Icons.dark_mode_rounded,
+      AppThemeType.unknown ||
+      AppThemeType.followSystem => Icons.hdr_auto_rounded,
+    });
+    return AppNavigationAuxiliaryChrome(
+      destination: AdaptiveNavigationDestination(
+        label: label,
+        icons: NavigationDestinationIcons(
+          material: icon,
+          materialSelected: icon,
+          apple: icon,
+          appleSelected: icon,
+        ),
+      ),
+      selected: false,
+      onSelected: () => context.read<AppThemeViewModel>().onTapChangeThemeType(
+        MediaQuery.platformBrightnessOf(context),
+      ),
+    );
+  }
 
   /// Destination rendered by non-compact navigation forms.
   final AdaptiveNavigationDestination destination;

--- a/lib/pages/habits_display/page_habits.dart
+++ b/lib/pages/habits_display/page_habits.dart
@@ -1033,6 +1033,8 @@ class HabitsTabPageState extends State<HabitsTabPage>
       collapsedViewportFraction: displayPageOccupyPrt / 100,
       expandedViewportFraction: kDefaultHabitCalendarBarExtendedPrt,
     );
+    final showThemeAction =
+        WindowSize.of(context).width == WindowSizeClass.compact;
     const trackPadding = kDefaultHabitListTileTrackPadding;
 
     //#region: appbar
@@ -1055,7 +1057,7 @@ class HabitsTabPageState extends State<HabitsTabPage>
           onGroupTypeSelected: _setHabitSummaryGroupType,
           onGroupDirectionToggled: _toggleHabitSummaryGroupDirection,
           onDisplayFilterChanged: _setHabitDisplayFilter,
-          onThemeToggled: _toggleHabitDisplayTheme,
+          onThemeToggled: showThemeAction ? _toggleHabitDisplayTheme : null,
         ),
         selectCallbacks: HabitDisplaySelectAppBarCallbacks(
           onDone: _onHabitEditAppbarLeadingButtonPressed,
@@ -1254,7 +1256,6 @@ class _HabitDisplayAppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isCompact = WindowSize.of(context).width == WindowSizeClass.compact;
     final (sortType, sortDirection) = context
         .select<
           HabitsSortViewModel,
@@ -1273,76 +1274,38 @@ class _HabitDisplayAppBar extends StatelessWidget {
         .select<HabitsFilterViewModel, HabitsDisplayFilter>(
           (vm) => vm.habitsDisplayFilter,
         );
-    if (!isCompact) {
-      return _buildAppBar(
-        sortType: sortType,
-        sortDirection: sortDirection,
-        groupType: groupType,
-        groupDirection: groupDirection,
-        groupingVisible: groupingVisible,
-        displayFilter: displayFilter,
-        themeType: AppThemeType.followSystem,
-        optionsCallbacks: HabitDisplayOptionsCallbacks(
-          onSortTypeSelected: optionsCallbacks.onSortTypeSelected,
-          onSortDirectionToggled: optionsCallbacks.onSortDirectionToggled,
-          onGroupTypeSelected: optionsCallbacks.onGroupTypeSelected,
-          onGroupDirectionToggled: optionsCallbacks.onGroupDirectionToggled,
-          onDisplayFilterChanged: optionsCallbacks.onDisplayFilterChanged,
-        ),
-      );
-    }
+    final themeType = context.select<AppThemeViewModel, AppThemeType>(
+      (vm) => vm.themeType,
+    );
 
-    return Selector<AppThemeViewModel, AppThemeType>(
-      selector: (_, vm) => vm.themeType,
-      builder: (_, themeType, _) => _buildAppBar(
-        sortType: sortType,
-        sortDirection: sortDirection,
-        groupType: groupType,
-        groupDirection: groupDirection,
-        groupingVisible: groupingVisible,
-        displayFilter: displayFilter,
-        themeType: themeType,
-        optionsCallbacks: optionsCallbacks,
+    return HabitDisplayAppBar(
+      geometry: geometry,
+      isCalendarExpanded: isCalendarExpanded,
+      toolbarHeight: toolbarHeight,
+      calendarHeight: calendarHeight,
+      calendarItemPadding: calendarItemPadding,
+      calendarTrackPadding: calendarTrackPadding,
+      horizonalScrollControllerGroup: horizonalScrollControllerGroup,
+      searchFilterMenuController: searchFilterMenuController,
+      config: HabitDisplayViewAppBarConfig(
+        onInfo: onInfo,
+        onOpenSettings: onOpenSettings,
+        onSelect: onSelect,
+        config: HabitDisplayConfig(
+          sortType: sortType,
+          sortDirection: sortDirection,
+          groupType: groupType,
+          groupDirection: groupDirection,
+          groupingVisible: groupingVisible,
+          displayFilter: displayFilter,
+          themeType: themeType,
+        ),
+        callbacks: optionsCallbacks,
       ),
+      selectCallbacks: selectCallbacks,
+      onCalendarToggleExpandPressed: onCalendarToggleExpandPressed,
     );
   }
-
-  Widget _buildAppBar({
-    required HabitDisplaySortType sortType,
-    required HabitDisplaySortDirection sortDirection,
-    required HabitDisplayGroupType? groupType,
-    required HabitDisplaySortDirection groupDirection,
-    required bool groupingVisible,
-    required HabitsDisplayFilter displayFilter,
-    required AppThemeType themeType,
-    required HabitDisplayOptionsCallbacks optionsCallbacks,
-  }) => HabitDisplayAppBar(
-    geometry: geometry,
-    isCalendarExpanded: isCalendarExpanded,
-    toolbarHeight: toolbarHeight,
-    calendarHeight: calendarHeight,
-    calendarItemPadding: calendarItemPadding,
-    calendarTrackPadding: calendarTrackPadding,
-    horizonalScrollControllerGroup: horizonalScrollControllerGroup,
-    searchFilterMenuController: searchFilterMenuController,
-    config: HabitDisplayViewAppBarConfig(
-      onInfo: onInfo,
-      onOpenSettings: onOpenSettings,
-      onSelect: onSelect,
-      config: HabitDisplayConfig(
-        sortType: sortType,
-        sortDirection: sortDirection,
-        groupType: groupType,
-        groupDirection: groupDirection,
-        groupingVisible: groupingVisible,
-        displayFilter: displayFilter,
-        themeType: themeType,
-      ),
-      callbacks: optionsCallbacks,
-    ),
-    selectCallbacks: selectCallbacks,
-    onCalendarToggleExpandPressed: onCalendarToggleExpandPressed,
-  );
 }
 
 class _HabitList extends StatefulWidget {

--- a/lib/pages/habits_display/page_habits.dart
+++ b/lib/pages/habits_display/page_habits.dart
@@ -1254,6 +1254,7 @@ class _HabitDisplayAppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isCompact = WindowSize.of(context).width == WindowSizeClass.compact;
     final (sortType, sortDirection) = context
         .select<
           HabitsSortViewModel,
@@ -1272,38 +1273,76 @@ class _HabitDisplayAppBar extends StatelessWidget {
         .select<HabitsFilterViewModel, HabitsDisplayFilter>(
           (vm) => vm.habitsDisplayFilter,
         );
-    final themeType = context.select<AppThemeViewModel, AppThemeType>(
-      (vm) => vm.themeType,
-    );
-
-    return HabitDisplayAppBar(
-      geometry: geometry,
-      isCalendarExpanded: isCalendarExpanded,
-      toolbarHeight: toolbarHeight,
-      calendarHeight: calendarHeight,
-      calendarItemPadding: calendarItemPadding,
-      calendarTrackPadding: calendarTrackPadding,
-      horizonalScrollControllerGroup: horizonalScrollControllerGroup,
-      searchFilterMenuController: searchFilterMenuController,
-      config: HabitDisplayViewAppBarConfig(
-        onInfo: onInfo,
-        onOpenSettings: onOpenSettings,
-        onSelect: onSelect,
-        config: HabitDisplayConfig(
-          sortType: sortType,
-          sortDirection: sortDirection,
-          groupType: groupType,
-          groupDirection: groupDirection,
-          groupingVisible: groupingVisible,
-          displayFilter: displayFilter,
-          themeType: themeType,
+    if (!isCompact) {
+      return _buildAppBar(
+        sortType: sortType,
+        sortDirection: sortDirection,
+        groupType: groupType,
+        groupDirection: groupDirection,
+        groupingVisible: groupingVisible,
+        displayFilter: displayFilter,
+        themeType: AppThemeType.followSystem,
+        optionsCallbacks: HabitDisplayOptionsCallbacks(
+          onSortTypeSelected: optionsCallbacks.onSortTypeSelected,
+          onSortDirectionToggled: optionsCallbacks.onSortDirectionToggled,
+          onGroupTypeSelected: optionsCallbacks.onGroupTypeSelected,
+          onGroupDirectionToggled: optionsCallbacks.onGroupDirectionToggled,
+          onDisplayFilterChanged: optionsCallbacks.onDisplayFilterChanged,
         ),
-        callbacks: optionsCallbacks,
+      );
+    }
+
+    return Selector<AppThemeViewModel, AppThemeType>(
+      selector: (_, vm) => vm.themeType,
+      builder: (_, themeType, _) => _buildAppBar(
+        sortType: sortType,
+        sortDirection: sortDirection,
+        groupType: groupType,
+        groupDirection: groupDirection,
+        groupingVisible: groupingVisible,
+        displayFilter: displayFilter,
+        themeType: themeType,
+        optionsCallbacks: optionsCallbacks,
       ),
-      selectCallbacks: selectCallbacks,
-      onCalendarToggleExpandPressed: onCalendarToggleExpandPressed,
     );
   }
+
+  Widget _buildAppBar({
+    required HabitDisplaySortType sortType,
+    required HabitDisplaySortDirection sortDirection,
+    required HabitDisplayGroupType? groupType,
+    required HabitDisplaySortDirection groupDirection,
+    required bool groupingVisible,
+    required HabitsDisplayFilter displayFilter,
+    required AppThemeType themeType,
+    required HabitDisplayOptionsCallbacks optionsCallbacks,
+  }) => HabitDisplayAppBar(
+    geometry: geometry,
+    isCalendarExpanded: isCalendarExpanded,
+    toolbarHeight: toolbarHeight,
+    calendarHeight: calendarHeight,
+    calendarItemPadding: calendarItemPadding,
+    calendarTrackPadding: calendarTrackPadding,
+    horizonalScrollControllerGroup: horizonalScrollControllerGroup,
+    searchFilterMenuController: searchFilterMenuController,
+    config: HabitDisplayViewAppBarConfig(
+      onInfo: onInfo,
+      onOpenSettings: onOpenSettings,
+      onSelect: onSelect,
+      config: HabitDisplayConfig(
+        sortType: sortType,
+        sortDirection: sortDirection,
+        groupType: groupType,
+        groupDirection: groupDirection,
+        groupingVisible: groupingVisible,
+        displayFilter: displayFilter,
+        themeType: themeType,
+      ),
+      callbacks: optionsCallbacks,
+    ),
+    selectCallbacks: selectCallbacks,
+    onCalendarToggleExpandPressed: onCalendarToggleExpandPressed,
+  );
 }
 
 class _HabitList extends StatefulWidget {

--- a/lib/pages/habits_display/page_today.dart
+++ b/lib/pages/habits_display/page_today.dart
@@ -182,7 +182,7 @@ class _Appbar extends StatelessWidget {
         apple: AppBarAppleStyle(collapsible: useLargeTitle),
       ),
       title: Text(l10n?.habitToday_appBar_title ?? "Today"),
-      actions: const [AppThemeSwitchButton()],
+      actions: useLargeTitle ? const [AppThemeSwitchButton()] : const [],
     );
   }
 }

--- a/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar_panel.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/cupertino/cupertino_navigation_sidebar_panel.dart
@@ -195,7 +195,7 @@ class _CupertinoSidebarDestination extends StatelessWidget {
     final label = Expanded(
       child: Text(
         destination.label,
-        maxLines: 1,
+        maxLines: 2,
         overflow: TextOverflow.ellipsis,
       ),
     );

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_rail.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_navigation_rail.dart
@@ -7,6 +7,7 @@ import '../shell/navigation_shell_form.dart';
 import '../shell/navigation_shell_frame.dart';
 import '../shell/side_navigation.dart';
 import '../window_control/window_control_layout.dart';
+import 'material_rail_destination_group_layout.dart';
 import 'material_wide_navigation_rail_button.dart';
 
 /// Material-specific NavigationRail geometry.
@@ -30,6 +31,7 @@ class MaterialAdaptiveNavigationRail extends StatelessWidget {
     required this.minWidth,
     required this.minExtendedWidth,
     this.leading,
+    this.trailing,
   });
 
   /// Zero-based index of the selected destination.
@@ -53,6 +55,9 @@ class MaterialAdaptiveNavigationRail extends StatelessWidget {
   /// Optional widget displayed above the destinations.
   final Widget? leading;
 
+  /// Optional widget pinned below the scrollable destination group.
+  final Widget? trailing;
+
   @override
   Widget build(BuildContext context) {
     return NavigationRail(
@@ -60,17 +65,24 @@ class MaterialAdaptiveNavigationRail extends StatelessWidget {
       extended: extended,
       minWidth: minWidth,
       minExtendedWidth: minExtendedWidth,
+      leadingAtTop: false,
+      trailingAtBottom: true,
+      scrollable: false,
+      mainAxisAlignment: MainAxisAlignment.start,
       // Host the custom content in leading so it shares NavigationRail's
       // surface and animation. It renders the destinations itself, so the
       // NavigationRail destinations below intentionally stay empty.
-      leading: _MaterialWideNavigationRailContent(
-        collapsedWidth: minWidth,
-        expandedWidth: minExtendedWidth,
-        leading: leading,
-        destinations: destinations,
-        selectedIndex: selectedIndex,
-        onDestinationSelected: onDestinationSelected,
+      leading: Expanded(
+        child: _MaterialWideNavigationRailContent(
+          collapsedWidth: minWidth,
+          expandedWidth: minExtendedWidth,
+          leading: leading,
+          destinations: destinations,
+          selectedIndex: selectedIndex,
+          onDestinationSelected: onDestinationSelected,
+        ),
       ),
+      trailing: trailing,
       destinations: const [],
     );
   }
@@ -86,8 +98,9 @@ class _MaterialWideNavigationRailContent extends StatelessWidget {
     this.leading,
   });
 
-  static const double _headerSpacing = 40.0;
-  static const double _destinationSpacing = 6.0;
+  static const double _collapsedDestinationSpacing = 4.0;
+  static const double _minimumLeadingDestinationSpacing = 8.0;
+  static const double _maximumLeadingDestinationSpacing = 40.0;
 
   final double collapsedWidth;
   final double expandedWidth;
@@ -99,18 +112,10 @@ class _MaterialWideNavigationRailContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final animation = NavigationRail.extendedAnimation(context);
-    return Column(
+    final destinationList = Column(
+      key: const ValueKey('material-rail-primary-destination-list'),
       mainAxisSize: MainAxisSize.min,
       children: [
-        AnimatedBuilder(
-          animation: animation,
-          builder: (context, child) => SizedBox(
-            width: lerpDouble(collapsedWidth, expandedWidth, animation.value)!,
-            child: child,
-          ),
-          child: leading,
-        ),
-        const SizedBox(height: _headerSpacing),
         for (final (index, destination) in destinations.indexed) ...[
           MaterialWideNavigationRailButton(
             slotKey: ValueKey('material-rail-destination-slot-$index'),
@@ -123,9 +128,52 @@ class _MaterialWideNavigationRailContent extends StatelessWidget {
             onPressed: () => onDestinationSelected(index),
           ),
           if (index != destinations.length - 1)
-            const SizedBox(height: _destinationSpacing),
+            AnimatedBuilder(
+              animation: animation,
+              builder: (context, _) => SizedBox(
+                height: lerpDouble(
+                  _collapsedDestinationSpacing,
+                  0,
+                  animation.value,
+                ),
+              ),
+            ),
         ],
       ],
+    );
+
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, child) => SizedBox(
+        width: lerpDouble(collapsedWidth, expandedWidth, animation.value)!,
+        child: child,
+      ),
+      child: CustomScrollView(
+        key: const ValueKey('material-rail-primary-scroll-view'),
+        slivers: [
+          if (leading != null)
+            SliverToBoxAdapter(
+              child: Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: leading,
+              ),
+            ),
+          SliverFillRemaining(
+            hasScrollBody: false,
+            // Keep a future rail FAB in this scrollable region. When one is
+            // added, place this 40-to-8dp flexible gap after the FAB.
+            child: MaterialRailDestinationGroupLayout(
+              minimumGap: leading == null || destinations.isEmpty
+                  ? 0
+                  : _minimumLeadingDestinationSpacing,
+              maximumGap: leading == null || destinations.isEmpty
+                  ? 0
+                  : _maximumLeadingDestinationSpacing,
+              child: destinationList,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -325,7 +373,7 @@ class _MaterialNavigationRailPanel extends StatelessWidget {
   });
 
   static const double _minimumRailButtonExtent = 44.0;
-  static const double _auxiliaryDestinationSpacing = 6.0;
+  static const double _collapsedAuxiliaryDestinationSpacing = 4.0;
 
   final int selectedIndex;
   final List<AdaptiveNavigationDestination> destinations;
@@ -367,29 +415,8 @@ class _MaterialNavigationRailPanel extends StatelessWidget {
     final leadingTopAvoidance = useVerticalFallback
         ? verticalAvoidance.top
         : 0.0;
-    final isRtl = Directionality.of(context) == TextDirection.rtl;
-
-    final primaryDestinationRail = MaterialAdaptiveNavigationRail(
-      key: const ValueKey('rail-panel'),
-      selectedIndex: selectedAuxiliaryIndex == null ? selectedIndex : -1,
-      onDestinationSelected: onDestinationSelected,
-      extended: extended,
-      minWidth: collapsedWidth,
-      minExtendedWidth: expandedWidth,
-      leading: Padding(
-        padding: EdgeInsets.only(
-          left: leadingHorizontalAvoidance.left,
-          top: leadingTopAvoidance,
-          right: leadingHorizontalAvoidance.right,
-        ),
-        child: const Align(
-          child: SizedBox.square(dimension: kMinInteractiveDimension),
-        ),
-      ),
-      destinations: destinations,
-    );
-
     final auxiliaryDestinationList = Column(
+      key: const ValueKey('material-rail-auxiliary-destination-list'),
       mainAxisSize: MainAxisSize.min,
       children: [
         for (final (index, destination) in auxiliaryDestinations.indexed) ...[
@@ -406,58 +433,49 @@ class _MaterialNavigationRailPanel extends StatelessWidget {
             onPressed: () => onAuxiliaryDestinationSelected?.call(index),
           ),
           if (index != auxiliaryDestinations.length - 1)
-            const SizedBox(height: _auxiliaryDestinationSpacing),
+            SizedBox(
+              height: extended ? 0 : _collapsedAuxiliaryDestinationSpacing,
+            ),
         ],
       ],
     );
-    final auxiliaryDestinationLayer = auxiliaryDestinations.isEmpty
-        ? null
-        : Positioned.fill(
-            child: SafeArea(
-              left: !isRtl,
-              right: isRtl,
-              child: Align(
-                alignment: AlignmentDirectional.bottomStart,
-                child: Padding(
-                  padding: const EdgeInsets.only(bottom: 8),
-                  child: auxiliaryDestinationList,
-                ),
-              ),
-            ),
-          );
-
-    final navigationToggleLayer = Positioned.fill(
-      child: SafeArea(
-        left: !isRtl,
-        right: isRtl,
-        child: Align(
-          alignment: AlignmentDirectional.topStart,
-          child: SizedBox(
-            width: toggleAnchorWidth,
-            child: Padding(
-              key: const ValueKey('rail-leading-safe-span'),
-              padding: EdgeInsets.only(
-                left: leadingHorizontalAvoidance.left,
-                top: leadingTopAvoidance,
-                right: leadingHorizontalAvoidance.right,
-              ),
-              child: Align(
-                heightFactor: 1,
-                child: IconButton(
-                  key: const ValueKey('rail-toggle-button'),
-                  tooltip: extended
-                      ? collapseNavigationLabel
-                      : expandNavigationLabel,
-                  icon: Icon(extended ? Icons.menu_open : Icons.menu),
-                  onPressed: onToggle,
-                ),
-              ),
+    final primaryDestinationRail = MaterialAdaptiveNavigationRail(
+      key: const ValueKey('rail-panel'),
+      selectedIndex: selectedAuxiliaryIndex == null ? selectedIndex : -1,
+      onDestinationSelected: onDestinationSelected,
+      extended: extended,
+      minWidth: collapsedWidth,
+      minExtendedWidth: expandedWidth,
+      leading: SizedBox(
+        width: toggleAnchorWidth,
+        child: Padding(
+          key: const ValueKey('rail-leading-safe-span'),
+          padding: EdgeInsets.only(
+            left: leadingHorizontalAvoidance.left,
+            top: leadingTopAvoidance,
+            right: leadingHorizontalAvoidance.right,
+          ),
+          child: Align(
+            heightFactor: 1,
+            child: IconButton(
+              key: const ValueKey('rail-toggle-button'),
+              tooltip: extended
+                  ? collapseNavigationLabel
+                  : expandNavigationLabel,
+              icon: Icon(extended ? Icons.menu_open : Icons.menu),
+              onPressed: onToggle,
             ),
           ),
         ),
       ),
+      destinations: destinations,
+      trailing: auxiliaryDestinations.isEmpty
+          ? null
+          : Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: auxiliaryDestinationList,
+            ),
     );
-
     final navigationResizeHandle = PositionedDirectional(
       end: 0,
       top: 0,
@@ -471,14 +489,7 @@ class _MaterialNavigationRailPanel extends StatelessWidget {
       ),
     );
 
-    return Stack(
-      children: [
-        primaryDestinationRail,
-        ?auxiliaryDestinationLayer,
-        navigationToggleLayer,
-        navigationResizeHandle,
-      ],
-    );
+    return Stack(children: [primaryDestinationRail, navigationResizeHandle]);
   }
 }
 

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_rail_destination_group_layout.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_rail_destination_group_layout.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+/// Places a rail destination group after a vertically flexible leading gap.
+///
+/// The gap uses [maximumGap] when space is available, shrinks as necessary,
+/// and contributes [minimumGap] to the child's intrinsic height. A surrounding
+/// scroll viewport can therefore begin scrolling only after the gap reaches
+/// its minimum.
+final class MaterialRailDestinationGroupLayout
+    extends SingleChildRenderObjectWidget {
+  const MaterialRailDestinationGroupLayout({
+    super.key,
+    required this.minimumGap,
+    required this.maximumGap,
+    required super.child,
+  }) : assert(minimumGap >= 0 && minimumGap < double.infinity),
+       assert(maximumGap >= minimumGap && maximumGap < double.infinity);
+
+  /// Smallest gap preserved before the surrounding viewport must scroll.
+  final double minimumGap;
+
+  /// Preferred gap used when the available height permits it.
+  final double maximumGap;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderMaterialRailDestinationGroupLayout(minimumGap, maximumGap);
+
+  @override
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    final destinationLayout =
+        renderObject as _RenderMaterialRailDestinationGroupLayout;
+    destinationLayout
+      ..minimumGap = minimumGap
+      ..maximumGap = maximumGap;
+  }
+}
+
+final class _RenderMaterialRailDestinationGroupLayout extends RenderShiftedBox {
+  _RenderMaterialRailDestinationGroupLayout(this._minimumGap, this._maximumGap)
+    : super(null);
+
+  double _minimumGap;
+
+  double get minimumGap => _minimumGap;
+
+  set minimumGap(double value) {
+    if (_minimumGap == value) return;
+    _minimumGap = value;
+    markNeedsLayout();
+  }
+
+  double _maximumGap;
+
+  double get maximumGap => _maximumGap;
+
+  set maximumGap(double value) {
+    if (_maximumGap == value) return;
+    _maximumGap = value;
+    markNeedsLayout();
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) =>
+      minimumGap + (child?.getMinIntrinsicHeight(width) ?? 0);
+
+  @override
+  double computeMaxIntrinsicHeight(double width) =>
+      minimumGap + (child?.getMaxIntrinsicHeight(width) ?? 0);
+
+  @override
+  double computeMinIntrinsicWidth(double height) =>
+      child?.getMinIntrinsicWidth(height) ?? 0;
+
+  @override
+  double computeMaxIntrinsicWidth(double height) =>
+      child?.getMaxIntrinsicWidth(height) ?? 0;
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    final childSize = child?.getDryLayout(constraints.loosen()) ?? Size.zero;
+    return constraints.constrain(
+      Size(childSize.width, childSize.height + minimumGap),
+    );
+  }
+
+  @override
+  void performLayout() {
+    final child = this.child;
+    if (child == null) {
+      size = constraints.smallest;
+      return;
+    }
+
+    child.layout(constraints.loosen(), parentUsesSize: true);
+    size = constraints.constrain(
+      Size(child.size.width, child.size.height + minimumGap),
+    );
+    final availableGap = size.height - child.size.height;
+    final gap = availableGap.clamp(minimumGap, maximumGap);
+    final childParentData = child.parentData! as BoxParentData;
+    childParentData.offset = Offset((size.width - child.size.width) / 2, gap);
+  }
+}

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_wide_navigation_rail_button.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_wide_navigation_rail_button.dart
@@ -21,11 +21,13 @@ class MaterialWideNavigationRailButton extends StatelessWidget {
     required this.onPressed,
   });
 
-  static const double _slotHeight = 80.0;
+  static const double _collapsedSlotHeight = 64.0;
   static const double _buttonHeight = 56.0;
   static const double _iconSize = 24.0;
   static const double _collapsedButtonWidth = 56.0;
   static const double _collapsedIndicatorHeight = 32.0;
+  static const double _collapsedIconLabelSpacing = 4.0;
+  static const double _collapsedBottomSpacing = 12.0;
   static const double _expandedHorizontalMargin = 20.0;
   static const double _expandedContentInset = 16.0;
   static const double _expandedIconLabelSpacing = 8.0;
@@ -60,16 +62,21 @@ class MaterialWideNavigationRailButton extends StatelessWidget {
           _buttonHeight,
           progress,
         )!;
-        final buttonTop = lerpDouble(16, 4, progress)!;
+        final collapsedSlotHeight = _collapsedHeightFor(context);
+        final slotHeight = lerpDouble(
+          collapsedSlotHeight,
+          _buttonHeight,
+          progress,
+        )!;
         return SizedBox(
           key: slotKey,
           width: slotWidth,
-          height: _slotHeight,
+          height: slotHeight,
           child: Stack(
             alignment: Alignment.topCenter,
             children: [
               Positioned(
-                top: buttonTop,
+                top: 0,
                 width: buttonWidth,
                 height: buttonHeight,
                 child: _MaterialWideNavigationRailButtonSurface(
@@ -82,7 +89,7 @@ class MaterialWideNavigationRailButton extends StatelessWidget {
               ),
               PositionedDirectional(
                 start: (slotWidth - _collapsedButtonWidth) / 2,
-                top: 48,
+                top: _collapsedIndicatorHeight + _collapsedIconLabelSpacing,
                 width: _collapsedButtonWidth,
                 child: ExcludeSemantics(
                   child: Opacity(
@@ -101,6 +108,31 @@ class MaterialWideNavigationRailButton extends StatelessWidget {
         );
       },
     );
+  }
+
+  double _collapsedHeightFor(BuildContext context) {
+    final painter = TextPainter(
+      text: TextSpan(
+        text: destination.label,
+        style: _materialRailLabelStyle(
+          context,
+          selected: selected,
+          expanded: false,
+        ),
+      ),
+      maxLines: 2,
+      locale: Localizations.maybeLocaleOf(context),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout(maxWidth: _collapsedButtonWidth);
+    final contentHeight =
+        _collapsedIndicatorHeight +
+        _collapsedIconLabelSpacing +
+        painter.height +
+        _collapsedBottomSpacing;
+    return contentHeight < _collapsedSlotHeight
+        ? _collapsedSlotHeight
+        : contentHeight;
   }
 }
 
@@ -285,28 +317,39 @@ class _MaterialWideNavigationRailLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final railTheme = NavigationRailTheme.of(context);
-    final baseStyle = expanded
-        ? theme.textTheme.labelLarge
-        : theme.textTheme.labelMedium;
-    final style = (baseStyle ?? const TextStyle())
-        .merge(
-          selected
-              ? railTheme.selectedLabelTextStyle
-              : railTheme.unselectedLabelTextStyle,
-        )
-        .copyWith(
-          color: selected
-              ? theme.colorScheme.secondary
-              : theme.colorScheme.onSurfaceVariant,
-        );
     return Text(
       destination.label,
       maxLines: 2,
       overflow: TextOverflow.ellipsis,
       textAlign: expanded ? null : TextAlign.center,
-      style: style,
+      style: _materialRailLabelStyle(
+        context,
+        selected: selected,
+        expanded: expanded,
+      ),
     );
   }
+}
+
+TextStyle _materialRailLabelStyle(
+  BuildContext context, {
+  required bool selected,
+  required bool expanded,
+}) {
+  final theme = Theme.of(context);
+  final railTheme = NavigationRailTheme.of(context);
+  final baseStyle = expanded
+      ? theme.textTheme.labelLarge
+      : theme.textTheme.labelMedium;
+  return (baseStyle ?? const TextStyle())
+      .merge(
+        selected
+            ? railTheme.selectedLabelTextStyle
+            : railTheme.unselectedLabelTextStyle,
+      )
+      .copyWith(
+        color: selected
+            ? theme.colorScheme.secondary
+            : theme.colorScheme.onSurfaceVariant,
+      );
 }

--- a/packages/mhabit_adaptive_ui/lib/src/material/material_wide_navigation_rail_button.dart
+++ b/packages/mhabit_adaptive_ui/lib/src/material/material_wide_navigation_rail_button.dart
@@ -21,7 +21,7 @@ class MaterialWideNavigationRailButton extends StatelessWidget {
     required this.onPressed,
   });
 
-  static const double _slotHeight = 64.0;
+  static const double _slotHeight = 80.0;
   static const double _buttonHeight = 56.0;
   static const double _iconSize = 24.0;
   static const double _collapsedButtonWidth = 56.0;
@@ -60,14 +60,16 @@ class MaterialWideNavigationRailButton extends StatelessWidget {
           _buttonHeight,
           progress,
         )!;
+        final buttonTop = lerpDouble(16, 4, progress)!;
         return SizedBox(
           key: slotKey,
           width: slotWidth,
           height: _slotHeight,
           child: Stack(
-            alignment: Alignment.center,
+            alignment: Alignment.topCenter,
             children: [
-              SizedBox(
+              Positioned(
+                top: buttonTop,
                 width: buttonWidth,
                 height: buttonHeight,
                 child: _MaterialWideNavigationRailButtonSurface(
@@ -301,7 +303,7 @@ class _MaterialWideNavigationRailLabel extends StatelessWidget {
         );
     return Text(
       destination.label,
-      maxLines: 1,
+      maxLines: 2,
       overflow: TextOverflow.ellipsis,
       textAlign: expanded ? null : TextAlign.center,
       style: style,

--- a/packages/mhabit_adaptive_ui/test/adaptive_auxiliary_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_auxiliary_navigation_test.dart
@@ -153,8 +153,124 @@ void main() {
       ),
       findsOneWidget,
     );
+    final scrollView = find.descendant(
+      of: find.byKey(const ValueKey('rail-panel')),
+      matching: find.byKey(const ValueKey('material-rail-primary-scroll-view')),
+    );
+    final scrollable = tester.state<ScrollableState>(
+      find.descendant(of: scrollView, matching: find.byType(Scrollable)),
+    );
+    final primaryDestinationList = find.byKey(
+      const ValueKey('material-rail-primary-destination-list'),
+    );
+    final toggle = find.byKey(const ValueKey('rail-toggle-button'));
+    expect(scrollable.position.maxScrollExtent, 0);
+    final leadingGap =
+        tester.getTopLeft(primaryDestinationList).dy -
+        tester.getBottomLeft(toggle).dy;
+    expect(leadingGap, 40);
+    expect(
+      tester
+          .getBottomLeft(
+            find.byKey(const ValueKey('material-rail-destination-slot-1')),
+          )
+          .dy,
+      lessThan(
+        tester
+            .getTopLeft(
+              find.byKey(
+                const ValueKey('material-rail-auxiliary-destination-list'),
+              ),
+            )
+            .dy,
+      ),
+    );
     await tester.tap(button);
     expect(selectedIndex, 1);
+  });
+
+  testWidgets('Material rail shrinks its leading gap before scrolling', (
+    tester,
+  ) async {
+    _setSurface(tester, const Size(700, 408));
+    await tester.pumpWidget(
+      _host(
+        platform: TargetPlatform.android,
+        selectedAuxiliaryIndex: null,
+        onSelected: (_) {},
+      ),
+    );
+
+    final scrollView = find.byKey(
+      const ValueKey('material-rail-primary-scroll-view'),
+    );
+    final scrollable = tester.state<ScrollableState>(
+      find.descendant(of: scrollView, matching: find.byType(Scrollable)),
+    );
+    final primaryDestinationList = find.byKey(
+      const ValueKey('material-rail-primary-destination-list'),
+    );
+    final toggle = find.byKey(const ValueKey('rail-toggle-button'));
+    final leadingGap =
+        tester.getTopLeft(primaryDestinationList).dy -
+        tester.getBottomLeft(toggle).dy;
+
+    expect(scrollable.position.maxScrollExtent, 0);
+    expect(leadingGap, inExclusiveRange(8, 40));
+  });
+
+  testWidgets('Material short rail scrolls primary content above auxiliary', (
+    tester,
+  ) async {
+    _setSurface(tester, const Size(700, 320));
+    await tester.pumpWidget(
+      _host(
+        platform: TargetPlatform.android,
+        selectedAuxiliaryIndex: null,
+        onSelected: (_) {},
+      ),
+    );
+
+    final rail = find.byKey(const ValueKey('rail-panel'));
+    final scrollView = find.descendant(
+      of: rail,
+      matching: find.byKey(const ValueKey('material-rail-primary-scroll-view')),
+    );
+    final scrollable = tester.state<ScrollableState>(
+      find.descendant(of: scrollView, matching: find.byType(Scrollable)),
+    );
+    final auxiliaryList = find.byKey(
+      const ValueKey('material-rail-auxiliary-destination-list'),
+    );
+    final firstDestination = find.byKey(
+      const ValueKey('material-rail-destination-slot-0'),
+    );
+    final toggle = find.byKey(
+      const ValueKey('rail-toggle-button'),
+      skipOffstage: false,
+    );
+    final initialDestinationTop = tester.getTopLeft(firstDestination).dy;
+    final initialToggleTop = tester.getTopLeft(toggle).dy;
+    final initialAuxiliaryTop = tester.getTopLeft(auxiliaryList).dy;
+
+    expect(scrollable.position.maxScrollExtent, greaterThan(0));
+    expect(initialDestinationTop - tester.getBottomLeft(toggle).dy, 8);
+    expect(
+      tester.getBottomLeft(scrollView).dy,
+      lessThanOrEqualTo(initialAuxiliaryTop),
+    );
+
+    await tester.drag(scrollView, const Offset(0, -80));
+    await tester.pumpAndSettle();
+
+    expect(scrollable.position.pixels, greaterThan(0));
+    expect(
+      tester.getTopLeft(firstDestination).dy,
+      lessThan(initialDestinationTop),
+    );
+    expect(tester.getTopLeft(toggle).dy, lessThan(initialToggleTop));
+    expect(tester.getTopLeft(auxiliaryList).dy, initialAuxiliaryTop);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('Apple Sidebar renders and invokes auxiliary destination', (

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -56,6 +56,30 @@ _TestRouter _buildRouter({
   );
 }
 
+List<AdaptiveNavigationDestination> _destinationsWithLabels(
+  String first,
+  String second,
+) => [
+  AdaptiveNavigationDestination(
+    label: first,
+    icons: const NavigationDestinationIcons(
+      material: Icon(Icons.home_outlined),
+      materialSelected: Icon(Icons.home),
+      apple: Icon(Icons.home_outlined),
+      appleSelected: Icon(Icons.home),
+    ),
+  ),
+  AdaptiveNavigationDestination(
+    label: second,
+    icons: const NavigationDestinationIcons(
+      material: Icon(Icons.calendar_today_outlined),
+      materialSelected: Icon(Icons.calendar_today),
+      apple: Icon(Icons.calendar_today_outlined),
+      appleSelected: Icon(Icons.calendar_today),
+    ),
+  ),
+];
+
 class _TestRouter extends RouterConfig<Object> {
   factory _TestRouter({
     required List<AdaptiveNavigationDestination> destinations,
@@ -3036,7 +3060,9 @@ void main() {
       tester,
     ) async {
       _setSurfaceSize(tester, const Size(700, 800));
-      final router = _buildRouter();
+      final router = _buildRouter(
+        destinations: _destinationsWithLabels('H', 'T'),
+      );
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
       await tester.pumpAndSettle();
 
@@ -3046,6 +3072,9 @@ void main() {
       );
       final destinationSlot = find.byKey(
         const ValueKey('material-rail-destination-slot-0'),
+      );
+      final todaySlot = find.byKey(
+        const ValueKey('material-rail-destination-slot-1'),
       );
       final indicator = find.descendant(
         of: destination,
@@ -3059,8 +3088,10 @@ void main() {
         of: destination,
         matching: find.byKey(const ValueKey('material-rail-expanded-label')),
       );
+      final toggle = find.byKey(const ValueKey('rail-toggle-button'));
 
       expect(tester.getSize(destination), const Size(56, 32));
+      expect(tester.getSize(destinationSlot).height, 64);
       expect(rail.minWidth, 96);
       expect(tester.getSize(indicator), const Size(56, 32));
       expect(tester.widget<Opacity>(collapsedLabel).opacity, 1);
@@ -3073,11 +3104,53 @@ void main() {
         tester.getRect(destination).overlaps(tester.getRect(collapsedLabel)),
         isFalse,
       );
+      expect(
+        tester.getTopLeft(collapsedLabel).dy -
+            tester.getBottomLeft(destination).dy,
+        4,
+      );
+      expect(
+        tester.getTopLeft(todaySlot).dy -
+            tester.getBottomLeft(destinationSlot).dy,
+        4,
+      );
+      expect(
+        tester.getTopLeft(destinationSlot).dy - tester.getBottomLeft(toggle).dy,
+        40,
+      );
       final label = tester.widget<Text>(
-        find.descendant(of: collapsedLabel, matching: find.text('Habits')),
+        find.descendant(of: collapsedLabel, matching: find.text('H')),
       );
       expect(label.maxLines, 2);
       expect(label.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets('material collapsed rail grows only wrapped destinations', (
+      tester,
+    ) async {
+      _setSurfaceSize(tester, const Size(700, 800));
+      final router = _buildRouter(
+        destinations: _destinationsWithLabels('H', 'A long destination label'),
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .getSize(
+              find.byKey(const ValueKey('material-rail-destination-slot-0')),
+            )
+            .height,
+        64,
+      );
+      expect(
+        tester
+            .getSize(
+              find.byKey(const ValueKey('material-rail-destination-slot-1')),
+            )
+            .height,
+        80,
+      );
     });
 
     testWidgets('material rail frames the complete expanded destination', (
@@ -3091,6 +3164,12 @@ void main() {
       final destination = find.byKey(
         const ValueKey('material-rail-destination-0'),
       );
+      final destinationSlot = find.byKey(
+        const ValueKey('material-rail-destination-slot-0'),
+      );
+      final todaySlot = find.byKey(
+        const ValueKey('material-rail-destination-slot-1'),
+      );
       final indicator = find.descendant(
         of: destination,
         matching: find.byKey(const ValueKey('material-rail-indicator')),
@@ -3102,6 +3181,7 @@ void main() {
       final indicatorRect = tester.getRect(indicator);
 
       expect(tester.getSize(destination), const Size(160, 56));
+      expect(tester.getSize(destinationSlot).height, 56);
       expect(tester.getSize(indicator), const Size(160, 56));
       expect(tester.widget<Opacity>(expandedLabel).opacity, 1);
       expect(
@@ -3115,13 +3195,20 @@ void main() {
         ),
         tester.getRect(destination),
       );
+      expect(
+        tester.getTopLeft(todaySlot).dy -
+            tester.getBottomLeft(destinationSlot).dy,
+        0,
+      );
     });
 
     testWidgets('material rail destinations follow the rail animation', (
       tester,
     ) async {
       _setSurfaceSize(tester, const Size(700, 800));
-      final router = _buildRouter();
+      final router = _buildRouter(
+        destinations: _destinationsWithLabels('H', 'T'),
+      );
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
       await tester.pumpAndSettle();
 
@@ -3157,7 +3244,10 @@ void main() {
       expect(tester.getSize(indicator).width, inExclusiveRange(56, 158));
       expect(tester.getSize(destination).height, inExclusiveRange(32, 56));
       expect(tester.getSize(indicator).height, inExclusiveRange(32, 56));
-      expect(tester.getCenter(destination).dy, collapsedCenterY);
+      expect(
+        tester.getCenter(destination).dy,
+        inExclusiveRange(collapsedCenterY, collapsedCenterY + 12),
+      );
       expect(tester.getCenter(todayDestination).dy, collapsedTodayCenterY);
       expect(
         tester.widget<Opacity>(collapsedLabel).opacity,
@@ -3171,7 +3261,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(tester.getSize(destination).width, closeTo(158, 0.01));
       expect(tester.getSize(indicator).width, closeTo(158, 0.01));
-      expect(tester.getCenter(destination).dy, collapsedCenterY);
+      expect(tester.getCenter(destination).dy, collapsedCenterY + 12);
       expect(tester.getCenter(todayDestination).dy, collapsedTodayCenterY);
 
       await tester.tap(find.byKey(const ValueKey('rail-toggle-button')));
@@ -3182,7 +3272,10 @@ void main() {
       expect(tester.getSize(indicator).width, inExclusiveRange(56, 158));
       expect(tester.getSize(destination).height, inExclusiveRange(32, 56));
       expect(tester.getSize(indicator).height, inExclusiveRange(32, 56));
-      expect(tester.getCenter(destination).dy, collapsedCenterY);
+      expect(
+        tester.getCenter(destination).dy,
+        inExclusiveRange(collapsedCenterY, collapsedCenterY + 12),
+      );
       expect(tester.getCenter(todayDestination).dy, collapsedTodayCenterY);
       expect(
         tester.widget<Opacity>(collapsedLabel).opacity,
@@ -3279,7 +3372,7 @@ void main() {
           final toggle = find.byKey(const ValueKey('rail-toggle-button'));
           final expandedCenter = tester.getCenter(toggle);
           final expandedTop = tester.getTopLeft(toggle).dy;
-          expect(expandedTop, 0);
+          expect(expandedTop, 8);
 
           await tester.tap(toggle);
           await tester.pump();
@@ -3317,14 +3410,14 @@ void main() {
           find.byKey(const ValueKey('rail-leading-safe-span')),
         );
         final collapsedCenter = tester.getCenter(toggle);
-        expect(tester.getTopLeft(toggle).dy, 0);
+        expect(tester.getTopLeft(toggle).dy, 8);
         expect(safeSpan().padding, const EdgeInsets.only(left: 40));
 
         await tester.tap(toggle);
         await tester.pumpAndSettle();
 
         expect(tester.getCenter(toggle).dx, closeTo(collapsedCenter.dx, 0.01));
-        expect(tester.getTopLeft(toggle).dy, 0);
+        expect(tester.getTopLeft(toggle).dy, 8);
         expect(safeSpan().padding, const EdgeInsets.only(left: 40));
       } finally {
         _resetWindowControlLayoutMock();

--- a/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
+++ b/packages/mhabit_adaptive_ui/test/adaptive_navigation_test.dart
@@ -3073,6 +3073,11 @@ void main() {
         tester.getRect(destination).overlaps(tester.getRect(collapsedLabel)),
         isFalse,
       );
+      final label = tester.widget<Text>(
+        find.descendant(of: collapsedLabel, matching: find.text('Habits')),
+      );
+      expect(label.maxLines, 2);
+      expect(label.overflow, TextOverflow.ellipsis);
     });
 
     testWidgets('material rail frames the complete expanded destination', (
@@ -4533,6 +4538,14 @@ void main() {
         find.byKey(const ValueKey('cupertino-sidebar-resize-handle')),
         findsOneWidget,
       );
+      final longLabel = tester.widget<Text>(
+        find.descendant(
+          of: find.byKey(const ValueKey('cupertino-sidebar-destination-0')),
+          matching: find.text('A very long habits destination label'),
+        ),
+      );
+      expect(longLabel.maxLines, 2);
+      expect(longLabel.overflow, TextOverflow.ellipsis);
       expect(tester.takeException(), isNull);
       debugDefaultTargetPlatformOverride = null;
     });

--- a/packages/mhabit_adaptive_ui/test/material/material_rail_destination_group_layout_test.dart
+++ b/packages/mhabit_adaptive_ui/test/material/material_rail_destination_group_layout_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mhabit_adaptive_ui/src/material/material_rail_destination_group_layout.dart';
+
+const _layoutKey = ValueKey('layout');
+const _childKey = ValueKey('child');
+
+Widget _host({
+  required double height,
+  double minimumGap = 8,
+  double maximumGap = 40,
+}) => MaterialApp(
+  home: Center(
+    child: SizedBox(
+      width: 100,
+      height: height,
+      child: MaterialRailDestinationGroupLayout(
+        key: _layoutKey,
+        minimumGap: minimumGap,
+        maximumGap: maximumGap,
+        child: const SizedBox(key: _childKey, width: 40, height: 100),
+      ),
+    ),
+  ),
+);
+
+double _gap(WidgetTester tester) =>
+    tester.getTopLeft(find.byKey(_childKey)).dy -
+    tester.getTopLeft(find.byKey(_layoutKey)).dy;
+
+void main() {
+  testWidgets('uses the maximum gap when height is available', (tester) async {
+    await tester.pumpWidget(_host(height: 200));
+
+    expect(_gap(tester), 40);
+    expect(
+      tester.getCenter(find.byKey(_childKey)).dx,
+      tester.getCenter(find.byKey(_layoutKey)).dx,
+    );
+  });
+
+  testWidgets('shrinks the gap between its maximum and minimum', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(height: 125));
+
+    expect(_gap(tester), 25);
+  });
+
+  testWidgets('reports the minimum gap through intrinsic height', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(height: 108));
+
+    final renderBox = tester.renderObject<RenderBox>(find.byKey(_layoutKey));
+    expect(_gap(tester), 8);
+    expect(renderBox.getMinIntrinsicHeight(100), 108);
+    expect(renderBox.getMaxIntrinsicHeight(100), 108);
+  });
+
+  testWidgets('updates its gap constraints without replacing the render box', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(height: 200, minimumGap: 12, maximumGap: 24));
+    final originalRenderObject = tester.renderObject(find.byKey(_layoutKey));
+    expect(_gap(tester), 24);
+
+    await tester.pumpWidget(_host(height: 200, minimumGap: 12, maximumGap: 16));
+
+    expect(tester.renderObject(find.byKey(_layoutKey)), originalRenderObject);
+    expect(_gap(tester), 16);
+  });
+
+  test('rejects invalid gaps', () {
+    expect(
+      () => MaterialRailDestinationGroupLayout(
+        minimumGap: -1,
+        maximumGap: 40,
+        child: const SizedBox(),
+      ),
+      throwsAssertionError,
+    );
+    expect(
+      () => MaterialRailDestinationGroupLayout(
+        minimumGap: 8,
+        maximumGap: 4,
+        child: const SizedBox(),
+      ),
+      throwsAssertionError,
+    );
+  });
+}

--- a/test/feature/habits_display/habit_display_page_test.dart
+++ b/test/feature/habits_display/habit_display_page_test.dart
@@ -681,7 +681,74 @@ void main() {
     );
     expect(header.delegate.minExtent, 44);
     expect(header.delegate.maxExtent, 44);
+    expect(find.byType(AppThemeSwitchButton), findsNothing);
   });
+
+  for (final testCase
+      in <({String description, Size size, bool themeExpected})>[
+        (
+          description: 'compact',
+          size: const Size(390, 800),
+          themeExpected: true,
+        ),
+        (
+          description: 'medium',
+          size: const Size(700, 800),
+          themeExpected: false,
+        ),
+      ]) {
+    testWidgets(
+      'Habits ${testCase.description} gates normal and Search theme actions',
+      (tester) async {
+        tester.view.physicalSize = testCase.size;
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        final profile = await _loadProfile();
+        final access = _LoadedHabitsDisplayAccess();
+        final sync = _FakeAppSyncWorkflowAccess();
+        addTearDown(() {
+          sync.dispose();
+          profile.dispose();
+        });
+
+        final vm = await _pumpHabitsTabPage(
+          tester,
+          profile: profile,
+          access: access,
+          sync: sync,
+          useBranchPage: true,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+
+        final normalActions = tester
+            .widget<AdaptiveAppBarActions<HabitDisplaySearchAction>>(
+              find.byType(AdaptiveAppBarActions<HabitDisplaySearchAction>),
+            );
+        expect(
+          normalActions.collection.roots.map((action) => action.id),
+          testCase.themeExpected
+              ? contains(habitDisplayThemeActionId)
+              : isNot(contains(habitDisplayThemeActionId)),
+        );
+
+        vm.onSearchOngoingChanged(true);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 600));
+
+        final searchActions = tester
+            .widget<AdaptiveAppBarActions<HabitDisplaySearchAction>>(
+              find.byType(AdaptiveAppBarActions<HabitDisplaySearchAction>),
+            );
+        expect(
+          searchActions.collection.roots.map((action) => action.id),
+          testCase.themeExpected
+              ? contains(habitDisplayThemeActionId)
+              : isNot(contains(habitDisplayThemeActionId)),
+        );
+      },
+    );
+  }
 
   testWidgets('framework dismiss intent does not collide with page shortcuts', (
     tester,

--- a/test/unit/entries/app/shell_test.dart
+++ b/test/unit/entries/app/shell_test.dart
@@ -10,18 +10,21 @@ import 'package:go_router/go_router.dart';
 import 'package:mhabit/entries/app/navigation_chrome.dart';
 import 'package:mhabit/entries/app/navigation_destination.dart';
 import 'package:mhabit/entries/app/shell.dart';
+import 'package:mhabit/l10n/localizations.dart';
 import 'package:mhabit/models/app_entry.dart';
 import 'package:mhabit/pages/app_debugger/page.dart'
     show onDebuggerNotificationTapped;
 import 'package:mhabit/pages/common/widgets.dart';
 import 'package:mhabit/pages/habits_display/navigation_chrome.dart';
 import 'package:mhabit/providers/app_ui/app_launch_entry.dart';
+import 'package:mhabit/providers/app_ui/app_theme.dart';
 import 'package:mhabit/routes/app_flow_page.dart';
 import 'package:mhabit/routes/app_material_page.dart';
 import 'package:mhabit/routes/app_navigation_branch.dart';
 import 'package:mhabit/routes/app_navigation_coordinator.dart';
 import 'package:mhabit/routes/app_router.dart';
 import 'package:mhabit/routes/navigator_helpers.dart';
+import 'package:mhabit/theme/color.dart';
 import 'package:mhabit/widgets/widgets.dart';
 import 'package:mhabit_adaptive_ui/mhabit_adaptive_ui.dart';
 import 'package:provider/provider.dart';
@@ -32,6 +35,19 @@ class _RecordingLaunchEntryViewModel extends AppLaunchEntryViewModel {
   @override
   Future<void> setNewLaunchEntry(AppEntrys newLaunchEntry) async {
     entries.add(newLaunchEntry);
+  }
+}
+
+class _TestThemeViewModel extends AppThemeViewModel {
+  AppThemeType value = AppThemeType.followSystem;
+
+  @override
+  AppThemeType get themeType => value;
+
+  @override
+  Future<void> setNewthemeType(AppThemeType newThemeType) async {
+    value = newThemeType;
+    notifyListeners();
   }
 }
 
@@ -447,6 +463,111 @@ void main() {
     );
     expect(launchEntry.entries, [AppEntrys.habitToday, AppEntrys.habitToday]);
   });
+
+  for (final testCase in <({TargetPlatform platform, String actionKey})>[
+    (
+      platform: TargetPlatform.android,
+      actionKey: 'material-rail-auxiliary-destination-0',
+    ),
+    (
+      platform: TargetPlatform.iOS,
+      actionKey: 'cupertino-sidebar-auxiliary-destination-0',
+    ),
+  ]) {
+    testWidgets(
+      '${testCase.platform.name} theme action cycles without changing navigation',
+      (tester) async {
+        _setSurface(tester, const Size(700, 800));
+        final coordinator = _MutableNavigationCoordinator(initialIndex: 1);
+        final chromeController = AppNavigationChromeController();
+        final launchEntry = _RecordingLaunchEntryViewModel();
+        final theme = _TestThemeViewModel();
+        addTearDown(coordinator.dispose);
+        addTearDown(chromeController.dispose);
+        addTearDown(launchEntry.dispose);
+        addTearDown(theme.dispose);
+
+        await tester.pumpWidget(
+          MultiProvider(
+            providers: [
+              ChangeNotifierProvider<AppLaunchEntryViewModel>.value(
+                value: launchEntry,
+              ),
+              ChangeNotifierProvider<AppThemeViewModel>.value(value: theme),
+            ],
+            child: MaterialApp(
+              theme: ThemeData(platform: testCase.platform),
+              localizationsDelegates: L10n.localizationsDelegates,
+              supportedLocales: L10n.supportedLocales,
+              home: AppNavigationShell(
+                coordinator: coordinator,
+                chromeController: chromeController,
+                auxiliaryChromeBuilder: (context) => [
+                  AppNavigationAuxiliaryChrome.themeMode(context),
+                  AppNavigationAuxiliaryChrome(
+                    destination: const AdaptiveNavigationDestination(
+                      label: 'Settings',
+                      icons: NavigationDestinationIcons(
+                        material: Icon(Icons.settings_outlined),
+                        materialSelected: Icon(Icons.settings),
+                        apple: Icon(CupertinoIcons.settings),
+                        appleSelected: Icon(CupertinoIcons.settings_solid),
+                      ),
+                    ),
+                    selected: true,
+                    onSelected: () {},
+                  ),
+                ],
+                child: const _StubPage('settings page'),
+              ),
+            ),
+          ),
+        );
+
+        final action = find.byKey(ValueKey(testCase.actionKey));
+        final settings = find.byKey(
+          ValueKey(
+            testCase.platform == TargetPlatform.iOS
+                ? 'cupertino-sidebar-auxiliary-destination-1'
+                : 'material-rail-auxiliary-destination-1',
+          ),
+        );
+        expect(action, findsOneWidget);
+        expect(settings, findsOneWidget);
+        expect(
+          tester.getTopLeft(action).dy,
+          lessThan(tester.getTopLeft(settings).dy),
+        );
+        expect(find.text('Follow System'), findsWidgets);
+        expect(
+          find.descendant(
+            of: action,
+            matching: find.byWidgetPredicate(
+              (widget) =>
+                  widget is Icon && widget.icon == Icons.hdr_auto_rounded,
+            ),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          tester
+              .widget<AdaptiveNavigationShell>(
+                find.byType(AdaptiveNavigationShell),
+              )
+              .selectedAuxiliaryIndex,
+          1,
+        );
+
+        await tester.tap(action);
+        await tester.pump();
+
+        expect(theme.value, AppThemeType.light);
+        expect(find.text('Light Theme'), findsWidgets);
+        expect(coordinator.selectedIndex, 1);
+        expect(launchEntry.entries, isEmpty);
+      },
+    );
+  }
 
   testWidgets('derives compact bar visibility from the active branch stack', (
     tester,


### PR DESCRIPTION
## Summary
Add a theme mode button and improve adaptive navigation layouts so the navigation rail, auxiliary navigation, and habit display pages respond more consistently across window sizes.

## Type of Change
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] style
- [ ] test
- [ ] chore

## Related Issue

## Checklist
- [x] Ran `make aio && make test` locally
- [ ] Updated `CHANGELOG.md` / `docs/CHANGELOG/zh.md` if this is a user-facing change

---

Implementation includes focused adaptive-navigation and habit-display tests.